### PR TITLE
(Port to C++) fix text buffer

### DIFF
--- a/future/src/ct/ct_actions_tree.cc
+++ b/future/src/ct/ct_actions_tree.cc
@@ -26,8 +26,18 @@ void CtActions::_node_add(bool duplicate, bool add_child)
      {
         if (!is_there_selected_node_or_error()) return;
         _ctTreestore->getNodeData(_ctMainWin->curr_tree_iter(), nodeData);
-        nodeData.anchoredWidgets.clear();
-        nodeData.rTextBuffer.clear();
+
+        if (nodeData.syntax != CtConst::RICH_TEXT_ID) {
+            nodeData.rTextBuffer = CtMiscUtil::getNewTextBuffer(nodeData.syntax, nodeData.rTextBuffer->get_text());
+            nodeData.anchoredWidgets.clear();
+        } else {
+            //state = self.state_machine.requested_state_previous(self.treestore[tree_iter_from][3])
+            //self.load_buffer_from_state(state, given_tree_iter=new_node_iter)
+
+            // todo: temporary solution
+            nodeData.anchoredWidgets.clear();
+            nodeData.rTextBuffer = CtMiscUtil::getNewTextBuffer(nodeData.syntax, nodeData.rTextBuffer->get_text());
+        }
     }
     else
     {
@@ -35,6 +45,7 @@ void CtActions::_node_add(bool duplicate, bool add_child)
         std::string title = add_child ? _("New Child Node Properties") : _("New Node Properties");
         nodeData = dialog_node_prop(title, *_ctMainWin, "", false, "", 0, CtConst::RICH_TEXT_ID, false, "", _ctTreestore->get_used_tags());
         if (nodeData.name.empty()) return;
+        nodeData.rTextBuffer = CtMiscUtil::getNewTextBuffer(nodeData.syntax);
     }
 
     nodeData.tsCreation = std::time(nullptr);
@@ -56,21 +67,7 @@ void CtActions::_node_add(bool duplicate, bool add_child)
     _ctTreestore->ctdb_handler()->pending_new_db_node(nodeData.nodeId);
     _ctTreestore->nodes_sequences_fix(_ctMainWin->curr_tree_iter()->parent(), false);
     _ctTreestore->updateNodeAuxIcon(nodeIter);
-    /* todo
-    self.nodes_names_dict[new_node_id] = ret_name
-    if self.node_add_is_duplication:
-        if self.syntax_highlighting != cons.RICH_TEXT_ID:
-            text_buffer_from = self.treestore[tree_iter_from][2]
-            text_buffer_to = self.treestore[new_node_iter][2]
-            content = text_buffer_from.get_text(*text_buffer_from.get_bounds())
-            text_buffer_to.begin_not_undoable_action()
-            text_buffer_to.set_text(content)
-            text_buffer_to.end_not_undoable_action()
-        else:
-            state = self.state_machine.requested_state_previous(self.treestore[tree_iter_from][3])
-            self.load_buffer_from_state(state, given_tree_iter=new_node_iter)
-    */
-    _ctMainWin->get_tree_view().set_cursor(_ctTreestore->get_path(nodeIter));
+    _ctMainWin->get_tree_view().set_cursor_safe(nodeIter);
     _ctMainWin->get_text_view().grab_focus();
 }
 

--- a/future/src/ct/ct_app.cc
+++ b/future/src/ct/ct_app.cc
@@ -188,7 +188,7 @@ void CtApp::quit_application()
 
 void CtApp::dialog_preferences()
 {
-    CtPrefDlg prefDlg(*get_windows()[0], _pCtMenu);
+    CtPrefDlg prefDlg(get_main_win(), _pCtMenu);
     prefDlg.show();
     prefDlg.run();
     prefDlg.hide();

--- a/future/src/ct/ct_codebox.cc
+++ b/future/src/ct/ct_codebox.cc
@@ -36,6 +36,8 @@ CtTextCell::~CtTextCell()
 }
 
 
