### PR TITLE
Command line HTML export

### DIFF
--- a/cherrytree
+++ b/cherrytree
@@ -51,6 +51,8 @@ if ARGPARSE_OK:
     parser = argparse.ArgumentParser()
     parser.add_argument('filepath', nargs='?', help='Optional CherryTree Document to Open')
     parser.add_argument("-n", "--node", help="Node Name to Focus")
+    parser.add_argument("-x", "--export", dest='mode', action='store_const', const='export', default='open', help="Export to HTML (-o must be set)")
+    parser.add_argument("-o", "--output", action='store', help="Set output directory.")
     args = parser.parse_args()
 else:
     class CherryArgs:

--- a/modules/core.py
+++ b/modules/core.py
@@ -27,7 +27,7 @@ if cons.HAS_APPINDICATOR: import appindicator
 class CherryTree:
     """Application's GUI"""
 
-    def __init__(self, lang_str, open_with_file, node_name, boss, is_startup, is_arg):
+    def __init__(self, lang_str, open_with_file, node_name, boss, is_startup, is_arg,export_mode):
         """GUI Startup"""
         self.boss = boss
         self.filetype = ""
@@ -194,7 +194,8 @@ class CherryTree:
         self.prefpage = 0
         support.set_menu_items_recent_documents(self)
         support.set_menu_items_special_chars(self)
-        self.window.show_all() # this before the config_file_apply that could hide something
+        if export_mode!=True:
+            self.window.show_all() # this before the config_file_apply that could hide something
         self.window.present()
         config.config_file_apply(self)
         self.combobox_prog_lang_init()
@@ -2090,7 +2091,10 @@ iter_end, exclude_iter_sel_end=True)
     def export_to_html(self, *args):
         """Export to HTML"""
         if not self.is_there_selected_node_or_error(): return
-        export_type = support.dialog_selnode_selnodeandsub_alltree(self, also_selection=True, also_index_in_page=True)
+        if args[0] == "Auto":
+            export_type = 3
+        else:
+            export_type = support.dialog_selnode_selnodeandsub_alltree(self, also_selection=True, also_index_in_page=True)
         if export_type == 0: return
         if export_type == 1:
             # only selected node
@@ -2107,7 +2111,11 @@ iter_end, exclude_iter_sel_end=True)
                     self.objects_buffer_refresh()
         elif export_type == 3:
             # all nodes
-            if self.html_handler.prepare_html_folder(self.file_name):
+            if args[0] == "Auto":
+                dir_string = args[1]
+            else:
+                dir_string = ""    
+            if self.html_handler.prepare_html_folder(self.file_name,dir_place=dir_string):
                 self.html_handler.nodes_all_export_to_html()
                 if self.filetype in ["b", "x"] and self.curr_tree_iter:
                     self.state_machine.update_state(self.treestore[self.curr_tree_iter][3])
@@ -2118,6 +2126,9 @@ iter_end, exclude_iter_sel_end=True)
                 folder_name = support.get_node_hierarchical_name(self, self.curr_tree_iter)
                 if self.html_handler.prepare_html_folder(folder_name):
                     self.html_handler.node_export_to_html(self.curr_tree_iter, only_selection=True)
+                    
+  #  def cmd_export_to_html(self):
+        
 
     def export_print_page_setup(self, action):
         """Print Page Setup Operations"""

--- a/modules/exports.py
+++ b/modules/exports.py
@@ -458,14 +458,25 @@ class Export2Html:
         self.dad = dad
         self.tree_links_text = ""
 
-    def prepare_html_folder(self, new_folder):
+    def prepare_html_folder(self, new_folder,dir_place=""):
         """Prepare the website folder"""
-        dir_place = support.dialog_folder_select(curr_folder=self.dad.pick_dir, parent=self.dad.window)
-        if dir_place == None: return False
-        new_folder = support.clean_from_chars_not_for_filename(new_folder) + "_HTML"
-        while os.path.exists(os.path.join(dir_place, new_folder)):
-            new_folder += "2"
-        self.new_path = os.path.join(dir_place, new_folder)
+        if dir_place == "":
+            dir_place = support.dialog_folder_select(curr_folder=self.dad.pick_dir, parent=self.dad.window)
+            if dir_place == None: return False     
+            new_folder = support.clean_from_chars_not_for_filename(new_folder) + "_HTML"
+            if os.path.exists(os.path.join(dir_place, new_folder)):
+                n=2
+                while os.path.exists(os.path.join(dir_place, new_folder+'%03d'%n)):
+                    n += 1
+                new_folder += '%03d'%n
+            self.new_path = os.path.join(dir_place, new_folder)
+        else:
+            if os.path.exists(os.path.join(dir_place)):
+                print "Export error: folder already exists!"
+                return False
+            else:
+                self.new_path = dir_place
+        
         self.images_dir = os.path.join(self.new_path, "images")
         self.embed_dir = os.path.join(self.new_path, "EmbeddedFiles")
         os.mkdir(self.new_path)

