### PR TITLE
Styles revamp

### DIFF
--- a/glade/styles.css
+++ b/glade/styles.css
@@ -16,7 +16,7 @@ Colours:
  * GENERAL
  ******************************************************************************/
 /*<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,700' rel='stylesheet' type='text/css'>*/
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,700);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,700);
 
 body {
     font-size: 13px;

--- a/glade/styles.css
+++ b/glade/styles.css
@@ -112,6 +112,7 @@ td {
 
 div.main h1 {
     font-weight: bold;
+    display: inline;
 }
 
 div.main h2 {
@@ -120,6 +121,7 @@ div.main h2 {
     font-weight: bold;
     font-size: 150%;
     color: #666666;
+    display: inline;
 }
 
 div.main h3 {
@@ -127,6 +129,7 @@ div.main h3 {
     font-weight: bold;
     font-size: 125%;
     color: #666666;
+    display: inline;
 }
 
 /* LINKS */

--- a/glade/styles.css
+++ b/glade/styles.css
@@ -22,6 +22,7 @@ body {
     font-size: 13px;
     font-family: "Open Sans", sans-serif !important;
     padding: 20x; 
+    white-space: pre-wrap;
 }
 
 div.main {


### PR DESCRIPTION
Fixes three issues in styles.css. 

The first bug is simple. Browsers get upset and issue a mixed-content warning when you import an insecure (http://) resource from a secure (https://) page. 


The second bug fixed is that every headings inserts newlines that do *not* exist in the original document. I sometimes use different headers on the same line in Cherrytree and, while the program itself renders them fine, the browser does not. Styling headings with     `display: inline;` fixes the issue.


The last and final bug that fixed is that whitespace does not render properly. If you have multiple levels of indentation in your notes and export to an HTML file, the indentation won't render. Applying the `white-space: pre-wrap;` style fixes the issue.