### PR TITLE
Fix incorrect version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cherrytree (0.38.1-1) xenial; urgency=low
+cherrytree (0.38.1-0xenial1) xenial; urgency=low
 
   * bugfix in export to txt
   * bugfix in all matches dialog hide/restore selected line


### PR DESCRIPTION
By using $upstreamversion-1 you are polluting Debian namespace.  Please use $upstreamversion-0$anythingyouwant for your own packages.  This makes it easier to update, track bugs, etc.

In all honesty, I usually advise upstreams against releasing their own binary distro packages.  It really isn't easy to get right and usually creates a bunch of problems. (Debian Maintainer speaking here)