+const Gsv::DrawSpacesFlags CtCodebox::DRAW_SPACES_FLAGS = Gsv::DRAW_SPACES_ALL & ~Gsv::DRAW_SPACES_NEWLINE;
+
 CtCodebox::CtCodebox(const Glib::ustring& textContent,
                      const Glib::ustring& syntaxHighlighting,
                      const int& frameWidth,

--- a/future/src/ct/ct_codebox.h
+++ b/future/src/ct/ct_codebox.h
@@ -42,6 +42,9 @@ protected:
 class CtCodebox : public CtAnchoredWidget, public CtTextCell
 {
 public:
+    static const Gsv::DrawSpacesFlags DRAW_SPACES_FLAGS;
+
+public:
     CtCodebox(const Glib::ustring& textContent,
               const Glib::ustring& syntaxHighlighting,
               const int& frameWidth,

--- a/future/src/ct/ct_image.cc
+++ b/future/src/ct/ct_image.cc
@@ -51,11 +51,18 @@ CtImage::CtImage(const char* stockImage,
     show_all();
 }
 
-Gtk::Image* CtImage::new_image_from_stock(const std::string& stockImage, const int& size)
+Glib::RefPtr<Gdk::Pixbuf> CtImage::get_icon(const std::string& name, int size)
 {
-    Glib::RefPtr<Gdk::Pixbuf> pix_buf = CtApp::R_icontheme->load_icon(stockImage, size);
+    if (CtApp::R_icontheme->has_icon(name))
+        return CtApp::R_icontheme->load_icon(name, size);
+    return Glib::RefPtr<Gdk::Pixbuf>();
+}
+
+Gtk::Image* CtImage::new_image_from_stock(const std::string& stockImage, int size)
+{
     Gtk::Image* image = Gtk::manage(new Gtk::Image());
-    image->set(pix_buf);
+    image->set_from_icon_name(stockImage, Gtk::BuiltinIconSize::ICON_SIZE_BUTTON);
+    //image->set(get_icon(stockImage, size));
     return image;
 }
 

--- a/future/src/ct/ct_image.h
+++ b/future/src/ct/ct_image.h
@@ -39,7 +39,8 @@ public:
     virtual ~CtImage() {}
 
 public:
-    static Gtk::Image* new_image_from_stock(const std::string& stockImage, const int& size);
+    static Glib::RefPtr<Gdk::Pixbuf> get_icon(const std::string& name, int size);
+    static Gtk::Image*               new_image_from_stock(const std::string& stockImage, int size);
 
 protected:
     Gtk::Image _image;

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -47,6 +47,12 @@ void CtTreeView::setExpandedCollapsed(CtTreeStore& ctTreestore)
     ctTreestore.setExpandedCollapsed(this, ctTreestore.getRootChildren(), mapExpandedCollapsed);
 }
 
+void CtTreeView::set_cursor_safe(const Gtk::TreeIter& iter)
+{
+    auto parent = iter->parent();
+    if (parent) expand_row(get_model()->get_path(parent), false);
+    set_cursor(get_model()->get_path(iter));
+}
 
 const double CtTextView::TEXT_SCROLL_MARGIN{0.3};
 
@@ -98,6 +104,12 @@ void CtTextView::setupForSyntax(const std::string& syntax)
         }
     }
     _setFontForSyntax(syntax);
+}
+
+void CtTextView::set_pixels_inside_wrap(int space_around_lines, int relative_wrapped_space)
+{
+    int pixels_around_wrap = (space_around_lines * (relative_wrapped_space / 100.0));
+    Gtk::TextView::set_pixels_inside_wrap(pixels_around_wrap);
 }
 
 void CtTextView::_setFontForSyntax(const std::string& syntaxHighlighting)

--- a/future/src/ct/ct_main_win.h
+++ b/future/src/ct/ct_main_win.h
@@ -33,6 +33,8 @@ public:
     CtTreeView();
     virtual ~CtTreeView();
     void setExpandedCollapsed(CtTreeStore& ctTreestore);
