### PR TITLE
(Port to C++) node_edit, node_child_add

### DIFF
--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -14,12 +14,12 @@ private:
 
 private:
     bool is_there_selected_node_or_error();
-    void _node_add(bool duplicate);
+    void _node_add(bool duplicate, bool add_child);
 
 public:
     // tree actions
-    void node_add()       { _node_add(false); }
-    void node_dublicate() { _node_add(true);  }
-    void node_child_add();
+    void node_add()       { _node_add(false, false); }
+    void node_dublicate() { _node_add(true, false);  }
+    void node_child_add() { _node_add(false, true); }
     void node_edit();
 };

--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -13,6 +13,7 @@ private:
     CtTreeStore* _ctTreestore;
 
 private:
+    bool is_there_selected_node_or_error();
     void _node_add(bool duplicate);
 
 public:

--- a/future/src/ct/ct_actions_tree.cc
+++ b/future/src/ct/ct_actions_tree.cc
@@ -19,36 +19,41 @@ bool CtActions::is_there_selected_node_or_error()
     return false;
 }
 
-void CtActions::_node_add(bool duplicate)
+void CtActions::_node_add(bool duplicate, bool add_child)
 {
-    CtNodeData node;
+    CtNodeData nodeData;
     if (duplicate)
      {
         if (!is_there_selected_node_or_error()) return;
-        _ctTreestore->getNodeData(_ctMainWin->curr_tree_iter(), node);
-        node.anchoredWidgets.clear();
-        node.rTextBuffer.clear();
+        _ctTreestore->getNodeData(_ctMainWin->curr_tree_iter(), nodeData);
+        nodeData.anchoredWidgets.clear();
+        nodeData.rTextBuffer.clear();
     }
     else
     {
-        node = dialog_node_prop(_("New Node Properties"), *_ctMainWin, "", false, "", 0, CtConst::RICH_TEXT_ID, false, "", _ctTreestore->get_used_tags());
-        if (node.name.empty()) return;
+        if (add_child && !is_there_selected_node_or_error()) return;
+        std::string title = add_child ? _("New Child Node Properties") : _("New Node Properties");
+        nodeData = dialog_node_prop(title, *_ctMainWin, "", false, "", 0, CtConst::RICH_TEXT_ID, false, "", _ctTreestore->get_used_tags());
+        if (nodeData.name.empty()) return;
     }
 
-    node.tsCreation = std::time(nullptr);
-    node.tsLastSave = node.tsCreation;
-    node.nodeId = _ctTreestore->node_id_get();
+    nodeData.tsCreation = std::time(nullptr);
+    nodeData.tsLastSave = nodeData.tsCreation;
+    nodeData.nodeId = _ctTreestore->node_id_get();
 
     _ctMainWin->update_window_save_needed();
-    CtApp::P_ctCfg->syntaxHighlighting = node.syntax;
+    CtApp::P_ctCfg->syntaxHighlighting = nodeData.syntax;
 
     Gtk::TreeIter nodeIter;
-    if (_ctMainWin->curr_tree_iter())
-        nodeIter = _ctTreestore->insertNode(&node, _ctMainWin->curr_tree_iter());
+    if (add_child) {
+        const Gtk::TreeIter parent = _ctMainWin->curr_tree_iter();
+        nodeIter = _ctTreestore->appendNode(&nodeData, &parent);
+    } else if (_ctMainWin->curr_tree_iter())
+        nodeIter = _ctTreestore->insertNode(&nodeData, _ctMainWin->curr_tree_iter());
     else
-        nodeIter = _ctTreestore->appendNode(&node);
+        nodeIter = _ctTreestore->appendNode(&nodeData);
 
-    _ctTreestore->ctdb_handler()->pending_new_db_node(node.nodeId);
+    _ctTreestore->ctdb_handler()->pending_new_db_node(nodeData.nodeId);
     _ctTreestore->nodes_sequences_fix(_ctMainWin->curr_tree_iter()->parent(), false);
     _ctTreestore->updateNodeAuxIcon(nodeIter);
     /* todo
@@ -69,24 +74,19 @@ void CtActions::_node_add(bool duplicate)
     _ctMainWin->get_text_view().grab_focus();
 }
 
-void CtActions::node_child_add()
-{
-
-}
-
 void CtActions::node_edit()
 {
     if (!is_there_selected_node_or_error()) return;
-    CtNodeData cur_data;
-    _ctTreestore->getNodeData(_ctMainWin->curr_tree_iter(), cur_data);
-    CtNodeData new_data = dialog_node_prop(_("Node Properties"), *_ctMainWin, cur_data.name, cur_data.isBold,
-                                           cur_data.foregroundRgb24, cur_data.customIconId, cur_data.syntax,
-                                           cur_data.isRO, cur_data.tags, _ctTreestore->get_used_tags());
-    if (new_data.name.empty()) return;
+    CtNodeData nodeData;
+    _ctTreestore->getNodeData(_ctMainWin->curr_tree_iter(), nodeData);
+    CtNodeData newData = dialog_node_prop(_("Node Properties"), *_ctMainWin, nodeData.name, nodeData.isBold,
+                                           nodeData.foregroundRgb24, nodeData.customIconId, nodeData.syntax,
+                                           nodeData.isRO, nodeData.tags, _ctTreestore->get_used_tags());
+    if (newData.name.empty()) return;
 
-    CtApp::P_ctCfg->syntaxHighlighting = new_data.syntax;
-    if (cur_data.syntax !=  new_data.syntax) {
-        if (cur_data.syntax == CtConst::RICH_TEXT_ID) {
+    CtApp::P_ctCfg->syntaxHighlighting = newData.syntax;
+    if (nodeData.syntax !=  newData.syntax) {
+        if (nodeData.syntax == CtConst::RICH_TEXT_ID) {
             // leaving rich text
             if (!ct_dialogs::question_dialog(_("Leaving the Node Type Rich Text you will Lose all Formatting for This Node, Do you want to Continue?"), *_ctMainWin)) {
                 return;
@@ -96,22 +96,22 @@ void CtActions::node_edit()
             //self.switch_buffer_text_source(self.curr_buffer, self.curr_tree_iter, self.syntax_highlighting, self.treestore[self.curr_tree_iter][4])
             //self.curr_buffer = self.treestore[self.curr_tree_iter][2]
             //self.state_machine.delete_states(self.get_node_id_from_tree_iter(self.curr_tree_iter))
-        } else if (new_data.syntax == CtConst::RICH_TEXT_ID) {
+        } else if (newData.syntax == CtConst::RICH_TEXT_ID) {
             // going to rich text
             // SWITCH SourceBuffer -> TextBuffer
             //self.switch_buffer_text_source(self.curr_buffer, self.curr_tree_iter, self.syntax_highlighting, self.treestore[self.curr_tree_iter][4])
             //self.curr_buffer = self.treestore[self.curr_tree_iter][2]
-        } else if (cur_data.syntax == CtConst::PLAIN_TEXT_ID) {
+        } else if (nodeData.syntax == CtConst::PLAIN_TEXT_ID) {
             // plain text to code
             //self.sourceview.modify_font(pango.FontDescription(self.code_font))
-        } else if (new_data.syntax == CtConst::PLAIN_TEXT_ID) {
+        } else if (newData.syntax == CtConst::PLAIN_TEXT_ID) {
             // code to plain text
             // self.sourceview.modify_font(pango.FontDescription(self.pt_font))
         }
-        _ctTreestore->updateNodeData(_ctMainWin->curr_tree_iter(), new_data);
+        _ctTreestore->updateNodeData(_ctMainWin->curr_tree_iter(), newData);
         //if self.syntax_highlighting not in [cons.RICH_TEXT_ID, cons.PLAIN_TEXT_ID]:
         //  self.set_sourcebuffer_syntax_highlight(self.curr_buffer, self.syntax_highlighting)
-        _ctMainWin->get_text_view().set_editable(!new_data.isRO);
+        _ctMainWin->get_text_view().set_editable(!newData.isRO);
         //self.update_selected_node_statusbar_info()
         _ctTreestore->updateNodeAuxIcon(_ctMainWin->curr_tree_iter());
         //self.treeview_set_colors()
@@ -295,10 +295,8 @@ CtNodeData dialog_node_prop(std::string title, Gtk::Window& parent, std::string 
     node.customIconId = c_icon_checkbutton.get_active() ? c_icon_id : 0;
     node.isBold = is_bold_checkbutton.get_active();
     if (fg_checkbutton.get_active()) {
-        std::string foregroundRgb24 = CtRgbUtil::getRgb24StrFromStrAny(fg_colorbutton.get_color().to_string());
-        node.fgOverride = true;
-        g_strlcpy(node.foregroundRgb24, foregroundRgb24.c_str(), 8);
-        CtApp::P_ctCfg->currColors['n'] = foregroundRgb24;
+        node.foregroundRgb24 = CtRgbUtil::getRgb24StrFromStrAny(fg_colorbutton.get_color().to_string());
+        CtApp::P_ctCfg->currColors['n'] = node.foregroundRgb24;
     }
     return node;
 }

--- a/future/src/ct/ct_config.cc
+++ b/future/src/ct/ct_config.cc
@@ -137,7 +137,7 @@ void CtConfig::_populateFromKeyfile()
     _populateBoolFromKeyfile("tree_visible", &treeVisible);
     if (_populateStringFromKeyfile("node_path", &nodePath))
     {
-        CtStrUtil::replaceInString(nodePath, " ", ":");
+        str::replace(nodePath, " ", ":");
         _populateIntFromKeyfile("cursor_position", &cursorPosition);
     }
     for (i=0; i<CtConst::MAX_RECENT_DOCS; i++)

--- a/future/src/ct/ct_dialogs.cc
+++ b/future/src/ct/ct_dialogs.cc
@@ -86,3 +86,47 @@ bool ct_dialogs::color_pick_dialog(Gtk::Window& parent, Gdk::RGBA& color)
     color = dialog.get_rgba();
     return true;
 }
+
+// The Question dialog, returns True if the user presses OK
+bool ct_dialogs::question_dialog(const std::string& message, Gtk::Window& parent)
+{
+    Gtk::MessageDialog dialog(parent, _("Question"),
+              true /* use_markup */, Gtk::MESSAGE_QUESTION,
+              Gtk::BUTTONS_OK_CANCEL, true /* modal */);
+    dialog.set_secondary_text(message);
+    dialog.set_position(Gtk::WindowPosition::WIN_POS_CENTER_ON_PARENT);
+    return dialog.run() == Gtk::RESPONSE_OK;
+}
+
+// The Info dialog
+void ct_dialogs::info_dialog(const std::string& message, Gtk::Window& parent)
+{
+    Gtk::MessageDialog dialog(parent, _("Info"),
+              true /* use_markup */, Gtk::MESSAGE_INFO,
+              Gtk::BUTTONS_OK, true /* modal */);
+    dialog.set_secondary_text(message);
+    dialog.set_position(Gtk::WindowPosition::WIN_POS_CENTER_ON_PARENT);
+    dialog.run();
+}
+
+// The Warning dialog
+void ct_dialogs::warning_dialog(const std::string& message, Gtk::Window& parent)
+{
+    Gtk::MessageDialog dialog(parent, _("Warning"),
+              true /* use_markup */, Gtk::MESSAGE_WARNING,
+              Gtk::BUTTONS_OK, true /* modal */);
+    dialog.set_secondary_text(message);
+    dialog.set_position(Gtk::WindowPosition::WIN_POS_CENTER_ON_PARENT);
+    dialog.run();
+}
+
+// The Error dialog
+void ct_dialogs::error_dialog(const std::string& message, Gtk::Window& parent)
+{
+    Gtk::MessageDialog dialog(parent, _("Error"),
+              true /* use_markup */, Gtk::MESSAGE_ERROR,
+              Gtk::BUTTONS_OK, true /* modal */);
+    dialog.set_secondary_text(message);
+    dialog.set_position(Gtk::WindowPosition::WIN_POS_CENTER_ON_PARENT);
+    dialog.run();
+}

