### PR TITLE
(Port to C++) node_add, node_duplicate

### DIFF
--- a/future/Makefile.am
+++ b/future/Makefile.am
@@ -56,7 +56,9 @@ COMMON_SOURCES = \
 	src/ct/ct_p7za_iface.cc \
 	src/ct/icons.gresource.cc \
 	src/ct/ct_menu.cc \
-	src/ct/ct_pref_dlg.cc
+	src/ct/ct_pref_dlg.cc \
+	src/ct/ct_actions_tree.cc \
+	src/ct/ct_dialogs.cc
 
 cherrytree_SOURCES = \
 	src/ct/ct_main.cc \

--- a/future/po/POTFILES.in
+++ b/future/po/POTFILES.in
@@ -13,3 +13,7 @@ src/ct/ct_const.cc
 src/ct/ct_misc_utils.cc
 src/ct/ct_p7za_iface.cc
 src/ct/ct_menu.cc
+src/ct/ct_actions_tree.cc
+src/ct/ct_dialogs.cc
+src/ct/ct_pref_dlg.cc
+src/ct/ct_pref_dlg.h

--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "ct_main_win.h"
+
+
+class CtMainWin;
+class CtActions
+{
+public:
+    void init(CtMainWin* mainWin, CtTreeStore* treeStore) { _ctMainWin = mainWin; _ctTreestore = treeStore; }
+
+private:
+    CtMainWin*   _ctMainWin;
+    CtTreeStore* _ctTreestore;
+
+private:
+    void _node_add(bool duplicate);
+
+public:
+    // tree actions
+    void node_add()       { _node_add(false); }
+    void node_dublicate() { _node_add(true);  }
+    void node_child_add();
+    void node_edit();
+};

