### PR TITLE
New config option: "Enable Symbol Auto Replacement"

### DIFF
--- a/future/src/ct/ct_config.cc
+++ b/future/src/ct/ct_config.cc
@@ -214,6 +214,7 @@ void CtConfig::_populateFromKeyfile()
     _populateIntFromKeyfile("embfile_max_size", &embfileMaxSize);
     _populateBoolFromKeyfile("line_wrapping", &lineWrapping);
     _populateBoolFromKeyfile("auto_smart_quotes", &autoSmartQuotes);
+    _populateBoolFromKeyfile("enable_symbol_autoreplace", &enableSymbolAutoreplace);
     _populateIntFromKeyfile("wrapping_indent", &wrappingIndent);
     _populateBoolFromKeyfile("auto_indent", &autoIndent);
     _populateBoolFromKeyfile("rt_show_white_spaces", &rtShowWhiteSpaces);

--- a/future/src/ct/ct_config.h
+++ b/future/src/ct/ct_config.h
@@ -94,6 +94,7 @@ public:
     int                                         embfileMaxSize{10};
     bool                                        lineWrapping{true};
     bool                                        autoSmartQuotes{true};
+    bool                                        enableSymbolAutoreplace{true};
     int                                         wrappingIndent{-14};
     bool                                        autoIndent{true};
     bool                                        rtShowWhiteSpaces{false};

--- a/future/src/ct/ct_pref_dlg.cc
+++ b/future/src/ct/ct_pref_dlg.cc
@@ -241,9 +241,12 @@ Gtk::Widget* CtPrefDlg::build_tab_text()
 
     Gtk::VBox* vbox_editor = Gtk::manage(new Gtk::VBox());
     Gtk::CheckButton* checkbutton_auto_smart_quotes = Gtk::manage(new Gtk::CheckButton(_("Enable Smart Quotes Auto Replacement")));
+    Gtk::CheckButton* checkbutton_enable_symbol_autoreplace = Gtk::manage(new Gtk::CheckButton(_("Enable Symbol Auto Replacement")));
     checkbutton_auto_smart_quotes->set_active(config->autoSmartQuotes);
+    checkbutton_enable_symbol_autoreplace->set_active(config->enableSymbolAutoreplace);
 
     vbox_editor->pack_start(*checkbutton_auto_smart_quotes, false, false);
+    vbox_editor->pack_start(*checkbutton_enable_symbol_autoreplace, false, false);
 
     Gtk::Frame* frame_editor = Gtk::manage(new Gtk::Frame(std::string("<b>")+_("Text Editor")+"</b>"));
     ((Gtk::Label*)frame_editor->get_label_widget())->set_use_markup(true);
@@ -259,6 +262,9 @@ Gtk::Widget* CtPrefDlg::build_tab_text()
 
     checkbutton_auto_smart_quotes->signal_toggled().connect([config, checkbutton_auto_smart_quotes](){
         config->autoSmartQuotes = checkbutton_auto_smart_quotes->get_active();
+    });
+    checkbutton_enable_symbol_autoreplace->signal_toggled().connect([config, checkbutton_enable_symbol_autoreplace](){
+        config->enableSymbolAutoreplace = checkbutton_enable_symbol_autoreplace->get_active();
     });
     return pMainBox;
 }

--- a/modules/config.py
+++ b/modules/config.py
@@ -270,6 +270,7 @@ def config_file_load(dad):
         dad.embfile_max_size = cfg.getint(section, "embfile_max_size") if cfg.has_option(section, "embfile_max_size") else MAX_SIZE_EMBFILE_MB_DEFAULT
         dad.line_wrapping = cfg.getboolean(section, "line_wrapping") if cfg.has_option(section, "line_wrapping") else True
         dad.auto_smart_quotes = cfg.getboolean(section, "auto_smart_quotes") if cfg.has_option(section, "auto_smart_quotes") else True
+        dad.enable_symbol_autoreplace = cfg.getboolean(section, "enable_symbol_autoreplace") if cfg.has_option(section, "enable_symbol_autoreplace") else True
         dad.wrapping_indent = cfg.getint(section, "wrapping_indent") if cfg.has_option(section, "wrapping_indent") else -14
         dad.auto_indent = cfg.getboolean(section, "auto_indent") if cfg.has_option(section, "auto_indent") else True
         dad.rt_show_white_spaces = cfg.getboolean(section, "rt_show_white_spaces") if cfg.has_option(section, "rt_show_white_spaces") else False
@@ -416,6 +417,7 @@ def config_file_load(dad):
         dad.embfile_max_size = MAX_SIZE_EMBFILE_MB_DEFAULT
         dad.line_wrapping = True
         dad.auto_smart_quotes = True
+        dad.enable_symbol_autoreplace = True
         dad.wrapping_indent = -14
         dad.auto_indent = True
         dad.toolbar_ui_list = menus.TOOLBAR_VEC_DEFAULT