+    void set_cursor_safe(const Gtk::TreeIter& iter);
+
 protected:
 };
 
@@ -41,7 +43,10 @@ class CtTextView : public Gsv::View
 public:
     CtTextView();
     virtual ~CtTextView();
+
     void setupForSyntax(const std::string& syntaxHighlighting);
+    void set_pixels_inside_wrap(int space_around_lines, int relative_wrapped_space);
+
     static const double TEXT_SCROLL_MARGIN;
 protected:
     void _setFontForSyntax(const std::string& syntaxHighlighting);

--- a/future/src/ct/ct_pref_dlg.h
+++ b/future/src/ct/ct_pref_dlg.h
@@ -10,7 +10,7 @@
 class CtPrefDlg : public Gtk::Dialog
 {
 public:
-    CtPrefDlg(Gtk::Window& parent, CtMenu* pCtMenu);
+    CtPrefDlg(CtMainWin* parent, CtMenu* pCtMenu);
 
 private:
     Gtk::Widget* build_tab_text_n_code();
@@ -35,10 +35,8 @@ private:
     const std::string reset_warning = std::string("<b>")+_("Are you sure to Reset to Default?")+"</b>";
 
 private:
-    Glib::RefPtr<Gdk::Pixbuf> get_icon(const std::string& name);
-    void                      need_restart(RESTART_REASON reason, const gchar* msg = nullptr);
+    void need_restart(RESTART_REASON reason, const gchar* msg = nullptr);
 
-private:
     std::string get_code_exec_term_run();
 
     void fill_commands_model(Glib::RefPtr<Gtk::ListStore> model);
@@ -67,6 +65,7 @@ private:
     UniversalModelColumns _commandModelColumns;
     UniversalModelColumns _toolbarModelColumns;
     UniversalModelColumns _shortcutModelColumns;
+    CtMainWin*            _pCtMainWin;
     CtMenu*               _pCtMenu;
     int                   _restartReasons;
 };

--- a/future/src/ct/ct_treestore.cc
+++ b/future/src/ct/ct_treestore.cc
@@ -274,6 +274,7 @@ void CtTreeStore::updateNodeData(Gtk::TreeIter treeIter, const CtNodeData& nodeD
     row[_columns.colAnchoredWidgets] = nodeData.anchoredWidgets;
 
     add_used_tags(nodeData.tags);
+    _nodes_names_dict[nodeData.nodeId] = nodeData.name;
 }
 
 void CtTreeStore::updateNodeAuxIcon(Gtk::TreeIter treeIter)

--- a/future/src/ct/ct_treestore.h
+++ b/future/src/ct/ct_treestore.h
@@ -137,9 +137,10 @@ protected:
 
     Glib::RefPtr<Gsv::Buffer> _getNodeTextBuffer(const Gtk::TreeIter& treeIter);
 
-    CtTreeModelColumns           _columns;
-    Glib::RefPtr<Gtk::TreeStore> _rTreeStore;
-    std::set<gint64>             _bookmarks;
-    std::set<std::string>        _usedTags;
-    CtSQLiteRead*                _pCtSQLiteRead{nullptr};
+    CtTreeModelColumns             _columns;
+    Glib::RefPtr<Gtk::TreeStore>   _rTreeStore;
+    std::set<gint64>               _bookmarks;
+    std::set<std::string>          _usedTags;
+    std::map<guint64, std::string> _nodes_names_dict; // for link tooltips
+    CtSQLiteRead*                  _pCtSQLiteRead{nullptr};
 };


### PR DESCRIPTION
(ref to keep progress: #444)
- New nodes get a valid text buffer, this fixes crashes. Duplicated nodes have partly valid content, this is a temporary solution. So basically, adding node/subnode, duplicating become useful.
- Fixed node_edit - lost text buffer
- Fixed commented code in pref dialogs related to updating the textview params in real time