--- a/future/src/ct/ct_actions_tree.cc
+++ b/future/src/ct/ct_actions_tree.cc
@@ -1,0 +1,254 @@
+#include "ct_actions.h"
+#include <gtkmm/dialog.h>
+#include <gtkmm/stock.h>
+#include "ct_image.h"
+#include "ct_app.h"
+#include "ct_dialogs.h"
+#include "ct_doc_rw.h"
+
+
+CtNodeData dialog_node_prop(std::string title, Gtk::Window& parent, std::string name,
+                      bool is_bold, std::string fg, int c_icon_id, std::string syntax_highl,
+                      bool ro, std::string tags, const std::set<std::string>& tags_set);
+
+
+void CtActions::_node_add(bool duplicate)
+{
+    CtNodeData node;
+    if (duplicate)
+     {
+        if (!_ctMainWin->curr_tree_iter()) return;
+        _ctTreestore->getNodeData(_ctMainWin->curr_tree_iter(), node);
+        node.anchoredWidgets.clear();
+        node.rTextBuffer.clear();
+    }
+    else
+    {
+        node = dialog_node_prop(_("New Node Properties"), *_ctMainWin, "", false, "", 0, CtConst::RICH_TEXT_ID, false, "", _ctTreestore->get_used_tags());
+        if (node.name.empty()) return;
+    }
+
+    node.tsCreation = std::time(nullptr);
+    node.tsLastSave = node.tsCreation;
+    node.nodeId = _ctTreestore->node_id_get();
+
+    _ctMainWin->update_window_save_needed();
+    CtApp::P_ctCfg->syntaxHighlighting = node.syntax;
+
+    Gtk::TreeIter nodeIter;
+    if (_ctMainWin->curr_tree_iter())
+        nodeIter = _ctTreestore->insertNode(&node, _ctMainWin->curr_tree_iter());
+    else
+        nodeIter = _ctTreestore->appendNode(&node);
+
+    _ctTreestore->ctdb_handler()->pending_new_db_node(node.nodeId);
+    _ctTreestore->nodes_sequences_fix(_ctMainWin->curr_tree_iter()->parent(), false);
+    _ctTreestore->updateNodeAuxIcon(nodeIter);
+    /* todo
+    self.nodes_names_dict[new_node_id] = ret_name
+    if self.node_add_is_duplication:
+        if self.syntax_highlighting != cons.RICH_TEXT_ID:
+            text_buffer_from = self.treestore[tree_iter_from][2]
+            text_buffer_to = self.treestore[new_node_iter][2]
+            content = text_buffer_from.get_text(*text_buffer_from.get_bounds())
+            text_buffer_to.begin_not_undoable_action()
+            text_buffer_to.set_text(content)
+            text_buffer_to.end_not_undoable_action()
+        else:
+            state = self.state_machine.requested_state_previous(self.treestore[tree_iter_from][3])
+            self.load_buffer_from_state(state, given_tree_iter=new_node_iter)
+    */
+    _ctMainWin->get_tree_view().set_cursor(_ctTreestore->get_path(nodeIter));
+    _ctMainWin->get_text_view().grab_focus();
+}
+
+void CtActions::node_child_add()
+{
+
+}
+
+void CtActions::node_edit()
+{
+
+}
+
+CtNodeData dialog_node_prop(std::string title, Gtk::Window& parent, std::string name,
+                      bool is_bold, std::string fg, int c_icon_id, std::string syntax_highl,
+                      bool ro, std::string tags, const std::set<std::string>& tags_set)
+{
+    auto dialog = Gtk::Dialog(title, parent, Gtk::DialogFlags::DIALOG_MODAL | Gtk::DialogFlags::DIALOG_DESTROY_WITH_PARENT);
+    dialog.add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_REJECT);
+    dialog.add_button(Gtk::Stock::OK, Gtk::RESPONSE_ACCEPT);
+    dialog.set_default_response(Gtk::RESPONSE_ACCEPT);
+    dialog.set_default_size(300, -1);
+    dialog.set_position(Gtk::WindowPosition::WIN_POS_CENTER_ON_PARENT);
+    auto name_entry = Gtk::Entry();
+    name_entry.set_text(name);
+    auto is_bold_checkbutton = Gtk::CheckButton(_("Bold"));
+    is_bold_checkbutton.set_active(is_bold);
+    auto fg_checkbutton = Gtk::CheckButton(_("Use Selected Color"));
+    fg_checkbutton.set_active(fg != "");
+    std::string real_fg = fg != "" ? fg : (CtApp::P_ctCfg->currColors.at('n') != "" ? CtApp::P_ctCfg->currColors.at('n') : "red");
+    auto fg_colorbutton = Gtk::ColorButton(Gdk::RGBA(real_fg));
+    fg_colorbutton.set_sensitive(fg != "");
+    auto fg_hbox = Gtk::HBox();
+    fg_hbox.set_spacing(2);
+    fg_hbox.pack_start(fg_checkbutton, false, false);
+    fg_hbox.pack_start(fg_colorbutton, false, false);
+    auto c_icon_checkbutton = Gtk::CheckButton(_("Use Selected Icon"));
+    c_icon_checkbutton.set_active(map::exists(CtConst::NODES_STOCKS, c_icon_id));
+    auto c_icon_button = Gtk::Button();
+    if (c_icon_checkbutton.get_active())
+        c_icon_button.set_image(*CtImage::new_image_from_stock(CtConst::NODES_STOCKS.at(c_icon_id), Gtk::ICON_SIZE_BUTTON));
+    else {
+        c_icon_button.set_label(_("click me"));
+        c_icon_button.set_sensitive(false);
+    }
+    auto c_icon_hbox = Gtk::HBox();
+    c_icon_hbox.set_spacing(2);
+    c_icon_hbox.pack_start(c_icon_checkbutton, false, false);
+    c_icon_hbox.pack_start(c_icon_button, false, false);
+    auto name_vbox = Gtk::VBox();
+    name_vbox.pack_start(name_entry);
+    name_vbox.pack_start(is_bold_checkbutton);
+    name_vbox.pack_start(fg_hbox);
+    name_vbox.pack_start(c_icon_hbox);
+    auto name_frame = Gtk::Frame(std::string("<b>")+_("Node Name")+"</b>");
+    ((Gtk::Label*)name_frame.get_label_widget())->set_use_markup(true);
+    name_frame.set_shadow_type(Gtk::SHADOW_NONE);
+    name_frame.add(name_vbox);
+    auto radiobutton_rich_text = Gtk::RadioButton(_("Rich Text"));
+    auto radiobutton_plain_text = Gtk::RadioButton(_("Plain Text"));
+    radiobutton_plain_text.join_group(radiobutton_rich_text);
+    auto radiobutton_auto_syntax_highl = Gtk::RadioButton(_("Automatic Syntax Highlighting"));
+    radiobutton_auto_syntax_highl.join_group(radiobutton_rich_text);
+    auto button_prog_lang = Gtk::Button();
+    std::string syntax_hl_id = syntax_highl;
+    if (syntax_highl == CtConst::RICH_TEXT_ID || syntax_highl == CtConst::PLAIN_TEXT_ID)
+        syntax_hl_id = CtApp::P_ctCfg->autoSynHighl;
+    std::string button_stock_id = CtConst::getStockIdForCodeType(syntax_hl_id);
+    button_prog_lang.set_label(syntax_hl_id);
+    button_prog_lang.set_image(*CtImage::new_image_from_stock(button_stock_id, Gtk::ICON_SIZE_MENU));
+    if (syntax_highl == CtConst::RICH_TEXT_ID) {
+        radiobutton_rich_text.set_active(true);
+        button_prog_lang.set_sensitive(false);
+    } else if (syntax_highl == CtConst::PLAIN_TEXT_ID) {
+        radiobutton_plain_text.set_active(true);
+        button_prog_lang.set_sensitive(false);
+    } else {
+        radiobutton_auto_syntax_highl.set_active(true);
+    }
+    auto type_vbox = Gtk::VBox();
+    type_vbox.pack_start(radiobutton_rich_text);
+    type_vbox.pack_start(radiobutton_plain_text);
+    type_vbox.pack_start(radiobutton_auto_syntax_highl);
+    type_vbox.pack_start(button_prog_lang);
+    auto type_frame = Gtk::Frame(std::string("<b>")+_("Node Type")+"</b>");
+    ((Gtk::Label*)type_frame.get_label_widget())->set_use_markup(true);
+    type_frame.set_shadow_type(Gtk::SHADOW_NONE);
+    type_frame.add(type_vbox);
+    type_frame.set_sensitive(ro == false);
+    auto tags_hbox = Gtk::HBox();
+    tags_hbox.set_spacing(2);
+    auto tags_entry = Gtk::Entry();
+    tags_entry.set_text(tags);
+    auto button_browse_tags = Gtk::Button();
+    button_browse_tags.set_image(*CtImage::new_image_from_stock("find", Gtk::ICON_SIZE_BUTTON));
+    button_browse_tags.set_sensitive(!tags_set.empty());
+    tags_hbox.pack_start(tags_entry);
+    tags_hbox.pack_start(button_browse_tags, false, false);
+    auto tags_frame = Gtk::Frame(std::string("<b>")+_("Tags for Searching")+"</b>");
+    ((Gtk::Label*)tags_frame.get_label_widget())->set_use_markup(true);
+    tags_frame.set_shadow_type(Gtk::SHADOW_NONE);
+    tags_frame.add(tags_hbox);
+    auto ro_checkbutton = Gtk::CheckButton(_("Read Only"));
+    ro_checkbutton.set_active(ro);
+    auto content_area = dialog.get_content_area();
+    content_area->set_spacing(5);
+    content_area->pack_start(name_frame);
+    content_area->pack_start(type_frame);
+    content_area->pack_start(tags_frame);
+    content_area->pack_start(ro_checkbutton);
+    content_area->show_all();
+    name_entry.grab_focus();
+
+    button_prog_lang.signal_clicked().connect([&parent, &button_prog_lang](){
+        auto itemStore = ct_dialogs::CtChooseDialogListStore::create();
+        for (auto lang: CtApp::R_languageManager->get_language_ids())
+            itemStore->add_row(CtConst::getStockIdForCodeType(lang), "", lang);
+        auto res = ct_dialogs::choose_item_dialog(parent, _("Automatic Syntax Highlighting"), itemStore);
+        if (res) {
+            std::string stock_id = res->get_value(itemStore->columns.desc);
+            button_prog_lang.set_label(stock_id);
+            button_prog_lang.set_image(*CtImage::new_image_from_stock(stock_id, Gtk::ICON_SIZE_MENU));
+        }
+    });
+    radiobutton_auto_syntax_highl.signal_toggled().connect([&radiobutton_auto_syntax_highl, &button_prog_lang](){
+       button_prog_lang.set_sensitive(radiobutton_auto_syntax_highl.get_active());
+    });
+    button_browse_tags.signal_clicked().connect([&parent, &tags_entry, &tags_set](){
+        auto itemStore = ct_dialogs::CtChooseDialogListStore::create();
+        for (const auto& tag: tags_set)
+            itemStore->add_row("", "", tag);
+        auto res = ct_dialogs::choose_item_dialog(parent, _("Choose Existing Tag"), itemStore, _("Tag Name"));
+        if (res) {
+            std::string cur_tag = tags_entry.get_text();
+            if  (str::endswith(cur_tag, CtConst::CHAR_SPACE))
+                tags_entry.set_text(cur_tag + res->get_value(itemStore->columns.desc));
+            else
+                tags_entry.set_text(cur_tag + CtConst::CHAR_SPACE + res->get_value(itemStore->columns.desc));
+        }
+    });
+    ro_checkbutton.signal_toggled().connect([&ro_checkbutton, &type_frame](){
+        type_frame.set_sensitive(ro_checkbutton.get_active());
+    });
+    fg_checkbutton.signal_toggled().connect([&fg_checkbutton, &fg_colorbutton](){
+        fg_colorbutton.set_sensitive(fg_checkbutton.get_active());
+    });
+    fg_colorbutton.signal_pressed().connect([&parent, &fg_colorbutton](){
+        Gdk::RGBA ret_color = fg_colorbutton.get_rgba();
+        if (ct_dialogs::color_pick_dialog(parent, ret_color))
+            fg_colorbutton.set_rgba(ret_color);
+    });
+    c_icon_checkbutton.signal_toggled().connect([&c_icon_checkbutton, &c_icon_button](){
+        c_icon_button.set_sensitive(c_icon_checkbutton.get_active());
+    });
+    c_icon_button.signal_clicked().connect([&parent, &c_icon_button, &c_icon_id](){
+        auto itemStore = ct_dialogs::CtChooseDialogListStore::create();
+        for (auto& pair: CtConst::NODES_ICONS)
+            itemStore->add_row(pair.second, std::to_string(pair.first), "");
+        auto res = ct_dialogs::choose_item_dialog(parent, _("Select Node Icon"), itemStore);
+        if (res) {
+            c_icon_id = std::stoi(res->get_value(itemStore->columns.key));
+            c_icon_button.set_label("");
+            c_icon_button.set_image(*CtImage::new_image_from_stock(res->get_value(itemStore->columns.stock_id), Gtk::ICON_SIZE_BUTTON));
+        }
+    });
+
+    if (dialog.run() != Gtk::RESPONSE_ACCEPT)
+        return CtNodeData();
+
+    CtNodeData node;
+    node.name = name_entry.get_text();
+    if (node.name.empty())
+        node.name = CtConst::CHAR_QUESTION;
+    if (radiobutton_rich_text.get_active())
+        node.syntax = CtConst::RICH_TEXT_ID;
+    else if (radiobutton_plain_text.get_active())
+        node.syntax = CtConst::PLAIN_TEXT_ID;
+    else {
+        node.syntax = button_prog_lang.get_label();
+        CtApp::P_ctCfg->autoSynHighl = node.syntax;
+    }
+    node.tags = tags_entry.get_text();
+    node.isRO = ro_checkbutton.get_active();
+    node.customIconId = c_icon_checkbutton.get_active() ? c_icon_id : 0;
+    node.isBold = is_bold_checkbutton.get_active();
+    if (fg_checkbutton.get_active()) {
+        std::string foregroundRgb24 = CtRgbUtil::getRgb24StrFromStrAny(fg_colorbutton.get_color().to_string());
+        node.fgOverride = true;
+        g_strlcpy(node.foregroundRgb24, foregroundRgb24.c_str(), 8);
+        CtApp::P_ctCfg->currColors['n'] = foregroundRgb24;
+    }
+    return node;
+}

