### PR TITLE
Optionally hide embedded file name in main note pane. 

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -169,6 +169,7 @@ def config_file_load(dad):
         dad.tabs_width = cfg.getint(section, "tabs_width") if cfg.has_option(section, "tabs_width") else 4
         dad.anchor_size = cfg.getint(section, "anchor_size") if cfg.has_option(section, "anchor_size") else 16
         dad.embfile_size = cfg.getint(section, "embfile_size") if cfg.has_option(section, "embfile_size") else 48
+        dad.embfile_show_filename = cfg.getboolean(section, "embfile_show_filename") if cfg.has_option(section, "embfile_show_filename") else True
         dad.line_wrapping = cfg.getboolean(section, "line_wrapping") if cfg.has_option(section, "line_wrapping") else True
         dad.auto_smart_quotes = cfg.getboolean(section, "auto_smart_quotes") if cfg.has_option(section, "auto_smart_quotes") else True
         dad.wrapping_indent = cfg.getint(section, "wrapping_indent") if cfg.has_option(section, "wrapping_indent") else -14
@@ -294,6 +295,7 @@ def config_file_load(dad):
         dad.tabs_width = 4
         dad.anchor_size = 16
         dad.embfile_size = 48
+        dad.embfile_show_filename = True
         dad.line_wrapping = True
         dad.auto_smart_quotes = True
         dad.wrapping_indent = -14
@@ -470,6 +472,7 @@ def config_file_save(dad):
     cfg.set(section, "tabs_width", dad.tabs_width)
     cfg.set(section, "anchor_size", dad.anchor_size)
     cfg.set(section, "embfile_size", dad.embfile_size)
+    cfg.set(section, "embfile_show_filename", dad.embfile_show_filename)
     cfg.set(section, "line_wrapping", dad.line_wrapping)
     cfg.set(section, "auto_smart_quotes", dad.auto_smart_quotes)
     cfg.set(section, "wrapping_indent", dad.wrapping_indent)
@@ -896,6 +899,8 @@ def preferences_tab_rich_text(dad, vbox_text_nodes, pref_dialog):
     spinbutton_embfile_size.set_value(dad.embfile_size)
     hbox_embfile_size.pack_start(label_embfile_size, expand=False)
     hbox_embfile_size.pack_start(spinbutton_embfile_size, expand=False)
+    checkbutton_embfile_show_filename = gtk.CheckButton(_("Show Embedded File Name"))
+    checkbutton_embfile_show_filename.set_active(dad.embfile_show_filename)
     label_limit_undoable_steps = gtk.Label(_("Limit of Undoable Steps Per Node"))
     adj_limit_undoable_steps = gtk.Adjustment(value=dad.limit_undoable_steps, lower=1, upper=10000, step_incr=1)
     spinbutton_limit_undoable_steps = gtk.SpinButton(adj_limit_undoable_steps)
@@ -908,6 +913,7 @@ def preferences_tab_rich_text(dad, vbox_text_nodes, pref_dialog):
     vbox_misc_text.pack_start(checkbutton_rt_highl_curr_line, expand=False)
     vbox_misc_text.pack_start(checkbutton_codebox_auto_resize, expand=False)
     vbox_misc_text.pack_start(hbox_embfile_size, expand=False)
+    vbox_misc_text.pack_start(checkbutton_embfile_show_filename, expand=False)
     vbox_misc_text.pack_start(hbox_misc_text, expand=False)
     frame_misc_text = gtk.Frame(label="<b>"+_("Miscellaneous")+"</b>")
     frame_misc_text.get_label_widget().set_use_markup(True)
@@ -991,6 +997,12 @@ def preferences_tab_rich_text(dad, vbox_text_nodes, pref_dialog):
             dad.embfile_size_mod = True
             support.dialog_info_after_restart(pref_dialog)
     spinbutton_embfile_size.connect('value-changed', on_spinbutton_embfile_size_value_changed)
+    def on_checkbutton_embfile_show_filename_toggled(checkbutton):
+        dad.embfile_show_filename = checkbutton.get_active()
+        if not dad.embfile_show_filename_mod:
+            dad.embfile_show_filename_mod = True
+            support.dialog_info_after_restart(pref_dialog)
+    checkbutton_embfile_show_filename.connect('toggled', on_checkbutton_embfile_show_filename_toggled)
     def on_spinbutton_limit_undoable_steps_value_changed(spinbutton):
         dad.limit_undoable_steps = int(spinbutton.get_value())
     spinbutton_limit_undoable_steps.connect('value-changed', on_spinbutton_limit_undoable_steps_value_changed)

--- a/modules/core.py
+++ b/modules/core.py
@@ -202,6 +202,7 @@ class CherryTree:
         self.file_update = False
         self.anchor_size_mod = False
         self.embfile_size_mod = False
+        self.embfile_show_filename_mod = False
         self.cursor_key_press = None
         self.autosave_timer_id = None
         self.spell_check_init = False
@@ -4152,10 +4153,11 @@ iter_end, exclude_iter_sel_end=True)
         elif "filename" in pixbuf_attrs:
             anchor.eventbox.connect("button-press-event", self.on_mouse_button_clicked_file, anchor)
             self.embfile_set_tooltip(anchor)
-            anchor_label = gtk.Label()
-            anchor_label.set_markup("<b><small>"+pixbuf.filename+"</small></b>")
-            anchor_label.modify_fg(gtk.STATE_NORMAL, gtk.gdk.color_parse(self.rt_def_fg))
-            anchor.frame.set_label_widget(anchor_label)
+            if self.embfile_show_filename :
+                anchor_label = gtk.Label()
+                anchor_label.set_markup("<b><small>"+pixbuf.filename+"</small></b>")
+                anchor_label.modify_fg(gtk.STATE_NORMAL, gtk.gdk.color_parse(self.rt_def_fg))
+                anchor.frame.set_label_widget(anchor_label)
         else:
             anchor.eventbox.connect("button-press-event", self.on_mouse_button_clicked_image, anchor)
             anchor.eventbox.connect("visibility-notify-event", self.on_image_visibility_notify_event)


### PR DESCRIPTION
 Embedded file icon and its tooltip will remain visible, it's name can be hidden.

I have changed this so my editing area can be a bit cleaner.  The filename above the embedded file icon is too large for me.

Changed preference screen:
![screenshot_1](https://cloud.githubusercontent.com/assets/5180908/17211123/c901883a-54c7-11e6-8984-902b00f2cda6.png)

With filenames:
![screenshot_2](https://cloud.githubusercontent.com/assets/5180908/17211128/cd148ed6-54c7-11e6-8c21-ba8f3791c46e.png)

Without filenames:
![screenshot_3](https://cloud.githubusercontent.com/assets/5180908/17211130/cf4da1a6-54c7-11e6-8667-b7d0191a3f89.png)

Config file entry:
![screenshot_4](https://cloud.githubusercontent.com/assets/5180908/17211132/d2caf0a4-54c7-11e6-8438-b85b1466d14a.png)