--- a/future/src/ct/ct_dialogs.h
+++ b/future/src/ct/ct_dialogs.h
@@ -20,11 +20,23 @@ public:
     void add_row(const std::string& stock_id, const std::string& key, const std::string& desc);
 };
 
-
 Gtk::TreeModel::iterator choose_item_dialog(Gtk::Window& parent,const std::string& title,
                                             Glib::RefPtr<CtChooseDialogListStore> model,
                                             const gchar* one_column_name = nullptr);
 
+// Dialog to select a color, featuring a palette
 bool color_pick_dialog(Gtk::Window& parent, Gdk::RGBA& color);
+
+// The Question dialog, returns True if the user presses OK
+bool question_dialog(const std::string& message, Gtk::Window& parent);
+
+// The Info dialog
+void info_dialog(const std::string& message, Gtk::Window& parent);
+
+// The Warning dialog
+void warning_dialog(const std::string& message, Gtk::Window& parent);
+
+// The Error dialog
+void error_dialog(const std::string& message, Gtk::Window& parent);
 
 } // namespace ct_dialogs

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -34,13 +34,11 @@ CtTreeView::~CtTreeView()
 void CtTreeView::setExpandedCollapsed(CtTreeStore& ctTreestore)
 {
     collapse_all();
-    std::vector<std::string> vecExpandedCollapsed;
-    CtStrUtil::gstringSplit2string(CtApp::P_ctCfg->expandedCollapsedString.c_str(), vecExpandedCollapsed, "_");
+    std::vector<std::string> vecExpandedCollapsed = str::split(CtApp::P_ctCfg->expandedCollapsedString, "_");
     std::map<gint64,bool> mapExpandedCollapsed;
     for (const std::string& element : vecExpandedCollapsed)
     {
-        std::vector<std::string> vecElem;
-        CtStrUtil::gstringSplit2string(element.c_str(), vecElem, ",");
+        std::vector<std::string> vecElem = str::split(element, ",");
         if (2 == vecElem.size())
         {
             mapExpandedCollapsed[std::stoi(vecElem[0])] = CtStrUtil::isStrTrue(vecElem[1]);

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -498,8 +498,7 @@ GtkWidget* CtMenu::add_separator(GtkWidget* pMenu)
 
 std::string CtMenu::get_toolbar_ui_str()
 {
-    std::vector<std::string> vecToolbarElements;
-    CtStrUtil::gstringSplit2string(CtApp::P_ctCfg->toolbarUiList.c_str(), vecToolbarElements, ",");
+    std::vector<std::string> vecToolbarElements = str::split(CtApp::P_ctCfg->toolbarUiList, ",");
     std::string toolbarUIStr;
     for (const std::string& element: vecToolbarElements)
     {

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -144,7 +144,7 @@ void CtMenu::init_actions(CtApp *pApp, CtActions* pActions)
     _actions.push_back(CtAction{tree_cat, "tree_add_node", "tree-node-add", _("Add _Node"), KB_CONTROL+"N", _("Add a Node having the same Parent of the Selected Node"), sigc::mem_fun(*pActions, &CtActions::node_add)});
     _actions.push_back(CtAction{tree_cat, "tree_add_subnode", "tree-subnode-add", _("Add _SubNode"), KB_CONTROL+KB_SHIFT+"N", _("Add a Child Node to the Selected Node"), sigc::signal<void>() /* dad.node_child_add */});
     _actions.push_back(CtAction{tree_cat, "tree_dup_node", "tree-node-dupl", _("_Duplicate Node"), KB_CONTROL+KB_SHIFT+"D", _("Duplicate the Selected Node"), sigc::mem_fun(*pActions, &CtActions::node_dublicate)});
-    _actions.push_back(CtAction{tree_cat, "tree_node_prop", "cherry_edit", _("Change Node _Properties"), "F2", _("Edit the Properties of the Selected Node"), sigc::signal<void>() /* dad.node_edit */});
+    _actions.push_back(CtAction{tree_cat, "tree_node_prop", "cherry_edit", _("Change Node _Properties"), "F2", _("Edit the Properties of the Selected Node"), sigc::mem_fun(*pActions, &CtActions::node_edit)});
     _actions.push_back(CtAction{tree_cat, "tree_node_toggle_ro", "locked", _("Toggle _Read Only"), KB_CONTROL+KB_ALT+"R", _("Toggle the Read Only Property of the Selected Node"), sigc::signal<void>() /* dad.node_toggle_read_only */});
     _actions.push_back(CtAction{tree_cat, "tree_node_date", "calendar", _("Insert Today's Node"), "F8", _("Insert a Node with Hierarchy Year/Month/Day"), sigc::signal<void>() /* dad.node_date */});
     _actions.push_back(CtAction{tree_cat, "tree_parse_info", "gtk-info", _("Tree _Info"), None, _("Tree Summary Information"), sigc::signal<void>() /* dad.tree_info */});

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -142,7 +142,7 @@ void CtMenu::init_actions(CtApp *pApp, CtActions* pActions)
     _actions.push_back(CtAction{fmt_cat, "fmt_justify_fill", "gtk-justify-fill", _("Justify _Fill"), None, _("Justify Fill the Current Paragraph"), sigc::signal<void>() /* dad.apply_tag_justify_fill */});
     const char* tree_cat = _("Tree");
     _actions.push_back(CtAction{tree_cat, "tree_add_node", "tree-node-add", _("Add _Node"), KB_CONTROL+"N", _("Add a Node having the same Parent of the Selected Node"), sigc::mem_fun(*pActions, &CtActions::node_add)});
-    _actions.push_back(CtAction{tree_cat, "tree_add_subnode", "tree-subnode-add", _("Add _SubNode"), KB_CONTROL+KB_SHIFT+"N", _("Add a Child Node to the Selected Node"), sigc::signal<void>() /* dad.node_child_add */});
+    _actions.push_back(CtAction{tree_cat, "tree_add_subnode", "tree-subnode-add", _("Add _SubNode"), KB_CONTROL+KB_SHIFT+"N", _("Add a Child Node to the Selected Node"), sigc::mem_fun(*pActions, &CtActions::node_child_add)});
     _actions.push_back(CtAction{tree_cat, "tree_dup_node", "tree-node-dupl", _("_Duplicate Node"), KB_CONTROL+KB_SHIFT+"D", _("Duplicate the Selected Node"), sigc::mem_fun(*pActions, &CtActions::node_dublicate)});
     _actions.push_back(CtAction{tree_cat, "tree_node_prop", "cherry_edit", _("Change Node _Properties"), "F2", _("Edit the Properties of the Selected Node"), sigc::mem_fun(*pActions, &CtActions::node_edit)});
     _actions.push_back(CtAction{tree_cat, "tree_node_toggle_ro", "locked", _("Toggle _Read Only"), KB_CONTROL+KB_ALT+"R", _("Toggle the Read Only Property of the Selected Node"), sigc::signal<void>() /* dad.node_toggle_read_only */});

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -293,15 +293,13 @@ bool CtStrUtil::isPgcharInPgcharSet(const gchar* pGcharNeedle, const std::set<co
 
 std::string CtFontUtil::getFontFamily(const std::string& fontStr)
 {
-    std::vector<std::string> splFont;
-    CtStrUtil::gstringSplit2string(fontStr.c_str(), splFont);
+    std::vector<std::string> splFont = str::split(fontStr, " ");
     return splFont.size() > 0 ? splFont.at(0) : "";
 }
 
 std::string CtFontUtil::getFontSizeStr(const std::string& fontStr)
 {
-    std::vector<std::string> splFont;
-    CtStrUtil::gstringSplit2string(fontStr.c_str(), splFont);
+    std::vector<std::string> splFont = str::split(fontStr, " ");
     return splFont.size() > 1 ? splFont.at(1) : "";
 }
 
@@ -417,14 +415,3 @@ bool str::endswith(const std::string& str, const std::string& ending) {
     return false;
 }
 
-std::string str::trim(std::string str)
-{
-    return CtStrUtil::trimString(str);
-}
-
-std::vector<std::string> str::split(const std::string& str, const std::string& delimer)
-{
-    std::vector<std::string> vec;
-    CtStrUtil::gstringSplit2string(str.c_str(), vec, delimer.c_str());
-    return vec;
-}

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -43,50 +43,11 @@ namespace CtStrUtil {
 
 bool isStrTrue(const Glib::ustring& inStr);
 
-template<class String> String replaceInString(String& subjectStr, const gchar* searchStr, const gchar* replaceStr)
-{
-    size_t pos = 0;
-    while ((pos = subjectStr.find(searchStr, pos)) != std::string::npos)
-    {
-        subjectStr.replace(pos, strlen(searchStr), replaceStr);
-        pos += strlen(replaceStr);
-    }
-    return subjectStr;
-}
-
-template<class String> String trimString(String& s)
-{
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) { return !std::isspace(ch); }));
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
-    return s;
-}
-
 gint64 gint64FromGstring(const gchar* inGstring, bool hexPrefix=false);
 
 guint32 getUint32FromHexChars(const char* hexChars, guint8 numChars);
 
-template<class VecOfStrings> void gstringSplit2string(const gchar *inStr, VecOfStrings& vecOfStrings, const gchar *delimiter=" ", gint max_tokens=-1)
-{
-    gchar **arrayOfStrings = g_strsplit(inStr, delimiter, max_tokens);
-    for(gchar **ptr = arrayOfStrings; *ptr; ptr++)
-    {
-        vecOfStrings.push_back(*ptr);
-    }
-    g_strfreev(arrayOfStrings);
-}
-
 std::vector<gint64> gstringSplit2int64(const gchar* inStr, const gchar* delimiter, gint max_tokens=-1);
-
-template<class String> void stringJoin4string(const std::vector<String>& inStrVec, String& outString, const gchar* delimiter=" ")
-{
-    bool firstIteration{true};
-    for (const String& element : inStrVec)
-    {
-        if (!firstIteration) outString += delimiter;
-        else firstIteration = false;
-        outString += element;
-    }
-}
 
 template<class String> void stringJoin4int64(const std::vector<gint64>& inInt64Vec, String& outString, const gchar* delimiter=" ")
 {
@@ -142,19 +103,48 @@ namespace str {
 
 bool endswith(const std::string& str, const std::string& ending);
 
-std::string trim(std::string str);
+template<class String>
+String replace(String& subjectStr, const gchar* searchStr, const gchar* replaceStr)
+{
+    size_t pos = 0;
+    while ((pos = subjectStr.find(searchStr, pos)) != std::string::npos)
+    {
+        subjectStr.replace(pos, strlen(searchStr), replaceStr);
+        pos += strlen(replaceStr);
+    }
+    return subjectStr;
+}
 
-std::vector<std::string> split(const std::string& str, const std::string& delimer);
+template<class String>
+String trim(String s)
+{
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) { return !std::isspace(ch); }));
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
+    return s;
+}
 
-template<class CONTAINER>
-std::string join(const CONTAINER cnt, const std::string& delimer)
+template<class STRING = std::string>
+std::vector<STRING> split(const std::string& str, const std::string& delimiter)
+{
+    std::vector<STRING> vecOfStrings;
+    gchar **arrayOfStrings = g_strsplit(str.c_str(), delimiter.c_str(), -1);
+    for(gchar **ptr = arrayOfStrings; *ptr; ptr++)
+    {
+        vecOfStrings.push_back(*ptr);
+    }
+    g_strfreev(arrayOfStrings);
+    return vecOfStrings;
+}
+
+template<class STRING>
+std::string join(const std::vector<STRING>& cnt, const std::string& delimer)
 {
     bool firstTime = true;
     std::stringstream ss;
     for (auto& v: cnt)
     {
       if (!firstTime) ss << delimer;
-      firstTime = false;
+      else firstTime = false;
       ss << v;
     }
     return ss.str();

--- a/future/src/ct/ct_pref_dlg.cc
+++ b/future/src/ct/ct_pref_dlg.cc
@@ -173,7 +173,7 @@ Gtk::Widget* CtPrefDlg::build_tab_text_n_code()
 
     textview_special_chars->get_buffer()->signal_changed().connect([config, textview_special_chars](){
         Glib::ustring new_special_chars = textview_special_chars->get_buffer()->get_text();
-        CtStrUtil::replaceInString(new_special_chars, CtConst::CHAR_NEWLINE, "");
+        str::replace(new_special_chars, CtConst::CHAR_NEWLINE, "");
         if (config->specialChars != new_special_chars)
         {
             config->specialChars = new_special_chars;
@@ -1645,9 +1645,9 @@ bool CtPrefDlg::edit_shortcut(Gtk::TreeView* treeview)
 bool CtPrefDlg::edit_shortcut_dialog(std::string& shortcut)
 {
     std::string kb_shortcut_key = shortcut;
-    CtStrUtil::replaceInString(kb_shortcut_key, _pCtMenu->KB_CONTROL.c_str(), "");
-    CtStrUtil::replaceInString(kb_shortcut_key, _pCtMenu->KB_SHIFT.c_str(), "");
-    CtStrUtil::replaceInString(kb_shortcut_key, _pCtMenu->KB_ALT.c_str(), "");
+    str::replace(kb_shortcut_key, _pCtMenu->KB_CONTROL.c_str(), "");
+    str::replace(kb_shortcut_key, _pCtMenu->KB_SHIFT.c_str(), "");
+    str::replace(kb_shortcut_key, _pCtMenu->KB_ALT.c_str(), "");
 
     Gtk::Dialog dialog(_("Edit Keyboard Shortcut"), *this, Gtk::DialogFlags::DIALOG_MODAL | Gtk::DialogFlags::DIALOG_DESTROY_WITH_PARENT);
     dialog.add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_REJECT);

--- a/future/src/ct/ct_pref_dlg.cc
+++ b/future/src/ct/ct_pref_dlg.cc
@@ -181,7 +181,7 @@ Gtk::Widget* CtPrefDlg::build_tab_text_n_code()
         }
     });
     button_reset->signal_clicked().connect([this, textview_special_chars](){
-        if (user_confirm(reset_warning))
+        if (ct_dialogs::question_dialog(reset_warning, *this))
             textview_special_chars->get_buffer()->set_text(CtConst::SPECIAL_CHARS_DEFAULT);
     });
     spinbutton_tab_width->signal_value_changed().connect([config, spinbutton_tab_width](){
@@ -611,13 +611,13 @@ Gtk::Widget* CtPrefDlg::build_tab_plain_text_n_code()
         add_new_command_in_model(liststore);
     });
     button_reset_cmds->signal_clicked().connect([this, config, liststore](){
-        if (user_confirm(reset_warning)) {
+        if (ct_dialogs::question_dialog(reset_warning, *this)) {
             config->customCodexecType.clear();
             fill_commands_model(liststore);
         }
     });
     button_reset_term->signal_clicked().connect([this, config, entry_term_run](){
-        if (user_confirm(reset_warning)) {
+        if (ct_dialogs::question_dialog(reset_warning, *this)) {
             config->customCodexecTerm.clear();
             entry_term_run->set_text(get_code_exec_term_run());
         }
@@ -1184,7 +1184,7 @@ Gtk::Widget* CtPrefDlg::build_tab_toolbar()
         need_restart(RESTART_REASON::TOOLBAR);
     });
     button_reset->signal_clicked().connect([this, config, liststore](){
-        if (user_confirm(reset_warning)) {
+        if (ct_dialogs::question_dialog(reset_warning, *this)) {
             config->toolbarUiList = CtConst::TOOLBAR_VEC_DEFAULT;
             fill_toolbar_model(liststore);
             need_restart(RESTART_REASON::TOOLBAR);
@@ -1246,7 +1246,7 @@ Gtk::Widget* CtPrefDlg::build_tab_kb_shortcuts()
             need_restart(RESTART_REASON::SHORTCUT);
     });
     button_reset->signal_clicked().connect([this, config, treestore](){
-        if (user_confirm(reset_warning)) {
+        if (ct_dialogs::question_dialog(reset_warning, *this)) {
             config->customKbShortcuts.clear();
             fill_shortcut_model(treestore);
             need_restart(RESTART_REASON::SHORTCUT);
@@ -1471,30 +1471,11 @@ Glib::RefPtr<Gdk::Pixbuf> CtPrefDlg::get_icon(const std::string& name)
     return Glib::RefPtr<Gdk::Pixbuf>();
 }
 
-
-bool CtPrefDlg::user_confirm(const std::string& warning)
-{
-    Gtk::MessageDialog dialog(*this, _("Warning"),
-              true /* use_markup */, Gtk::MESSAGE_QUESTION,
-              Gtk::BUTTONS_OK_CANCEL);
-    dialog.set_secondary_text(warning);
-    return dialog.run() == Gtk::RESPONSE_OK;
-}
-
-void CtPrefDlg::user_inform(const std::string& info)
-{
-    Gtk::MessageDialog dialog(*this, _("Info"),
-              true /* use_markup */, Gtk::MESSAGE_INFO,
-              Gtk::BUTTONS_OK);
-    dialog.set_secondary_text(info);
-    dialog.run();
-}
-
 void CtPrefDlg::need_restart(RESTART_REASON reason, const gchar* msg /*= nullptr*/)
 {
     if (!(_restartReasons & (int)reason)) {
         _restartReasons |= (int)reason;
-        user_inform(msg ? msg : _("This Change will have Effect Only After Restarting CherryTree"));
+        ct_dialogs::info_dialog(msg ? msg : _("This Change will have Effect Only After Restarting CherryTree"), *this);
     }
 }
 
@@ -1650,7 +1631,7 @@ bool CtPrefDlg::edit_shortcut(Gtk::TreeView* treeview)
             for(const CtAction& action: _pCtMenu->get_actions())
                 if (action.get_shortcut() == shortcut && action.id != id) {
                     // todo: this is a shorter version from python code
-                    if (!user_confirm(std::string("<b>") + _("The Keyboard Shortcut '%s' is already in use") + "</b>"))
+                    if (!ct_dialogs::question_dialog(std::string("<b>") + _("The Keyboard Shortcut '%s' is already in use") + "</b>", *this))
                         return false;
                     CtApp::P_ctCfg->customKbShortcuts[action.id] = "";
                 }

--- a/future/src/ct/ct_pref_dlg.h
+++ b/future/src/ct/ct_pref_dlg.h
@@ -36,8 +36,6 @@ private:
 
 private:
     Glib::RefPtr<Gdk::Pixbuf> get_icon(const std::string& name);
-    bool                      user_confirm(const std::string& warning);
-    void                      user_inform(const std::string& info);
     void                      need_restart(RESTART_REASON reason, const gchar* msg = nullptr);
 
 private:

--- a/future/src/ct/ct_sqlite3_rw.cc
+++ b/future/src/ct/ct_sqlite3_rw.cc
@@ -314,10 +314,11 @@ CtNodeData CtSQLiteRead::_sqlite3GetNodeProperties(gint64 nodeId)
         nodeData.customIconId = readonly_n_custom_icon_id >> 1;
         gint64 richtxt_bold_foreground = sqlite3_column_int64(p_stmt, 4);
         nodeData.isBold = static_cast<bool>((richtxt_bold_foreground >> 1) & 0x01);
-        nodeData.fgOverride = static_cast<bool>((richtxt_bold_foreground >> 2) & 0x01);
-        if (nodeData.fgOverride)
+        if (static_cast<bool>((richtxt_bold_foreground >> 2) & 0x01))
         {
-            CtRgbUtil::setRgb24StrFromRgb24Int((richtxt_bold_foreground >> 3) & 0xffffff, nodeData.foregroundRgb24);
+            char foregroundRgb24[8];
+            CtRgbUtil::setRgb24StrFromRgb24Int((richtxt_bold_foreground >> 3) & 0xffffff, foregroundRgb24);
+            nodeData.foregroundRgb24 = foregroundRgb24;
         }
         nodeData.tsCreation = sqlite3_column_int64(p_stmt, 5);
         nodeData.tsLastSave = sqlite3_column_int64(p_stmt, 6);

--- a/future/src/ct/ct_treestore.cc
+++ b/future/src/ct/ct_treestore.cc
@@ -248,11 +248,7 @@ void CtTreeStore::getNodeData(Gtk::TreeIter treeIter, CtNodeData& nodeData)
     //row[_columns.rColPixbufAux] = ;
     nodeData.customIconId = row[_columns.colCustomIconId];
     nodeData.isBold = _getBold(row[_columns.colWeight]);
-
-    nodeData.fgOverride = false;
-    nodeData.foregroundRgb24[0] = 0;
     //row[_columns.colForeground] = ;
-
     nodeData.tsCreation = row[_columns.colTsCreation];
     nodeData.tsLastSave = row[_columns.colTsLastSave];
     nodeData.anchoredWidgets = row[_columns.colAnchoredWidgets];

--- a/future/src/ct/ct_treestore.cc
+++ b/future/src/ct/ct_treestore.cc
@@ -248,7 +248,11 @@ void CtTreeStore::getNodeData(Gtk::TreeIter treeIter, CtNodeData& nodeData)
     //row[_columns.rColPixbufAux] = ;
     nodeData.customIconId = row[_columns.colCustomIconId];
     nodeData.isBold = _getBold(row[_columns.colWeight]);
+
+    nodeData.fgOverride = false;
+    nodeData.foregroundRgb24[0] = 0;
     //row[_columns.colForeground] = ;
+
     nodeData.tsCreation = row[_columns.colTsCreation];
     nodeData.tsLastSave = row[_columns.colTsLastSave];
     nodeData.anchoredWidgets = row[_columns.colAnchoredWidgets];

--- a/future/src/ct/ct_treestore.h
+++ b/future/src/ct/ct_treestore.h
@@ -49,8 +49,7 @@ struct CtNodeData
     bool           isRO{false};
     guint32        customIconId{0};
     bool           isBold{false};
-    bool           fgOverride{false};
-    char           foregroundRgb24[8];
+    Glib::ustring  foregroundRgb24;
     gint64         tsCreation{0};
     gint64         tsLastSave{0};
     Glib::RefPtr<Gsv::Buffer>  rTextBuffer{nullptr};

--- a/future/src/ct/ct_xml_rw.cc
+++ b/future/src/ct/ct_xml_rw.cc
@@ -87,7 +87,7 @@ Gtk::TreeIter CtXmlRead::_xmlNodeProcess(xmlpp::Element* pNodeElement, const Gtk
     nodeData.nodeId = CtStrUtil::gint64FromGstring(pNodeElement->get_attribute_value("unique_id").c_str());
     nodeData.name = pNodeElement->get_attribute_value("name");
     nodeData.syntax = pNodeElement->get_attribute_value("prog_lang");
-    nodeData.tags = pNodeElement->get_attribute_value("name");
+    nodeData.tags = pNodeElement->get_attribute_value("tags");
     nodeData.isRO = Glib::str_has_prefix(pNodeElement->get_attribute_value("readonly"), "T");
     nodeData.customIconId = CtStrUtil::gint64FromGstring(pNodeElement->get_attribute_value("custom_icon_id").c_str());
     nodeData.isBold = Glib::str_has_prefix(pNodeElement->get_attribute_value("is_bold"), "T");

--- a/future/src/ct/ct_xml_rw.cc
+++ b/future/src/ct/ct_xml_rw.cc
@@ -91,12 +91,7 @@ Gtk::TreeIter CtXmlRead::_xmlNodeProcess(xmlpp::Element* pNodeElement, const Gtk
     nodeData.isRO = Glib::str_has_prefix(pNodeElement->get_attribute_value("readonly"), "T");
     nodeData.customIconId = CtStrUtil::gint64FromGstring(pNodeElement->get_attribute_value("custom_icon_id").c_str());
     nodeData.isBold = Glib::str_has_prefix(pNodeElement->get_attribute_value("is_bold"), "T");
-    Glib::ustring foregroundRgb24 = pNodeElement->get_attribute_value("foreground");
-    nodeData.fgOverride = !foregroundRgb24.empty();
-    if (nodeData.fgOverride)
-    {
-        g_strlcpy(nodeData.foregroundRgb24, foregroundRgb24.c_str(), 8);
-    }
+    nodeData.foregroundRgb24 = pNodeElement->get_attribute_value("foreground");
     nodeData.tsCreation = CtStrUtil::gint64FromGstring(pNodeElement->get_attribute_value("ts_creation").c_str());
     nodeData.tsLastSave = CtStrUtil::gint64FromGstring(pNodeElement->get_attribute_value("ts_lastSave").c_str());
     nodeData.rTextBuffer = getTextBuffer(nodeData.syntax, nodeData.anchoredWidgets, pNodeElement);

--- a/future/tests/tests_misc_utils.cpp
+++ b/future/tests/tests_misc_utils.cpp
@@ -40,27 +40,27 @@ TEST(MiscUtilsGroup, isStrTrue)
     CHECK(!CtStrUtil::isStrTrue("0"));
 }
 
-TEST(MiscUtilsGroup, replaceInString)
+TEST(MiscUtilsGroup, str__replace)
 {
     {
         Glib::ustring testReplaceStr = "one two threetwo";
-        STRCMP_EQUAL("one four threefour", CtStrUtil::replaceInString(testReplaceStr, "two", "four").c_str());
+        STRCMP_EQUAL("one four threefour", str::replace(testReplaceStr, "two", "four").c_str());
     }
     {
         std::string testReplaceStr = "one two threetwo";
-        STRCMP_EQUAL("one four threefour", CtStrUtil::replaceInString(testReplaceStr, "two", "four").c_str());
+        STRCMP_EQUAL("one four threefour", str::replace(testReplaceStr, "two", "four").c_str());
     }
 }
 
-TEST(MiscUtilsGroup, trimString)
+TEST(MiscUtilsGroup, str__trim)
 {
     {
         Glib::ustring testTrimStr = "\t one two three ";
-        STRCMP_EQUAL("one two three", CtStrUtil::trimString(testTrimStr).c_str());
+        STRCMP_EQUAL("one two three", str::trim(testTrimStr).c_str());
     }
     {
         std::string testTrimStr = "\t one two three ";
-        STRCMP_EQUAL("one two three", CtStrUtil::trimString(testTrimStr).c_str());
+        STRCMP_EQUAL("one two three", str::trim(testTrimStr).c_str());
     }
 }
 
@@ -80,16 +80,14 @@ TEST(MiscUtilsGroup, getUint32FromHexChars)
     CHECK_EQUAL(0xa, CtStrUtil::getUint32FromHexChars("aff", 1));
 }
 
-TEST(MiscUtilsGroup, gstringSplit2string)
+TEST(MiscUtilsGroup, str__split)
 {
     {
-        std::vector<std::string> splittedVec;
-        CtStrUtil::gstringSplit2string(":a:bc::d:", splittedVec, ":");
+        std::vector<std::string> splittedVec = str::split(":a:bc::d:", ":");
         CHECK(std::vector<std::string>({"", "a", "bc", "", "d", ""}) == splittedVec);
     }
     {
-        std::vector<Glib::ustring> splittedVec;
-        CtStrUtil::gstringSplit2string(" a bc  d ", splittedVec);
+        std::vector<Glib::ustring> splittedVec = str::split<Glib::ustring>(" a bc  d ", " ");
         CHECK(std::vector<Glib::ustring>({"", "a", "bc", "", "d", ""}) == splittedVec);
     }
 }
@@ -98,22 +96,6 @@ TEST(MiscUtilsGroup, gstringSplit2int64)
 {
     std::vector<gint64> splittedVec = CtStrUtil::gstringSplit2int64("-1, 1,0, 1000", ",");
     CHECK(std::vector<gint64>({-1, 1, 0, 1000}) == splittedVec);
-}
-
-TEST(MiscUtilsGroup, stringJoin4string)
-{
-    {
-        std::vector<Glib::ustring> vecToJoin({"", "a", "bc", "", "d", ""});
-        Glib::ustring rejoined;
-        CtStrUtil::stringJoin4string(vecToJoin, rejoined, ":");
-        STRCMP_EQUAL(":a:bc::d:", rejoined.c_str());
-    }
-    {
-        std::vector<std::string> vecToJoin({"", "a", "bc", "", "d", ""});
-        std::string rejoined;
-        CtStrUtil::stringJoin4string(vecToJoin, rejoined);
-        STRCMP_EQUAL(" a bc  d ", rejoined.c_str());
-    }
 }
 
 TEST(MiscUtilsGroup, stringJoin4int64)
@@ -194,6 +176,17 @@ TEST(MiscUtilsGroup, str__join)
     CHECK(str::join(empty_v, ",") == "");
     CHECK(str::join(v_1, ",") == "1");
     CHECK(str::join(v_2, ",") == "1,2");
+
+    {
+        std::vector<Glib::ustring> vecToJoin({"", "a", "bc", "", "d", ""});
+        Glib::ustring rejoined = str::join(vecToJoin, ":");
+        STRCMP_EQUAL(":a:bc::d:", rejoined.c_str());
+    }
+    {
+        std::vector<std::string> vecToJoin({"", "a", "bc", "", "d", ""});
+        std::string rejoined = str::join(vecToJoin, " ");
+        STRCMP_EQUAL(" a bc  d ", rejoined.c_str());
+    }
 }
 
 TEST(MiscUtilsGroup, vec_remove)


### PR DESCRIPTION
(ref to keep progress: #444)
- Added node_edit and node_child_add.
- Made CtNodeData::foregroundRgb24 as Glib::ustring because char[8] doesn't copy by default and writing constructor and operator= for it is not worth.
- Removed duplicates for str:: in utils [(because of the comment)](https://github.com/giuspen/cherrytree/pull/455#issuecomment-457081452)