@@ -608,6 +610,7 @@ def config_file_save(dad):
     cfg.set(section, "embfile_max_size", dad.embfile_max_size)
     cfg.set(section, "line_wrapping", dad.line_wrapping)
     cfg.set(section, "auto_smart_quotes", dad.auto_smart_quotes)
+    cfg.set(section, "enable_symbol_autoreplace", dad.enable_symbol_autoreplace)
     cfg.set(section, "wrapping_indent", dad.wrapping_indent)
     cfg.set(section, "auto_indent", dad.auto_indent)
     cfg.set(section, "rt_show_white_spaces", dad.rt_show_white_spaces)
@@ -1205,7 +1208,11 @@ def preferences_tab_text(dad, vbox_text, pref_dialog):
     checkbutton_auto_smart_quotes = gtk.CheckButton(_("Enable Smart Quotes Auto Replacement"))
     checkbutton_auto_smart_quotes.set_active(dad.auto_smart_quotes)
 
+    checkbutton_enable_symbol_autoreplace = gtk.CheckButton(_("Enable Symbol Auto Replacement"))
+    checkbutton_enable_symbol_autoreplace.set_active(dad.enable_symbol_autoreplace)
+
     vbox_editor.pack_start(checkbutton_auto_smart_quotes, expand=False)
+    vbox_editor.pack_start(checkbutton_enable_symbol_autoreplace, expand=False)
 
     frame_editor = gtk.Frame(label="<b>"+_("Text Editor")+"</b>")
     frame_editor.get_label_widget().set_use_markup(True)
@@ -1218,7 +1225,10 @@ def preferences_tab_text(dad, vbox_text, pref_dialog):
     vbox_text.pack_start(frame_editor, expand=False)
     def on_checkbutton_auto_smart_quotes_toggled(checkbutton):
         dad.auto_smart_quotes = checkbutton.get_active()
+    def on_checkbutton_enable_symbol_autoreplace_toggled(checkbutton):
+        dad.enable_symbol_autoreplace = checkbutton.get_active()
     checkbutton_auto_smart_quotes.connect('toggled', on_checkbutton_auto_smart_quotes_toggled)
+    checkbutton_enable_symbol_autoreplace.connect('toggled', on_checkbutton_enable_symbol_autoreplace_toggled)
 
 def preferences_tab_plain_text_n_code(dad, vbox_code_nodes, pref_dialog):
     """Preferences Dialog, Plain Text and Code Tab"""

--- a/modules/support.py
+++ b/modules/support.py
@@ -410,7 +410,7 @@ def on_sourceview_event_after_key_press(dad, text_view, event, syntax_highl):
                     new_num += 1
                     list_info = dad.lists_handler.get_next_list_info_on_level(iter_start, curr_level)
         else: # keyname == cons.STR_KEY_SPACE
-            if is_code is False and iter_start.backward_chars(2):
+            if is_code is False and iter_start.backward_chars(2) and dad.enable_symbol_autoreplace:
                 if iter_start.get_char() == cons.CHAR_GREATER and iter_start.backward_char():
                     if iter_start.get_line_offset() == 0:
                         # at line start

--- a/sandbox/gtkmm/ct_config.cc
+++ b/sandbox/gtkmm/ct_config.cc
@@ -210,6 +210,7 @@ public:
     int                                         m_embfile_max_size;
     bool                                        m_line_wrapping;
     bool                                        m_auto_smart_quotes;
+    bool                                        m_enable_symbol_autoreplace;
     int                                         m_wrapping_indent;
     bool                                        m_auto_indent;
     bool                                        m_rt_show_white_spaces;
@@ -371,6 +372,7 @@ void CTConfig::_populate_with_defaults()
     m_embfile_max_size = 10;
     m_line_wrapping = true;
     m_auto_smart_quotes = true;
+    m_enable_symbol_autoreplace = true;
     m_wrapping_indent = -14;
     m_auto_indent = true;
     m_rt_show_white_spaces = false;
@@ -636,6 +638,7 @@ void CTConfig::_populate_from_keyfile()
     _populate_int_from_keyfile("embfile_max_size", &m_embfile_max_size);
     _populate_bool_from_keyfile("line_wrapping", &m_line_wrapping);
     _populate_bool_from_keyfile("auto_smart_quotes", &m_auto_smart_quotes);
+    _populate_bool_from_keyfile("enable_symbol_autoreplace", &m_enable_symbol_autoreplace);
     _populate_int_from_keyfile("wrapping_indent", &m_wrapping_indent);
     _populate_bool_from_keyfile("auto_indent", &m_auto_indent);
     _populate_bool_from_keyfile("rt_show_white_spaces", &m_rt_show_white_spaces);


### PR DESCRIPTION
Allowes to switch off symbol replacement, like "* " and "(c)".
It can be quite annoying, and having such option would be nice.

Tested only python version, had trouble with building c-version.