--- a/future/src/ct/ct_app.h
+++ b/future/src/ct/ct_app.h
@@ -30,6 +30,7 @@
 #include "ct_config.h"
 #include "ct_main_win.h"
 #include "ct_menu.h"
+#include "ct_actions.h"
 
 class CtTmp
 {
@@ -46,6 +47,7 @@ protected:
 
 class CtMenu;
 class CtMainWin;
+class CtActions;
 class CtApp: public Gtk::Application
 {
 protected:
@@ -65,6 +67,7 @@ public:
 
 private:
     CtMenu* _pCtMenu;
+    CtActions* _pCtActions;
 
 protected:
     void on_activate() override;
@@ -76,10 +79,10 @@ protected:
 
 public:
     void quit_application();
-    void add_node();
     void dialog_preferences();
 
 private:
     CtMainWin* create_appwindow();
+    CtMainWin* get_main_win();
     void on_hide_window(Gtk::Window* window);
 };

--- a/future/src/ct/ct_const.cc
+++ b/future/src/ct/ct_const.cc
@@ -121,6 +121,8 @@ const gchar    CtConst::STR_KEY_RIGHT[]             {"Right"};
 const gchar    CtConst::STR_STOCK_CT_IMP[]          {"import_in_cherrytree"};
 const gchar    CtConst::CHAR_NEWLINE[]              {"\n"};
 const gchar    CtConst::CHAR_STAR[]                 {"*"};
+const gchar    CtConst::CHAR_SPACE[]                {" "};
+const gchar    CtConst::CHAR_QUESTION[]             {"?"};
 
 const std::set<const gchar*> CtConst::TEXT_SYNTAXES {
     RICH_TEXT_ID,

--- a/future/src/ct/ct_const.h
+++ b/future/src/ct/ct_const.h
@@ -125,6 +125,8 @@ extern const gchar    STR_KEY_RIGHT[];
 extern const gchar    STR_STOCK_CT_IMP[];
 extern const gchar    CHAR_NEWLINE[];
 extern const gchar    CHAR_STAR[];
+extern const gchar    CHAR_SPACE[];
+extern const gchar    CHAR_QUESTION[];
 extern const std::set<const gchar*> TEXT_SYNTAXES;
 extern const std::set<const gchar*> TAG_PROPERTIES;
 extern const gchar    TOOLBAR_VEC_DEFAULT[];
@@ -139,7 +141,6 @@ extern const Glib::ustring CODE_EXEC_TMP_BIN;
 extern const Glib::ustring CODE_EXEC_COMMAND;
 extern const std::map<Glib::ustring, Glib::ustring> CODE_EXEC_TYPE_CMD_DEFAULT;
 extern const std::map<Glib::ustring, Glib::ustring> CODE_EXEC_TERM_RUN_DEFAULT;
-
 
 Glib::ustring getStockIdForCodeType(Glib::ustring code_type);
 

--- a/future/src/ct/ct_dialogs.cc
+++ b/future/src/ct/ct_dialogs.cc
@@ -1,0 +1,88 @@
+#include "ct_dialogs.h"
+#include <gtkmm/stock.h>
+#include <gtkmm/scrolledwindow.h>
+#include <gtkmm/treeview.h>
+#include <gtkmm/cellrendererpixbuf.h>
+#include <gtkmm/colorchooserdialog.h>
+#include "ct_app.h"
+
+using namespace ct_dialogs;
+
+Glib::RefPtr<CtChooseDialogListStore> CtChooseDialogListStore::create()
+{
+    Glib::RefPtr<CtChooseDialogListStore> model(new CtChooseDialogListStore());
+    model->set_column_types(model->columns);
+    return model;
+}
+
+void CtChooseDialogListStore::add_row(const std::string& stock_id, const std::string& key, const std::string& desc)
+{
+    auto row = *append();
+    row[columns.stock_id] = stock_id;
+    row[columns.key] = key;
+    row[columns.desc] = desc;
+}
+
+
+Gtk::TreeModel::iterator ct_dialogs::choose_item_dialog(Gtk::Window& parent, const std::string& title,
+                                                        Glib::RefPtr<CtChooseDialogListStore> model,
+                                                        const gchar* one_columns_name /* = nullptr */)
+{
+    Gtk::Dialog dialog(title, parent, Gtk::DialogFlags::DIALOG_MODAL | Gtk::DialogFlags::DIALOG_DESTROY_WITH_PARENT);
+    dialog.set_transient_for(parent);
+    dialog.add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_REJECT);
+    dialog.add_button(Gtk::Stock::OK, Gtk::RESPONSE_ACCEPT);
+    dialog.set_default_response(Gtk::RESPONSE_ACCEPT);
+    dialog.set_position(Gtk::WindowPosition::WIN_POS_CENTER_ON_PARENT);
+    dialog.set_default_size(400, 300);
+    Gtk::ScrolledWindow* scrolledwindow = Gtk::manage(new Gtk::ScrolledWindow());
+    scrolledwindow->set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC);
+    Gtk::TreeView* elements_treeview = Gtk::manage(new Gtk::TreeView(model));
+    elements_treeview->set_headers_visible(false);
+    Gtk::CellRendererPixbuf pix_buf_renderer;
+    if (one_columns_name == nullptr) {
+        int col_num = elements_treeview->append_column("", pix_buf_renderer) - 1;
+        elements_treeview->get_column(col_num)->add_attribute(pix_buf_renderer, "icon-name", model->columns.stock_id);
+    }
+    elements_treeview->append_column(one_columns_name ? one_columns_name : "", model->columns.desc);
+    scrolledwindow->add(*elements_treeview);
+    //list_parms->sel_iter = elements_liststore->get_iter_first()
+    //if list_parms->sel_iter:
+    //    elements_treeview->set_cursor(elements_liststore->get_path(list_parms->sel_iter))
+    auto content_area = dialog.get_content_area();
+    content_area->pack_start(*scrolledwindow);
+    content_area->show_all();
+    elements_treeview->grab_focus();
+
+    if (dialog.run() != Gtk::RESPONSE_ACCEPT) return Gtk::TreeModel::iterator();
+    return elements_treeview->get_selection()->get_selected();
+}
+
+// Dialog to select a color, featuring a palette
+bool ct_dialogs::color_pick_dialog(Gtk::Window& parent, Gdk::RGBA& color)
+{
+    Gtk::ColorChooserDialog dialog(_("Pick a Color"), parent);
+    dialog.set_transient_for(parent);
+    dialog.set_modal(true);
+    dialog.set_property("destroy-with-parent", true);
+    dialog.set_position(Gtk::WindowPosition::WIN_POS_CENTER_ON_PARENT);
+    std::vector<std::string> colors = str::split(CtApp::P_ctCfg->colorPalette, ":");
+    std::vector<Gdk::RGBA> rgbas;
+    for (const auto& c: colors)
+        rgbas.push_back(Gdk::RGBA(c));
+    dialog.add_palette(Gtk::Orientation::ORIENTATION_HORIZONTAL, 10, rgbas);
+    dialog.set_rgba(color);
+
+    if (Gtk::RESPONSE_OK != dialog.run())
+        return false;
+
+    std::string ret_color_hex8 = CtRgbUtil::rgb_any_to_24(dialog.get_rgba());
+    size_t color_qty = colors.size();
+    colors.erase(std::find(colors.begin(), colors.end(), ret_color_hex8));
+    if (color_qty == colors.size())
+        colors.pop_back();
+    colors.insert(colors.begin(), ret_color_hex8);
+
+    color = dialog.get_rgba();
+    return true;
+}

--- a/future/src/ct/ct_dialogs.h
+++ b/future/src/ct/ct_dialogs.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "gtkmm/dialog.h"
+#include <gtkmm/liststore.h>
+
+namespace ct_dialogs {
+
+class CtChooseDialogListStore : public Gtk::ListStore
+{
+public:
+    struct CtChooseDialogModelColumns : public Gtk::TreeModel::ColumnRecord
+    {
+       Gtk::TreeModelColumn<Glib::ustring> stock_id;
+       Gtk::TreeModelColumn<Glib::ustring> key;
+       Gtk::TreeModelColumn<Glib::ustring> desc;
+       CtChooseDialogModelColumns() { add(stock_id); add(key); add(desc); }
+    } columns;
+
+public:
+    static Glib::RefPtr<CtChooseDialogListStore> create();
+    void add_row(const std::string& stock_id, const std::string& key, const std::string& desc);
+};
+
+
+Gtk::TreeModel::iterator choose_item_dialog(Gtk::Window& parent,const std::string& title,
+                                            Glib::RefPtr<CtChooseDialogListStore> model,
+                                            const gchar* one_column_name = nullptr);
+
+bool color_pick_dialog(Gtk::Window& parent, Gdk::RGBA& color);
+
+} // namespace ct_dialogs

