### PR TITLE
Export to HTML now exports embedded files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+*.mo
+*.directory


### PR DESCRIPTION
Hi Giuspen

Thanks for writing CherryTree, I am starting to use it as a lab book. I really like it for this as I can give others read access to an HTML export without them needing to install anything.

One thing that was worrying though was any embedded files were not exported as part of the HTML export. I have added this functionality in my first commit. I only do it for the HTML node export, not for the HTML selection export, because as far as I can see this is only for copying to the clipboard (am I correct on this?).

I am also thinking of extending the command line functionality to allow HTML export so I can automate it.

Julian