### PR TITLE
Don't use legacy path for AppStream metainfo file

### DIFF
--- a/linux/manual-install.txt
+++ b/linux/manual-install.txt
@@ -20,6 +20,6 @@
 
 9. for the command line manual, copy cherrytree.1.gz from linux folder to /usr/share/man/man1
 
-10. for the software center application descriptor copy cherrytree.appdata.xml from linux folder to /usr/share/appdata
+10. for the software center application descriptor copy cherrytree.appdata.xml from linux folder to /usr/share/metainfo
 
 11. finally the command "update-desktop-database" must be entered into the terminal

--- a/setup.py
+++ b/setup.py
@@ -194,7 +194,7 @@ else:
                       ("share/mime/packages", ["linux/cherrytree.xml"]),
                       ("share/mime-info", ["linux/cherrytree.mime", "linux/cherrytree.keys"]),
                       ("share/application-registry", ["linux/cherrytree.applications"]),
-                      ("share/appdata", ["linux/cherrytree.appdata.xml"]),
+                      ("share/metainfo", ["linux/cherrytree.appdata.xml"]),
                       ("share/man/man1", ["linux/cherrytree.1.gz"])
                    ],
        cmdclass={


### PR DESCRIPTION
Metainfo files should be installed into /usr/share/metainfo.

See: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location