--- a/future/src/ct/ct_doc_rw.h
+++ b/future/src/ct/ct_doc_rw.h
@@ -67,6 +67,8 @@ public:
     Glib::RefPtr<Gsv::Buffer> getTextBuffer(const std::string& syntax,
                                             std::list<CtAnchoredWidget*>& anchoredWidgets,
                                             const gint64& nodeId);
+    void pending_new_db_node(gint64 node_id) { /* todo: */ }
+
 private:
     sqlite3* _pDb;
     std::list<gint64> _sqlite3GetChildrenNodeIdFromFatherId(gint64 father_id);

--- a/future/src/ct/ct_image.cc
+++ b/future/src/ct/ct_image.cc
@@ -51,6 +51,14 @@ CtImage::CtImage(const char* stockImage,
     show_all();
 }
 
+Gtk::Image* CtImage::new_image_from_stock(const std::string& stockImage, const int& size)
+{
+    Glib::RefPtr<Gdk::Pixbuf> pix_buf = CtApp::R_icontheme->load_icon(stockImage, size);
+    Gtk::Image* image = Gtk::manage(new Gtk::Image());
+    image->set(pix_buf);
+    return image;
+}
+
 
 CtImagePng::CtImagePng(const std::string& rawBlob,
                        const Glib::ustring& link,

--- a/future/src/ct/ct_image.h
+++ b/future/src/ct/ct_image.h
@@ -37,6 +37,10 @@ public:
             const int& charOffset,
             const std::string& justification);
     virtual ~CtImage() {}
+
+public:
+    static Gtk::Image* new_image_from_stock(const std::string& stockImage, const int& size);
+
 protected:
     Gtk::Image _image;
     Glib::RefPtr<Gdk::Pixbuf> _rPixbuf;

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -163,6 +163,12 @@ void CtMainWin::configApply()
     set_size_request(CtApp::P_ctCfg->winRect[2], CtApp::P_ctCfg->winRect[3]);
 }
 
+void update_window_save_needed(const std::string& update_type = "",
+                               bool new_machine_state = false, void* give_tree_iter = nullptr)
+{
+    // todo:
+}
+
 bool CtMainWin::readNodesFromGioFile(const Glib::RefPtr<Gio::File>& r_file, const bool isImport)
 {
     bool retOk{false};
@@ -263,6 +269,26 @@ void CtMainWin::_titleUpdate(bool saveNeeded)
     title += "CherryTree ";
     title += CtConst::CT_VERSION;
     set_title(title);
+}
+
+Gtk::TreeIter CtMainWin::curr_tree_iter()
+{
+    return _ctTreeview.get_selection()->get_selected();
+}
+
+CtTreeStore& CtMainWin::get_tree_store()
+{
+    return _ctTreestore;
+}
+
+CtTreeView& CtMainWin::get_tree_view()
+{
+    return _ctTreeview;
+}
+
+CtTextView& CtMainWin::get_text_view()
+{
+    return _ctTextview;
 }
 
 

--- a/future/src/ct/ct_main_win.h
+++ b/future/src/ct/ct_main_win.h
@@ -69,6 +69,13 @@ public:
 
     bool readNodesFromGioFile(const Glib::RefPtr<Gio::File>& r_file, const bool isImport);
     void configApply();
+    void update_window_save_needed(const std::string& update_type = "",
+                                   bool new_machine_state = false, void* give_tree_iter = nullptr) { /* todo: */ }
+
+    Gtk::TreeIter curr_tree_iter();
+    CtTreeStore&  get_tree_store();
+    CtTreeView&   get_tree_view();
+    CtTextView&   get_text_view();
 
 protected:
     void                _onTheTreeviewSignalCursorChanged();

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -54,7 +54,7 @@ CtMenu::CtMenu()
     _rGtkBuilder = Gtk::Builder::create();
 }
 
-void CtMenu::init_actions(CtApp *pApp)
+void CtMenu::init_actions(CtApp *pApp, CtActions* pActions)
 {
     // stubs for menu bar
     _actions.push_back(CtAction{"", "FileMenu", None, _("_File"), None, None, sigc::signal<void>()});
@@ -141,9 +141,9 @@ void CtMenu::init_actions(CtApp *pApp)
     _actions.push_back(CtAction{fmt_cat, "fmt_justify_right", "gtk-justify-right", _("Justify _Right"), None, _("Justify Right the Current Paragraph"), sigc::signal<void>() /* dad.apply_tag_justify_right */});
     _actions.push_back(CtAction{fmt_cat, "fmt_justify_fill", "gtk-justify-fill", _("Justify _Fill"), None, _("Justify Fill the Current Paragraph"), sigc::signal<void>() /* dad.apply_tag_justify_fill */});
     const char* tree_cat = _("Tree");
-    _actions.push_back(CtAction{tree_cat, "tree_add_node", "tree-node-add", _("Add _Node"), KB_CONTROL+"N", _("Add a Node having the same Parent of the Selected Node"), sigc::mem_fun(*pApp, &CtApp::add_node) /* dad.node_add */});
+    _actions.push_back(CtAction{tree_cat, "tree_add_node", "tree-node-add", _("Add _Node"), KB_CONTROL+"N", _("Add a Node having the same Parent of the Selected Node"), sigc::mem_fun(*pActions, &CtActions::node_add)});
     _actions.push_back(CtAction{tree_cat, "tree_add_subnode", "tree-subnode-add", _("Add _SubNode"), KB_CONTROL+KB_SHIFT+"N", _("Add a Child Node to the Selected Node"), sigc::signal<void>() /* dad.node_child_add */});
-    _actions.push_back(CtAction{tree_cat, "tree_dup_node", "tree-node-dupl", _("_Duplicate Node"), KB_CONTROL+KB_SHIFT+"D", _("Duplicate the Selected Node"), sigc::signal<void>() /* dad.node_duplicate */});
+    _actions.push_back(CtAction{tree_cat, "tree_dup_node", "tree-node-dupl", _("_Duplicate Node"), KB_CONTROL+KB_SHIFT+"D", _("Duplicate the Selected Node"), sigc::mem_fun(*pActions, &CtActions::node_dublicate)});
     _actions.push_back(CtAction{tree_cat, "tree_node_prop", "cherry_edit", _("Change Node _Properties"), "F2", _("Edit the Properties of the Selected Node"), sigc::signal<void>() /* dad.node_edit */});
     _actions.push_back(CtAction{tree_cat, "tree_node_toggle_ro", "locked", _("Toggle _Read Only"), KB_CONTROL+KB_ALT+"R", _("Toggle the Read Only Property of the Selected Node"), sigc::signal<void>() /* dad.node_toggle_read_only */});
     _actions.push_back(CtAction{tree_cat, "tree_node_date", "calendar", _("Insert Today's Node"), "F8", _("Insert a Node with Hierarchy Year/Month/Day"), sigc::signal<void>() /* dad.node_date */});

--- a/future/src/ct/ct_menu.h
+++ b/future/src/ct/ct_menu.h
@@ -41,6 +41,7 @@ struct CtAction
 };
 
 class CtApp;
+class CtActions;
 class CtMenu
 {
 public:
@@ -52,7 +53,7 @@ public:
 public:
     CtMenu();
 
-    void init_actions(CtApp* pApp);
+    void init_actions(CtApp* pApp, CtActions* pActions);
     CtAction const* find_action(const std::string& id);
     const std::list<CtAction>& get_actions() { return _actions; }
 

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -382,9 +382,49 @@ char* CtRgbUtil::setRgb24StrFromStrAny(const char* rgbStrAny, char* rgb24StrOut)
     return rgb24StrOut;
 }
 
