### PR TITLE
Fix AppStream metadata validation

### DIFF
--- a/linux/cherrytree.appdata.xml
+++ b/linux/cherrytree.appdata.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Giuseppe Penone <giuspen@gmail.com> -->
-<application>
- <id type="desktop">cherrytree.desktop</id>
+<component type="desktop-application">
+ <id>com.giuspen.cherrytree</id>
  <metadata_license>CC0-1.0</metadata_license>
  <project_license>GPL-3.0+</project_license>
+ <name>CherryTree</name>
+ <summary>Hierarchical Note Taking</summary>
  <description>
   <p>
    A hierarchical note taking application, featuring rich text and syntax highlighting, storing data in a single xml or sqlite file.
@@ -19,9 +21,14 @@
   </ul>
  </description>
  <screenshots>
-  <screenshot type="default">http://www.giuspen.com/images/cherrytree-main_window_text.png</screenshot>
-  <screenshot>http://www.giuspen.com/images/cherrytree-main_window_code.png</screenshot>
+  <screenshot type="default">
+   <image>https://www.giuspen.com/images/cherrytree-main_window_text.png</image>
+  </screenshot>
+  <screenshot>
+   <image>https://www.giuspen.com/images/cherrytree-main_window_code.png</image>
+  </screenshot>
  </screenshots>
- <url type="homepage">http://www.giuspen.com/cherrytree</url>
- <updatecontact>giuspen@gmail.com</updatecontact>
-</application>
+ <launchable type="desktop-id">cherrytree.desktop</launchable>
+ <url type="homepage">https://www.giuspen.com/cherrytree</url>
+ <update_contact>giuspen@gmail.com</update_contact>
+</component>


### PR DESCRIPTION
This updates the AppStream metadata to a newer version, and fixes all compatibility problems detected by `appstreamcli validate cherrytree.appdata.xml`:
```
W - cherrytree.appdata.xml:cherrytree.desktop:26
    Found invalid tag: 'updatecontact'. Non-standard tags must be prefixed with 
    "x-".

I - cherrytree.appdata.xml:cherrytree.desktop:4
    The id tag for "cherrytree.desktop" still contains a 'type' property, probably 
    from an old conversion.

E - cherrytree.appdata.xml:cherrytree.desktop
    The component is missing a summary (<summary/> tag).

W - cherrytree.appdata.xml:cherrytree.desktop:4
    The component ID is not a reverse domain-name. Please update the ID and that of 
    the accompanying .desktop file to follow the latest version of the Desktop-Entry 
    and AppStream specifications and avoid future issues.

E - cherrytree.appdata.xml:cherrytree.desktop:22
    The screenshot does not contain any images.

E - cherrytree.appdata.xml:cherrytree.desktop
    The component is missing a name (<name/> tag).

I - cherrytree.appdata.xml:cherrytree.desktop:25
    Consider using a secure (HTTPS) URL for 'http://www.giuspen.com/cherrytree'

E - cherrytree.appdata.xml:cherrytree.desktop:23
    The screenshot does not contain any images.
```