--- a/modules/main.py
+++ b/modules/main.py
@@ -53,12 +53,20 @@ class CherryTreeHandler():
         self.running_windows = []
         self.embfiles_id = 0
         self.systray_active = False
-        self.window_open_new(filepath_fix(args.filepath), args.node, True, True if args.filepath else False)
-        self.server_check_timer_id = gobject.timeout_add(1000, self.server_periodic_check) # 1 sec
+        
+        if args.mode == "export":
+            if args.output and args.filepath:
+                ghost_window = core.CherryTree(self.lang_str, filepath_fix(args.filepath), args.node, self, True, True,True)
+                ghost_window.export_to_html("Auto",args.output)  
+            else:
+                print "Export error: Either output or input not specified"
+        else:
+            self.window_open_new(filepath_fix(args.filepath), args.node, True, True if args.filepath else False)
+            self.server_check_timer_id = gobject.timeout_add(1000, self.server_periodic_check) # 1 sec
 
     def window_open_new(self, filepath, node_name, is_startup, is_arg):
         """Open a new top level Window"""
-        window = core.CherryTree(self.lang_str, filepath, node_name, self, is_startup, is_arg)
+        window = core.CherryTree(self.lang_str, filepath, node_name, self, is_startup, is_arg,False)
         self.running_windows.append(window)
         #print self.running_windows
 
@@ -205,9 +213,11 @@ def main(args):
             name = dbus.service.BusName("com.giuspen.CherryTreeService", session_bus)
             object = CherryTreeObject(session_bus, '/CherryTreeObject')
             CherryTreeHandler(args, lang_str)
-            gtk.main()
+            if args.mode != "export":
+                gtk.main()
     else:
         print "dbus fail, maybe a firewall problem, centralized instances disabled"
         lang_str = initializations()
         CherryTreeHandler(args, lang_str)
-        gtk.main()
+        if args.mode != "export":
+            gtk.main()

--- a/modules/main.py
+++ b/modules/main.py
@@ -199,7 +199,11 @@ def main(args):
         DBUS_OK = True
     except:
         DBUS_OK = False
-    if DBUS_OK:
+        
+    if args.mode == "export":
+        lang_str = initializations()
+        CherryTreeHandler(args, lang_str)
+    elif DBUS_OK:
         try:
             # client
             remote_object = session_bus.get_object("com.giuspen.CherryTreeService", "/CherryTreeObject")
@@ -213,11 +217,9 @@ def main(args):
             name = dbus.service.BusName("com.giuspen.CherryTreeService", session_bus)
             object = CherryTreeObject(session_bus, '/CherryTreeObject')
             CherryTreeHandler(args, lang_str)
-            if args.mode != "export":
-                gtk.main()
+            gtk.main()
     else:
         print "dbus fail, maybe a firewall problem, centralized instances disabled"
         lang_str = initializations()
         CherryTreeHandler(args, lang_str)
-        if args.mode != "export":
-            gtk.main()
+        gtk.main()


### PR DESCRIPTION
Hi Giuseppe (sorry for misspelling your name before!)

As I said before I was planning to make HTML exporting possible from the command line, so I can automate the export. I have managed this. I just create a "Ghost window" for cherry tree which does all the initialisation, but never shows the window, then I run the full export for all nodes. I have updated the command line options, to allow an output option and an option for the export. When starting it doesn't check for a D-Bus session, because then it can't export if the program is open.

I made on other change to the HTML export for the normal graphical method. Now when the export folder already exists it numbers them
file.ctb_HTML
file.ctb_HTML002
file.ctb_HTML003
file.ctb_HTML004
instead of
file.ctb_HTML
file.ctb_HTML2
file.ctb_HTML22
file.ctb_HTML222

Julian