+std::string CtRgbUtil::getRgb24StrFromStrAny(const std::string& rgbStrAny)
+{
+    char rgb24Str[8];
+    setRgb24StrFromStrAny(rgbStrAny.c_str(), rgb24Str);
+    return rgb24Str;
+}
+
+
 guint32 CtRgbUtil::getRgb24IntFromStrAny(const char* rgbStrAny)
 {
     char rgb24Str[8];
     setRgb24StrFromStrAny(rgbStrAny, rgb24Str);
     return getRgb24IntFromRgb24Str(rgb24Str);
+}
+
+std::string CtRgbUtil::rgb_to_string(Gdk::RGBA color)
+{
+    char rgbStrOut[16];
+    sprintf(rgbStrOut, "#%.2x%.2x%.2x", color.get_red_u(), color.get_green_u(), color.get_blue_u());
+    return rgbStrOut;
+}
+
+std::string CtRgbUtil::rgb_any_to_24(Gdk::RGBA color)
+{
+    char rgb24StrOut[16];
+    CtRgbUtil::setRgb24StrFromStrAny(CtRgbUtil::rgb_to_string(color).c_str(), rgb24StrOut);
+    return rgb24StrOut;
+}
+
+bool str::endswith(const std::string& str, const std::string& ending) {
+    if (str.length() >= ending.length())
+        return (0 == str.compare(str.length() - ending.length(), ending.length(), ending));
+    return false;
+}
+
+std::string str::trim(std::string str)
+{
+    return CtStrUtil::trimString(str);
+}
+
+std::vector<std::string> str::split(const std::string& str, const std::string& delimer)
+{
+    std::vector<std::string> vec;
+    CtStrUtil::gstringSplit2string(str.c_str(), vec, delimer.c_str());
+    return vec;
 }

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -126,6 +126,66 @@ guint32 getRgb24IntFromRgb24Str(const char* rgb24Str);
 
 char* setRgb24StrFromStrAny(const char* rgbStrAny, char* rgb24StrOut);
 
+std::string getRgb24StrFromStrAny(const std::string& rgbStrAny);
+
 guint32 getRgb24IntFromStrAny(const char* rgbStrAny);
 
+std::string rgb_to_string(Gdk::RGBA color);
+
+std::string rgb_any_to_24(Gdk::RGBA color);
+
+
 } // namespace CtRgbUtil
+
+
+namespace str {
+
+bool endswith(const std::string& str, const std::string& ending);
+
+std::string trim(std::string str);
+
+std::vector<std::string> split(const std::string& str, const std::string& delimer);
+
+template<class CONTAINER>
+std::string join(const CONTAINER cnt, const std::string& delimer)
+{
+    bool firstTime = true;
+    std::stringstream ss;
+    for (auto& v: cnt)
+    {
+      if (!firstTime) ss << delimer;
+      firstTime = false;
+      ss << v;
+    }
+    return ss.str();
+}
+
+
+} // namespace str
+
+namespace vec {
+
+template<class VEC, class VAL>
+void remove(VEC& vec, const VAL& val)
+{
+    auto it = std::find(vec.begin(), vec.end(), val);
+    if (it != vec.end())
+        vec.erase(it);
+}
+
+template<class VEC, class VAL>
+bool exists(const VEC& vec, const VAL& val)
+{
+    return std::find(vec.begin(), vec.end(), val) != vec.end();
+}
+
+} // namespace vec
+
+namespace map {
+
+template<class MAP, class KEY>
+bool exists(const MAP& m, KEY& key) {
+    return m.find(key) != m.end();
+}
+
+} // namespace map

--- a/future/src/ct/ct_pref_dlg.cc
+++ b/future/src/ct/ct_pref_dlg.cc
@@ -8,6 +8,8 @@
 #include <gdk/gdkkeysyms.h>
 #include "ct_app.h"
 #include "ct_misc_utils.h"
+#include "ct_image.h"
+#include "ct_dialogs.h"
 
 CtPrefDlg::CtPrefDlg(Gtk::Window& parent, CtMenu* pCtMenu)
     : Gtk::Dialog (_("Preferences"), parent, true)
@@ -104,7 +106,7 @@ Gtk::Widget* CtPrefDlg::build_tab_text_n_code()
     Gtk::Entry* entry_timestamp_format = Gtk::manage(new Gtk::Entry());
     entry_timestamp_format->set_text(config->timestampFormat);
     Gtk::Button* button_strftime_help = Gtk::manage(new Gtk::Button());
-    button_strftime_help->set_image(*new_image_from_stock("gtk-help", Gtk::ICON_SIZE_BUTTON));
+    button_strftime_help->set_image(*CtImage::new_image_from_stock("gtk-help", Gtk::ICON_SIZE_BUTTON));
     hbox_timestamp->pack_start(*label_timestamp, false, false);
     hbox_timestamp->pack_start(*entry_timestamp_format, false, false);
     hbox_timestamp->pack_start(*button_strftime_help, false, false);
@@ -121,7 +123,7 @@ Gtk::Widget* CtPrefDlg::build_tab_text_n_code()
     Gtk::Label* label_special_chars = Gtk::manage(new Gtk::Label(_("Special Characters")));
     Gtk::HBox* hbox_reset = Gtk::manage(new Gtk::HBox());
     Gtk::Button* button_reset = Gtk::manage(new Gtk::Button());
-    button_reset->set_image(*new_image_from_stock("gtk-undo", Gtk::ICON_SIZE_BUTTON));
+    button_reset->set_image(*CtImage::new_image_from_stock("gtk-undo", Gtk::ICON_SIZE_BUTTON));
     button_reset->set_tooltip_text(_("Reset to Default"));
     hbox_reset->pack_start(*Gtk::manage(new Gtk::Label()), true, false); // todo: not sure about third arg
     hbox_reset->pack_start(*button_reset, false, false);
