### PR TITLE
Renamed Find and Find to Find Previous and Find Next

### DIFF
--- a/modules/findreplace.py
+++ b/modules/findreplace.py
@@ -320,8 +320,8 @@ class FindReplace:
             dialog = gtk.Dialog(title=_("Iterate Latest Find/Replace"),
                 parent=self.dad.window, flags=gtk.DIALOG_DESTROY_WITH_PARENT)
             button_close = dialog.add_button(_("Close"), 0)
-            button_find_bw = dialog.add_button(_("Find"), 4)
-            button_find_fw = dialog.add_button(_("Find"), 1)
+            button_find_bw = dialog.add_button(_("Find Previous"), 4)
+            button_find_fw = dialog.add_button(_("Find Next"), 1)
             button_replace = dialog.add_button(_("Replace"), 2)
             button_undo = dialog.add_button(_("Undo"), 3)
             dialog.set_position(gtk.WIN_POS_CENTER_ON_PARENT)


### PR DESCRIPTION
The **Iterate Latest Find/Replace** menu currently has two buttons that display the text **Find**. This commit changes the display text of both for clarity.

**Before commit:**

![image](https://user-images.githubusercontent.com/21287680/48305874-70cc5480-e500-11e8-8bc4-9134471cabdb.png)

**After commit:**

![image](https://user-images.githubusercontent.com/21287680/48305877-7aee5300-e500-11e8-9e98-8ffd157c15df.png)