@@ -408,13 +410,13 @@ Gtk::Widget* CtPrefDlg::build_tab_rich_text()
         //if new_lang_code != dad.spell_check_lang: dad.spell_check_set_new_lang(new_lang_code)
     });
     colorbutton_text_fg->signal_color_set().connect([this, config, colorbutton_text_fg](){
-        config->rtDefFg = rgb_any_to_24(colorbutton_text_fg->get_rgba());
+        config->rtDefFg = CtRgbUtil::rgb_any_to_24(colorbutton_text_fg->get_rgba());
         //if dad.curr_tree_iter and dad.syntax_highlighting == cons.RICH_TEXT_ID:
         //    dad.widget_set_colors(dad.sourceview, dad.rt_def_fg, dad.rt_def_bg, False)
         //    support.rich_text_node_modify_codeboxes_color(dad.curr_buffer.get_start_iter(), dad)
     });
     colorbutton_text_bg->signal_color_set().connect([this, config, colorbutton_text_bg](){
-        config->rtDefBg = rgb_any_to_24(colorbutton_text_bg->get_rgba());
+        config->rtDefBg = CtRgbUtil::rgb_any_to_24(colorbutton_text_bg->get_rgba());
         //if dad.curr_tree_iter and dad.syntax_highlighting == cons.RICH_TEXT_ID:
         //    if dad.rt_highl_curr_line:
         //        dad.set_sourcebuffer_with_style_scheme()
@@ -449,7 +451,7 @@ Gtk::Widget* CtPrefDlg::build_tab_rich_text()
     checkbutton_monospace_bg->signal_toggled().connect([this, config, checkbutton_monospace_bg, colorbutton_monospace_bg](){
         if (checkbutton_monospace_bg->get_active())
         {
-            config->monospaceBg = rgb_any_to_24(colorbutton_monospace_bg->get_rgba());
+            config->monospaceBg = CtRgbUtil::rgb_any_to_24(colorbutton_monospace_bg->get_rgba());
             colorbutton_monospace_bg->set_sensitive(true);
         } else {
             config->monospaceBg = "";
@@ -458,7 +460,7 @@ Gtk::Widget* CtPrefDlg::build_tab_rich_text()
         need_restart(RESTART_REASON::MONOSPACE);
     });
     colorbutton_monospace_bg->signal_color_set().connect([this, config, colorbutton_monospace_bg](){
-        config->monospaceBg = rgb_any_to_24(colorbutton_monospace_bg->get_rgba());
+        config->monospaceBg = CtRgbUtil::rgb_any_to_24(colorbutton_monospace_bg->get_rgba());
         need_restart(RESTART_REASON::MONOSPACE);
     });
     checkbutton_rt_show_white_spaces->signal_toggled().connect([config, checkbutton_rt_show_white_spaces](){
@@ -535,10 +537,10 @@ Gtk::Widget* CtPrefDlg::build_tab_plain_text_n_code()
     scrolledwindow->add(*treeview);
 
     Gtk::Button* button_add = Gtk::manage(new Gtk::Button());
-    button_add->set_image(*new_image_from_stock("gtk-add", Gtk::ICON_SIZE_BUTTON));
+    button_add->set_image(*CtImage::new_image_from_stock("gtk-add", Gtk::ICON_SIZE_BUTTON));
     button_add->set_tooltip_text(_("Add"));
     Gtk::Button* button_reset_cmds = Gtk::manage(new Gtk::Button());
-    button_reset_cmds->set_image(*new_image_from_stock("gtk-undo", Gtk::ICON_SIZE_BUTTON));
+    button_reset_cmds->set_image(*CtImage::new_image_from_stock("gtk-undo", Gtk::ICON_SIZE_BUTTON));
     button_reset_cmds->set_tooltip_text(_("Reset to Default"));
     Gtk::VBox* vbox_buttons = Gtk::manage(new Gtk::VBox());
     vbox_buttons->pack_start(*button_add, false, false);
@@ -550,7 +552,7 @@ Gtk::Widget* CtPrefDlg::build_tab_plain_text_n_code()
     Gtk::Entry* entry_term_run = Gtk::manage(new Gtk::Entry());
     entry_term_run->set_text(get_code_exec_term_run());
     Gtk::Button* button_reset_term = Gtk::manage(new Gtk::Button());
-    button_reset_term->set_image(*new_image_from_stock("gtk-undo", Gtk::ICON_SIZE_BUTTON));
+    button_reset_term->set_image(*CtImage::new_image_from_stock("gtk-undo", Gtk::ICON_SIZE_BUTTON));
     button_reset_term->set_tooltip_text(_("Reset to Default"));
     hbox_term_run->pack_start(*entry_term_run, true, false);
     hbox_term_run->pack_start(*button_reset_term, false, false);
@@ -683,7 +685,7 @@ Gtk::Widget* CtPrefDlg::build_tab_tree_1()
     checkbutton_aux_icon_hide->set_active(config->auxIconHide);
 
     Gtk::Button* c_icon_button = Gtk::manage(new Gtk::Button());
-    c_icon_button->set_image(*new_image_from_stock(CtConst::NODES_STOCKS.at(config->defaultIconText), Gtk::ICON_SIZE_BUTTON));
+    c_icon_button->set_image(*CtImage::new_image_from_stock(CtConst::NODES_STOCKS.at(config->defaultIconText), Gtk::ICON_SIZE_BUTTON));
     Gtk::HBox* c_icon_hbox = Gtk::manage(new Gtk::HBox());
     c_icon_hbox->set_spacing(2);
     c_icon_hbox->pack_start(*radiobutton_node_icon_custom, false, false);
@@ -739,12 +741,12 @@ Gtk::Widget* CtPrefDlg::build_tab_tree_1()
     pMainBox->pack_start(*frame_nodes_startup, false, false);
 
     colorbutton_tree_fg->signal_color_set().connect([this, config, colorbutton_tree_fg](){
-        config->ttDefFg = rgb_any_to_24(colorbutton_tree_fg->get_rgba());
+        config->ttDefFg = CtRgbUtil::rgb_any_to_24(colorbutton_tree_fg->get_rgba());
         //dad.treeview_set_colors()
         //if dad.curr_tree_iter: dad.update_node_name_header()
     });
     colorbutton_tree_bg->signal_color_set().connect([this, config, colorbutton_tree_bg](){
-        config->ttDefBg = rgb_any_to_24(colorbutton_tree_bg->get_rgba());
+        config->ttDefBg = CtRgbUtil::rgb_any_to_24(colorbutton_tree_bg->get_rgba());
         //dad.treeview_set_colors()
         //if dad.curr_tree_iter: dad.update_node_name_header()
     });
@@ -900,10 +902,10 @@ Gtk::Widget* CtPrefDlg::build_tab_fonts()
 {
     CtConfig* config = CtApp::P_ctCfg;
 
-    Gtk::Image* image_rt = new_image_from_stock(Gtk::Stock::SELECT_FONT.id, Gtk::ICON_SIZE_MENU);
-    Gtk::Image* image_pt = new_image_from_stock(Gtk::Stock::SELECT_FONT.id, Gtk::ICON_SIZE_MENU);
-    Gtk::Image* image_code = new_image_from_stock("xml", Gtk::ICON_SIZE_MENU);
-    Gtk::Image* image_tree = new_image_from_stock("cherries", Gtk::ICON_SIZE_MENU);
+    Gtk::Image* image_rt = CtImage::new_image_from_stock(Gtk::Stock::SELECT_FONT.id, Gtk::ICON_SIZE_MENU);
+    Gtk::Image* image_pt = CtImage::new_image_from_stock(Gtk::Stock::SELECT_FONT.id, Gtk::ICON_SIZE_MENU);
+    Gtk::Image* image_code = CtImage::new_image_from_stock("xml", Gtk::ICON_SIZE_MENU);
+    Gtk::Image* image_tree = CtImage::new_image_from_stock("cherries", Gtk::ICON_SIZE_MENU);
     Gtk::Label* label_rt = Gtk::manage(new Gtk::Label(_("Rich Text")));
     Gtk::Label* label_pt = Gtk::manage(new Gtk::Label(_("Plain Text")));
     Gtk::Label* label_code = Gtk::manage(new Gtk::Label(_("Code Font")));
@@ -1115,19 +1117,19 @@ Gtk::Widget* CtPrefDlg::build_tab_links()
         need_restart(RESTART_REASON::ANCHOR_SIZE);
     });
     colorbutton_col_link_webs->signal_color_set().connect([this, config, colorbutton_col_link_webs](){
-        config->colLinkWebs = rgb_to_string(colorbutton_col_link_webs->get_rgba());
+        config->colLinkWebs = CtRgbUtil::rgb_to_string(colorbutton_col_link_webs->get_rgba());
         need_restart(RESTART_REASON::COLOR);
     });
     colorbutton_col_link_node->signal_color_set().connect([this, config, colorbutton_col_link_node](){
-        config->colLinkNode = rgb_to_string(colorbutton_col_link_node->get_rgba());
+        config->colLinkNode = CtRgbUtil::rgb_to_string(colorbutton_col_link_node->get_rgba());
         need_restart(RESTART_REASON::COLOR);
     });
     colorbutton_col_link_file->signal_color_set().connect([this, config, colorbutton_col_link_file](){
-        config->colLinkFile =  rgb_to_string(colorbutton_col_link_file->get_rgba());
+        config->colLinkFile =  CtRgbUtil::rgb_to_string(colorbutton_col_link_file->get_rgba());
         need_restart(RESTART_REASON::COLOR);
     });
     colorbutton_col_link_fold->signal_color_set().connect([this, config, colorbutton_col_link_fold](){
-        config->colLinkFold = rgb_to_string(colorbutton_col_link_fold->get_rgba());
+        config->colLinkFold = CtRgbUtil::rgb_to_string(colorbutton_col_link_fold->get_rgba());
         need_restart(RESTART_REASON::COLOR);
     });
 
@@ -1150,13 +1152,13 @@ Gtk::Widget* CtPrefDlg::build_tab_toolbar()
     scrolledwindow->add(*treeview);
 
     Gtk::Button* button_add = Gtk::manage(new Gtk::Button());
-    button_add->set_image(*new_image_from_stock(Gtk::Stock::ADD.id,  Gtk::ICON_SIZE_BUTTON));
+    button_add->set_image(*CtImage::new_image_from_stock(Gtk::Stock::ADD.id,  Gtk::ICON_SIZE_BUTTON));
     button_add->set_tooltip_text(_("Add"));
     Gtk::Button* button_remove = Gtk::manage(new Gtk::Button());
-    button_remove->set_image(*new_image_from_stock(Gtk::Stock::REMOVE.id, Gtk::ICON_SIZE_BUTTON));
+    button_remove->set_image(*CtImage::new_image_from_stock(Gtk::Stock::REMOVE.id, Gtk::ICON_SIZE_BUTTON));
     button_remove->set_tooltip_text(_("Remove Selected"));
     Gtk::Button* button_reset = Gtk::manage(new Gtk::Button());
-    button_reset->set_image(*new_image_from_stock(Gtk::Stock::UNDO.id, Gtk::ICON_SIZE_BUTTON));
+    button_reset->set_image(*CtImage::new_image_from_stock(Gtk::Stock::UNDO.id, Gtk::ICON_SIZE_BUTTON));
     button_reset->set_tooltip_text(_("Reset to Default"));
 
     Gtk::HBox* hbox = Gtk::manage(new Gtk::HBox());
@@ -1223,10 +1225,10 @@ Gtk::Widget* CtPrefDlg::build_tab_kb_shortcuts()
 
     Gtk::VBox* vbox_buttons = Gtk::manage(new Gtk::VBox());
     Gtk::Button* button_edit = Gtk::manage(new Gtk::Button());
-    button_edit->set_image(*new_image_from_stock(Gtk::Stock::ADD.id,  Gtk::ICON_SIZE_BUTTON));
+    button_edit->set_image(*CtImage::new_image_from_stock(Gtk::Stock::ADD.id,  Gtk::ICON_SIZE_BUTTON));
     button_edit->set_tooltip_text(_("Change Selected"));
     Gtk::Button* button_reset = Gtk::manage(new Gtk::Button());
-    button_reset->set_image(*new_image_from_stock(Gtk::Stock::UNDO.id,  Gtk::ICON_SIZE_BUTTON));
+    button_reset->set_image(*CtImage::new_image_from_stock(Gtk::Stock::UNDO.id,  Gtk::ICON_SIZE_BUTTON));
     button_reset->set_tooltip_text(_("Reset to Default"));
     vbox_buttons->pack_start(*button_edit, false, false);
     vbox_buttons->pack_start(*Gtk::manage(new Gtk::Label()), true, true);
@@ -1469,26 +1471,6 @@ Glib::RefPtr<Gdk::Pixbuf> CtPrefDlg::get_icon(const std::string& name)
     return Glib::RefPtr<Gdk::Pixbuf>();
 }
 
-Gtk::Image* CtPrefDlg::new_image_from_stock(const std::string& id, Gtk::IconSize size)
-{
-    Gtk::Image* image = Gtk::manage(new Gtk::Image());
-    image->set_from_icon_name(id, size);
-    return image;
-}
-
-std::string CtPrefDlg::rgb_any_to_24(Gdk::RGBA color)
-{
-    char rgb24StrOut[16];
-    CtRgbUtil::setRgb24StrFromStrAny(rgb_to_string(color).c_str(), rgb24StrOut);
-    return rgb24StrOut;
-}
-
-std::string CtPrefDlg::rgb_to_string(Gdk::RGBA color)
-{
-    char rgbStrOut[16];
-    sprintf(rgbStrOut, "#%.2x%.2x%.2x", color.get_red_u(), color.get_green_u(), color.get_blue_u());
-    return rgbStrOut;
-}
 
 bool CtPrefDlg::user_confirm(const std::string& warning)
 {
@@ -1514,33 +1496,6 @@ void CtPrefDlg::need_restart(RESTART_REASON reason, const gchar* msg /*= nullptr
         _restartReasons |= (int)reason;
         user_inform(msg ? msg : _("This Change will have Effect Only After Restarting CherryTree"));
     }
-}
-
-Gtk::TreeModel::iterator CtPrefDlg::choose_item_dialog(const std::string& title, Glib::RefPtr<Gtk::ListStore> model)
-{
-    Gtk::Dialog dialog(title, *this, Gtk::DialogFlags::DIALOG_MODAL | Gtk::DialogFlags::DIALOG_DESTROY_WITH_PARENT);
-    dialog.add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_REJECT);
-    dialog.add_button(Gtk::Stock::OK, Gtk::RESPONSE_ACCEPT);
-    dialog.set_default_response(Gtk::RESPONSE_ACCEPT);
-    dialog.set_position(Gtk::WindowPosition::WIN_POS_CENTER_ON_PARENT);
-    dialog.set_default_size(400, 300);
-    Gtk::ScrolledWindow* scrolledwindow = Gtk::manage(new Gtk::ScrolledWindow());
-    scrolledwindow->set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC);
-    Gtk::TreeView* elements_treeview = Gtk::manage(new Gtk::TreeView(model));
-    elements_treeview->set_headers_visible(false);
-    elements_treeview->append_column("", _chooseItemColumns.icon);
-    elements_treeview->append_column("", _chooseItemColumns.desc);
-    scrolledwindow->add(*elements_treeview);
-    //list_parms->sel_iter = elements_liststore->get_iter_first()
-    //if list_parms->sel_iter:
-    //    elements_treeview->set_cursor(elements_liststore->get_path(list_parms->sel_iter))
-    auto content_area = dialog.get_content_area();
-    content_area->pack_start(*scrolledwindow);
-    content_area->show_all();
-    elements_treeview->grab_focus();
-
-    if (dialog.run() != Gtk::RESPONSE_ACCEPT) return Gtk::TreeModel::iterator();
-    return elements_treeview->get_selection()->get_selected();
 }
 
 std::string CtPrefDlg::get_code_exec_term_run()
@@ -1602,8 +1557,7 @@ void CtPrefDlg::add_new_command_in_model(Glib::RefPtr<Gtk::ListStore> model)
 
 void CtPrefDlg::fill_toolbar_model(Glib::RefPtr<Gtk::ListStore> model)
 {
-    std::vector<std::string> vecToolbarElements;
-    CtStrUtil::gstringSplit2string(CtApp::P_ctCfg->toolbarUiList.c_str(), vecToolbarElements, ",");
+    std::vector<std::string> vecToolbarElements = str::split(CtApp::P_ctCfg->toolbarUiList, ",");
     model->clear();
     for(const std::string& key: vecToolbarElements)
         add_new_item_in_toolbar_model(model->append(), key);
@@ -1636,26 +1590,21 @@ void CtPrefDlg::add_new_item_in_toolbar_model(Gtk::TreeModel::iterator row, cons
 
 bool CtPrefDlg::add_new_item_in_toolbar_model(Gtk::TreeView* treeview, Glib::RefPtr<Gtk::ListStore> model)
 {
-    Glib::RefPtr<Gtk::ListStore> itemStore = Gtk::ListStore::create(_chooseItemColumns);
-    auto sep_row = *itemStore->append();
-    sep_row[_chooseItemColumns.key] = CtConst::TAG_SEPARATOR;
-    sep_row[_chooseItemColumns.desc] = CtConst::TAG_SEPARATOR_ANSI_REPR;
+    auto itemStore = ct_dialogs::CtChooseDialogListStore::create();
+    itemStore->add_row("", CtConst::TAG_SEPARATOR, CtConst::TAG_SEPARATOR_ANSI_REPR);
     for (const CtAction& action: _pCtMenu->get_actions())
     {
         if (action.desc.empty()) continue; // skip stub menu entries
         if (action.id == "ct_open_file" && CtApp::P_ctCfg->toolbarUiList.find(CtConst::CHAR_STAR) != std::string::npos) continue;
-        if (std::find(CtConst::TOOLBAR_VEC_BLACKLIST.begin(), CtConst::TOOLBAR_VEC_BLACKLIST.end(), action.id) != CtConst::TOOLBAR_VEC_BLACKLIST.end()) continue;
-        auto row = *itemStore->append();
-        row[_chooseItemColumns.key] = action.id;
-        if (action.image != "") row[_chooseItemColumns.icon] = get_icon(action.image);
-        row[_chooseItemColumns.desc] = action.desc;
+        if (vec::exists(CtConst::TOOLBAR_VEC_BLACKLIST, action.id)) continue;
+        itemStore->add_row(action.image, action.id, action.desc);
     }
 
-    auto chosen_row = choose_item_dialog(_("Select Element to Add"), itemStore);
+    auto chosen_row = ct_dialogs::choose_item_dialog(*this, _("Select Element to Add"), itemStore);
     if (chosen_row) {
         auto selected_row = treeview->get_selection()->get_selected();
         auto new_row = selected_row ? model->insert_after(*selected_row) : model->append();
-        add_new_item_in_toolbar_model(new_row, chosen_row->get_value(_chooseItemColumns.key));
+        add_new_item_in_toolbar_model(new_row, chosen_row->get_value(itemStore->columns.key));
         return true;
     }
     return false;
@@ -1663,10 +1612,10 @@ bool CtPrefDlg::add_new_item_in_toolbar_model(Gtk::TreeView* treeview, Glib::Ref
 
 void CtPrefDlg::update_config_toolbar_from_model(Glib::RefPtr<Gtk::ListStore> model)
 {
-    std::string acc;
+    std::vector<std::string> items;
     for (auto it: model->children())
-        acc += it.get_value(_toolbarModelColumns.key) + ",";
-    CtApp::P_ctCfg->toolbarUiList = acc.substr(0, acc.size()-1);
+        items.push_back(it.get_value(_toolbarModelColumns.key));
+    CtApp::P_ctCfg->toolbarUiList = str::join(items, ",");
 }
 
 void CtPrefDlg::fill_shortcut_model(Glib::RefPtr<Gtk::TreeStore> model)

--- a/future/src/ct/ct_pref_dlg.h
+++ b/future/src/ct/ct_pref_dlg.h
@@ -36,13 +36,9 @@ private:
 
 private:
     Glib::RefPtr<Gdk::Pixbuf> get_icon(const std::string& name);
-    Gtk::Image*               new_image_from_stock(const std::string& id, Gtk::IconSize size);
-    std::string               rgb_any_to_24(Gdk::RGBA color);
-    std::string               rgb_to_string(Gdk::RGBA color);
     bool                      user_confirm(const std::string& warning);
     void                      user_inform(const std::string& info);
     void                      need_restart(RESTART_REASON reason, const gchar* msg = nullptr);
-    Gtk::TreeModel::iterator  choose_item_dialog(const std::string& title, Glib::RefPtr<Gtk::ListStore> model);
 
 private:
     std::string get_code_exec_term_run();
@@ -73,7 +69,6 @@ private:
     UniversalModelColumns _commandModelColumns;
     UniversalModelColumns _toolbarModelColumns;
     UniversalModelColumns _shortcutModelColumns;
-    UniversalModelColumns _chooseItemColumns;
     CtMenu*               _pCtMenu;
     int                   _restartReasons;
 };

--- a/future/src/ct/ct_treestore.h
+++ b/future/src/ct/ct_treestore.h
@@ -96,7 +96,11 @@ public:
     void          viewConnect(Gtk::TreeView* pTreeView);
     void          viewAppendColumns(Gtk::TreeView* pTreeView);
     bool          readNodesFromFilepath(const char* filepath, const bool isImport, const Gtk::TreeIter* pParentIter=nullptr);
+    void          getNodeData(Gtk::TreeIter treeIter, CtNodeData& nodeData);
+    void          updateNodeData(Gtk::TreeIter treeIter, const CtNodeData& nodeData);
+    void          updateNodeAuxIcon(Gtk::TreeIter treeIter);
     Gtk::TreeIter appendNode(CtNodeData* pNodeData, const Gtk::TreeIter* pParentIter=nullptr);
+    Gtk::TreeIter insertNode(CtNodeData* pNodeData, const Gtk::TreeIter& afterIter);
 
     void          onRequestAddBookmark(gint64 nodeId);
     Gtk::TreeIter onRequestAppendNode(CtNodeData* pNodeData, const Gtk::TreeIter* pParentIter);
@@ -110,15 +114,33 @@ public:
     void setTreePathTextCursorFromConfig(Gtk::TreeView* pTreeView, Gsv::View* pTextView);
     void treeviewSafeSetCursor(Gtk::TreeView* pTreeView, Gtk::TreeIter& iter);
 
+    gint64                       node_id_get();
+    void                         add_used_tags(const std::string& tags);
+    const std::set<std::string>& get_used_tags() { return _usedTags; }
+
+public:
+    Gtk::TreeIter get_iter_first();
+    Gtk::TreeIter iter_children(Gtk::TreeIter tree_iter);
+    Gtk::TreeIter iter_next(Gtk::TreeIter tree_iter);
+    Gtk::TreeIter iter_parent(Gtk::TreeIter tree_iter);
+    int           iter_depth(Gtk::TreeIter tree_iter);
+    Gtk::TreePath get_path(Gtk::TreeIter tree_iter);
+
+    void nodes_sequences_fix(Gtk::TreeIter father_iter, bool process_children) { /* todo: */ }
+    CtSQLiteRead* ctdb_handler() { return _pCtSQLiteRead; }
+
 protected:
     guint16                   _getPangoWeight(bool isBold);
-    Glib::RefPtr<Gdk::Pixbuf> _getNodeIcon(int nodeDepth, std::string &syntax, guint32 customIconId);
+    bool                      _getBold(guint16 pangoWeight);
+    Glib::RefPtr<Gdk::Pixbuf> _getNodeIcon(int nodeDepth, const std::string &syntax, guint32 customIconId);
     void                      _iterDeleteAnchoredWidgets(const Gtk::TreeModel::Children& children);
+
 
     Glib::RefPtr<Gsv::Buffer> _getNodeTextBuffer(const Gtk::TreeIter& treeIter);
 
     CtTreeModelColumns           _columns;
     Glib::RefPtr<Gtk::TreeStore> _rTreeStore;
     std::set<gint64>             _bookmarks;
+    std::set<std::string>        _usedTags;
     CtSQLiteRead*                _pCtSQLiteRead{nullptr};
 };

--- a/future/tests/tests_misc_utils.cpp
+++ b/future/tests/tests_misc_utils.cpp
@@ -176,6 +176,37 @@ TEST(MiscUtilsGroup, getRgb24IntFromStrAny)
     CHECK_EQUAL(expectedInt24, CtRgbUtil::getRgb24IntFromStrAny("f122ab335744"));
 }
 
+TEST(MiscUtilsGroup, str__endswith)
+{
+    CHECK(str::endswith("", ""));
+    CHECK(str::endswith("123", ""));
+    CHECK(str::endswith("123", "23"));
+    CHECK(!str::endswith("123", "1"));
+    CHECK(!str::endswith("", "1"));
+}
+
+TEST(MiscUtilsGroup, str__join)
+{
+    std::vector<std::string> empty_v;
+    std::vector<std::string> v_1{"1"};
+    std::vector<std::string> v_2{"1", "2"};
+
+    CHECK(str::join(empty_v, ",") == "");
+    CHECK(str::join(v_1, ",") == "1");
+    CHECK(str::join(v_2, ",") == "1,2");
+}
+
+TEST(MiscUtilsGroup, vec_remove)
+{
+    std::vector<int> empty_v;
+    std::vector<int> v_3{1, 2, 3};
+
+    vec::remove(empty_v, 1);
+    vec::remove(v_3, 0);
+    CHECK(v_3.size() == 3);
+    vec::remove(v_3, 2);
+    CHECK(v_3.size() == 2);
+}
 
 int main(int ac, char** av)
 {


### PR DESCRIPTION
- Added `CtActions` to keep action functions. Also, there is `CtAction`, so the naming might be a bit confusing.
- Added actions: `node_add` and `node_duplicate`. The property dialog, its controls, and adding a node into the treestore are working, but some functions are still stubs. And when the node gets focus, sig fault occurs. I suppose, the problem is with uninitialized rTextBuffer.
- Added ct_dialogs where I will try to keep dialogs from support.py.
- I tried another approach in naming string and containers helper functions, like std::trim, str::join, str::split, str::endswith, vec::remove and etc. I think, this way it is easier to remember what to type. What do you think? Also, I keep the previous duplicate functions just in case.

BTW, can `ct_doc_rw.h`, `ct_xml_rw.cc`, `ct_sqlite3_rw` be renamed? It's just quite hard to look for them in IDE project tree while they are in totally different places. Maybe `ct_doc_rw.h`, `ct_doc_xml_rw.cc`, `ct_doc_sqlite3_rw.cc` or another way will be better?

I'll be out of town for the weekend, so I can start the next task next Monday.