### PR TITLE
(Port to C++, edit menu) paste-clipboard, duplicate row, move row up and down

### DIFF
--- a/future/Makefile.am
+++ b/future/Makefile.am
@@ -293,11 +293,11 @@ libp7za_a_SOURCES = \
 
 cherrytree_LDADD = ${CHERRYTREE_LIBS} libp7za.a
 
-cherrytree_LDFLAGS = -Wl,--whole-archive $(top_srcdir)/libp7za.a -Wl,--no-whole-archive -lpthread
+cherrytree_LDFLAGS = -Wl,--whole-archive $(top_srcdir)/libp7za.a -lstdc++fs -Wl,--no-whole-archive -lpthread
 
 run_tests_LDADD = ${CHERRYTREE_LIBS} libp7za.a
 
-run_tests_LDFLAGS = -Wl,--whole-archive $(top_srcdir)/libp7za.a -Wl,--no-whole-archive -lpthread
+run_tests_LDFLAGS = -Wl,--whole-archive $(top_srcdir)/libp7za.a -lstdc++fs -Wl,--no-whole-archive -lpthread
 
 
 dist_noinst_SCRIPTS = autogen.sh

--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -187,9 +187,12 @@ private:
     // helper for edit actions
     void          _image_edit_dialog(Glib::RefPtr<Gdk::Pixbuf> pixbuf, Gtk::TextIter insert_iter, Gtk::TextIter* iter_bound);
     Glib::ustring _get_iter_alignment(Gtk::TextIter text_iter);
-    void          _image_insert(Gtk::TextIter iter_insert, Glib::RefPtr<Gdk::Pixbuf> pixbuf,
-                                Glib::ustring image_justification = "", Glib::RefPtr<Gtk::TextBuffer> text_buffer = Glib::RefPtr<Gtk::TextBuffer>());
     void          _text_selection_change_case(gchar change_type);
+
+public:
+    void          image_insert(Gtk::TextIter iter_insert, Glib::RefPtr<Gdk::Pixbuf> pixbuf, Glib::ustring link,
+                               Glib::ustring image_justification = "", Glib::RefPtr<Gtk::TextBuffer> text_buffer = Glib::RefPtr<Gtk::TextBuffer>());
+
 
 public:
     // edit actions

--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -146,7 +146,7 @@ public:
 
 private:
     struct text_view_n_buffer_codebox_proof {
-        Gtk::TextView*                  text_view;
+        CtTextView*                     text_view;
         Glib::RefPtr<Gtk::TextBuffer>   text_buffer;
         std::string                     syntax_highl;
         bool                            from_codebox;

--- a/future/src/ct/ct_actions_edit.cc
+++ b/future/src/ct/ct_actions_edit.cc
@@ -266,9 +266,88 @@ void CtActions::text_row_selection_duplicate()
     // todo: self.state_machine.update_state()
 }
 
+// Moves Up the Current Row/Selected Rows
 void CtActions::text_row_up()
 {
+    auto proof = _get_text_view_n_buffer_codebox_proof();
+    if (!proof.text_buffer) return;
+    if (!_is_curr_node_not_read_only_or_error()) return;
 
+    auto text_buffer = proof.text_buffer;
+    CtTextRange range = CtList(text_buffer).get_paragraph_iters();
+    int last_line_situation = false;
+    range.iter_end.forward_char();
+    bool missing_leading_newline = false;
+    Gtk::TextIter destination_iter = range.iter_start;
+
+    if (!destination_iter.backward_char()) return;
+    if (!destination_iter.backward_char())
+        missing_leading_newline = true;
+    else
+    {
+        while (destination_iter.get_char() != CtConst::CHAR_NEWLINE[0])
+            if (!destination_iter.backward_char())
+            {
+                missing_leading_newline = true;
+                break;
+            }
+    }
+    if (!missing_leading_newline) destination_iter.forward_char();
+    int destination_offset = destination_iter.get_offset();
+    int start_offset = range.iter_start.get_offset();
+    int end_offset = range.iter_end.get_offset();
+    //#print "iter_start %s %s '%s'" % (start_offset, ord(iter_start.get_char()), iter_start.get_char())
+    //#print "iter_end %s %s '%s'" % (end_offset, ord(iter_end.get_char()), iter_end.get_char())
+    //#print "destination_iter %s %s '%s'" % (destination_offset, ord(destination_iter.get_char()), destination_iter.get_char())
+    Glib::ustring text_to_move = text_buffer->get_text(range.iter_start, range.iter_end);
+    int diff_offsets = end_offset - start_offset;
+    if (proof.from_codebox || proof.syntax_highl != CtConst::RICH_TEXT_ID)
+    {
+        text_buffer->erase(range.iter_start, range.iter_end);
+        destination_iter = text_buffer->get_iter_at_offset(destination_offset);
+        if (text_to_move.empty() || text_to_move[text_to_move.length()-1] != CtConst::CHAR_NEWLINE[0])
+        {
+            diff_offsets += 1;
+            text_to_move += CtConst::CHAR_NEWLINE;
+        }
+        text_buffer->move_mark(text_buffer->get_insert(), destination_iter);
+        text_buffer->insert(destination_iter, text_to_move);
+        proof.text_view->set_selection_at_offset_n_delta(destination_offset, diff_offsets-1);
+    }
+    else
+    {
+        Glib::ustring rich_text = CtClipboard().rich_text_get_from_text_buffer_selection(_pCtMainWin->curr_tree_iter(),
+                                                                                         text_buffer, range.iter_start, range.iter_end, 'n', true /*exclude_iter_sel_end*/);
+        text_buffer->erase(range.iter_start, range.iter_end);
+        destination_iter = text_buffer->get_iter_at_offset(destination_offset);
+        if (destination_offset > 0)
+        {
+            // clear the newline from any tag
+            Gtk::TextIter clr_start_iter = text_buffer->get_iter_at_offset(destination_offset-1);
+            text_buffer->remove_all_tags(clr_start_iter, destination_iter);
+        }
+        bool append_newline = false;
+        if (text_to_move.empty() || text_to_move[text_to_move.length()-1] != CtConst::CHAR_NEWLINE[0])
+        {
+            diff_offsets += 1;
+            append_newline = true;
+        }
+        text_buffer->move_mark(text_buffer->get_insert(), destination_iter);
+        // trick of space to prevent subsequent text to take pasted text tag(s)
+        text_buffer->insert_at_cursor(CtConst::CHAR_SPACE);
+        destination_iter = text_buffer->get_iter_at_offset(destination_offset);
+        text_buffer->move_mark(text_buffer->get_insert(), destination_iter);
+        // write moved line
+        CtClipboard().from_xml_string_to_buffer(text_buffer, rich_text);
+        if (append_newline)
+            text_buffer->insert_at_cursor(CtConst::CHAR_NEWLINE);
+        // clear space trick
+        Gtk::TextIter cursor_iter = text_buffer->get_iter_at_mark(text_buffer->get_insert());
+        text_buffer->erase(cursor_iter, text_buffer->get_iter_at_offset(cursor_iter.get_offset()+1));
+        // selection
+        proof.text_view->set_selection_at_offset_n_delta(destination_offset, diff_offsets-1);
+    }
+    // todo: self.state_machine.update_state()
 }
 
 void CtActions::text_row_down()

--- a/future/src/ct/ct_clipboard.cc
+++ b/future/src/ct/ct_clipboard.cc
@@ -412,9 +412,17 @@ void CtClipboard::_on_received_to_plain_text(const Gtk::SelectionData& selection
     pTextView->scroll_to(curr_buffer->get_insert());
 }
 
+// From Clipboard to Rich Text
 void CtClipboard::_on_received_to_rich_text(const Gtk::SelectionData& selection_data, Gtk::TextView* pTextView, bool)
 {
-
+    Glib::ustring rich_text = selection_data.get_text();
+    if (rich_text.empty())
+    {
+        std::cout << "? no clipboard rich text" << std::endl;
+        return;
+    }
+    from_xml_string_to_buffer(pTextView->get_buffer(), rich_text);
+    pTextView->scroll_to(pTextView->get_buffer()->get_insert());
 }
 
 void CtClipboard::_on_received_to_codebox(const Gtk::SelectionData& selection_data, Gtk::TextView* pTextView, bool)

--- a/future/src/ct/ct_clipboard.cc
+++ b/future/src/ct/ct_clipboard.cc
@@ -511,10 +511,9 @@ void CtClipboard::_on_received_to_html(const Gtk::SelectionData& selection_data,
 // From Clipboard to Image
 void CtClipboard::_on_received_to_image(const Gtk::SelectionData& selection_data, Gtk::TextView* pTextView, bool)
 {
-    auto pixbuf = selection_data.get_pixbuf();
-    // todo:
-    //pixbuf.link = ""
-    //self.dad.image_insert(self.dad.curr_buffer.get_iter_at_mark(self.dad.curr_buffer.get_insert()), pixbuf)
+    Glib::RefPtr<const Gdk::Pixbuf> pixbuf = selection_data.get_pixbuf();
+    Glib::ustring link = "";
+    CtApp::P_ctActions->image_insert(pTextView->get_buffer()->get_insert()->get_iter(), pixbuf->copy(), link);
     pTextView->scroll_to(pTextView->get_buffer()->get_insert());
 }
 

--- a/future/src/ct/ct_clipboard.h
+++ b/future/src/ct/ct_clipboard.h
@@ -68,7 +68,7 @@ private:
 
 private:
     void _set_clipboard_data(const std::vector<std::string>& targets_list, CtClipboardData* clip_data);
-    void _on_clip_data_getl(Gtk::SelectionData& selection_data, guint info, CtClipboardData* clip_data);
+    void _on_clip_data_get(Gtk::SelectionData& selection_data, guint info, CtClipboardData* clip_data);
     void _on_clip_data_clear(CtClipboardData* clip_data);
 
 private:

--- a/future/src/ct/ct_doc_rw.h
+++ b/future/src/ct/ct_doc_rw.h
@@ -59,7 +59,7 @@ private:
 public:
     static void getTextBufferIter(Glib::RefPtr<Gsv::Buffer>& rTextBuffer, Gtk::TextIter* insertIter,
                                   std::list<CtAnchoredWidget*>& anchoredWidgets,
-                                  xmlpp::Node *pNodeParent);
+                                  xmlpp::Node *pNodeParent, int forceCharOffset = -1);
     static bool populateTableMatrixGetIsHeadFront(CtTableMatrix& tableMatrix, xmlpp::Element* pNodeElement);
 };
 

--- a/future/src/ct/ct_export2html.cc
+++ b/future/src/ct/ct_export2html.cc
@@ -389,6 +389,7 @@ Glib::ustring CtExport2Html::_link_process_folderpath(const Glib::ustring& folde
 {
     Glib::ustring folderpath_orig = Glib::Base64::decode(folderpath_raw);
     Glib::ustring folderpath = CtFileSystem::get_proper_platform_filepath(folderpath_orig);
+    // todo:
     //if not os.path.isabs(folderpath) and os.path.isdir(os.path.join(self.file_dir, folderpath)):
     //    folderpath = os.path.join(self.file_dir, folderpath)
     return folderpath;

--- a/future/src/ct/ct_image.cc
+++ b/future/src/ct/ct_image.cc
@@ -51,6 +51,18 @@ CtImage::CtImage(const char* stockImage,
     show_all();
 }
 
+CtImage::CtImage(Glib::RefPtr<Gdk::Pixbuf> pixBuf,
+                 const int charOffset,
+                 const std::string& justification)
+ : CtAnchoredWidget(charOffset, justification)
+{
+    _rPixbuf = pixBuf;
+
+    _image.set(_rPixbuf);
+    _frame.add(_image);
+    show_all();
+}
+
 void CtImage::save(const Glib::ustring& file_name, const Glib::ustring& type)
 {
     _rPixbuf->save(file_name, type);
@@ -77,6 +89,16 @@ CtImagePng::CtImagePng(const std::string& rawBlob,
                        const int charOffset,
                        const std::string& justification)
  : CtImage(rawBlob, "image/png", charOffset, justification),
+   _link(link)
+{
+    updateLabelWidget();
+}
+
+CtImagePng::CtImagePng(Glib::RefPtr<Gdk::Pixbuf> pixBuf,
+                       const Glib::ustring& link,
+                       const int charOffset,
+                       const std::string& justification)
+ : CtImage(pixBuf, charOffset, justification),
    _link(link)
 {
     updateLabelWidget();

--- a/future/src/ct/ct_image.h
+++ b/future/src/ct/ct_image.h
@@ -37,6 +37,9 @@ public:
             const int size,
             const int charOffset,
             const std::string& justification);
+    CtImage(Glib::RefPtr<Gdk::Pixbuf> pixBuf,
+            const int charOffset,
+            const std::string& justification);
     virtual ~CtImage() {}
 
     virtual void applyWidthHeight(const int parentTextWidth) {}
@@ -57,6 +60,10 @@ class CtImagePng : public CtImage
 {
 public:
     CtImagePng(const std::string& rawBlob,
+               const Glib::ustring& link,
+               const int charOffset,
+               const std::string& justification);
+    CtImagePng(Glib::RefPtr<Gdk::Pixbuf> pixBuf,
                const Glib::ustring& link,
                const int charOffset,
                const std::string& justification);

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -27,6 +27,7 @@
 #include "ct_app.h"
 #include <ctime>
 #include <regex>
+#include <filesystem>
 
 CtDocType CtMiscUtil::getDocType(std::string fileName)
 {
@@ -358,6 +359,14 @@ Gtk::BuiltinIconSize CtMiscUtil::getIconSize(int size)
     }
 }
 
+// Returns True if one set of the Given Chars are the first of in_string
+bool CtTextIterUtil::get_first_chars_of_string_are(const Glib::ustring& text, const std::vector<Glib::ustring>& chars_list)
+{
+    for (auto& chars: chars_list)
+        if (str::startswith(text, chars))
+            return true;
+    return false;
+}
 
 bool CtTextIterUtil::get_next_chars_from_iter_are(Gtk::TextIter text_iter, const Glib::ustring& chars_list)
 {
@@ -835,18 +844,17 @@ Glib::ustring CtFileSystem::get_proper_platform_filepath(Glib::ustring filepath)
 
 bool CtFileSystem::isdir(const Glib::ustring& path)
 {
-    // todo:
-    return false;
+    return std::filesystem::is_directory(std::filesystem::path(path));
 }
 
 bool CtFileSystem::isfile(const Glib::ustring& path)
 {
-    // todo:
-    return false;
+    return std::filesystem::is_regular_file(std::filesystem::path(path));
 }
 
 Glib::ustring CtFileSystem::join(const Glib::ustring& path1, const Glib::ustring& path2)
 {
+    // todo: improve the trick
     const gchar* sep = CtConst::IS_WIN_OS ? CtConst::CHAR_BSLASH : CtConst::CHAR_SLASH;
     return path1 + sep + path2;
 }

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -67,6 +67,8 @@ Gtk::BuiltinIconSize getIconSize(int size);
 
 namespace CtTextIterUtil {
 
+bool get_first_chars_of_string_are(const Glib::ustring& text, const std::vector<Glib::ustring>& chars_list);
+
 bool get_next_chars_from_iter_are(Gtk::TextIter text_iter, const Glib::ustring& chars_list);
 
 bool get_next_chars_from_iter_are(Gtk::TextIter text_iter, const std::vector<Glib::ustring>& chars_list_vec);

--- a/future/src/ct/ct_treestore.cc
+++ b/future/src/ct/ct_treestore.cc
@@ -492,6 +492,27 @@ void CtTreeStore::applyTextBufferToCtTextView(const Gtk::TreeIter& treeIter, CtT
     pTextView->grab_focus();
 }
 
+void CtTreeStore::addAnchoredWidgets(Gtk::TreeIter treeIter, std::list<CtAnchoredWidget*> anchoredWidgetList, Gtk::TextView* pTextView)
+{
+    auto widgets = treeIter->get_value(_columns.colAnchoredWidgets);
+    for (auto new_widget: anchoredWidgetList)
+        widgets.push_back(new_widget);
+    treeIter->set_value(_columns.colAnchoredWidgets, widgets);
+
+    for (CtAnchoredWidget* pCtAnchoredWidget : anchoredWidgetList)
+    {
+        Glib::RefPtr<Gtk::TextChildAnchor> rChildAnchor = pCtAnchoredWidget->getTextChildAnchor();
+        if (rChildAnchor)
+        {
+            if (0 == rChildAnchor->get_widgets().size())
+            {
+                pTextView->add_child_at_anchor(*pCtAnchoredWidget, rChildAnchor);
+                pCtAnchoredWidget->applyWidthHeight(pTextView->get_allocation().get_width());
+            }
+        }
+    }
+}
+
 gint64 CtTreeStore::node_id_get()
 {
     // todo: this function works differently from python code

--- a/future/src/ct/ct_treestore.h
+++ b/future/src/ct/ct_treestore.h
@@ -128,6 +128,7 @@ public:
     Gtk::TreeIter onRequestAppendNode(CtNodeData* pNodeData, const Gtk::TreeIter* pParentIter);
 
     void applyTextBufferToCtTextView(const Gtk::TreeIter& treeIter, CtTextView* pTextView);
+    void addAnchoredWidgets(Gtk::TreeIter treeIter, std::list<CtAnchoredWidget*> anchoredWidgetList, Gtk::TextView* pTextView);
     const Gtk::TreeModel::Children getRootChildren() { return _rTreeStore->children(); }
     void expandToTreeRow(Gtk::TreeView* pTreeView, Gtk::TreeRow& row);
     void setTreePathTextCursorFromConfig(Gtk::TreeView* pTreeView, Gsv::View* pTextView);

--- a/future/src/ct/ct_xml_rw.cc
+++ b/future/src/ct/ct_xml_rw.cc
@@ -124,7 +124,7 @@ CtXmlNodeType CtXmlRead::_xmlNodeGetTypeFromName(const Glib::ustring& xmlNodeNam
 
 void CtXmlRead::getTextBufferIter(Glib::RefPtr<Gsv::Buffer>& rTextBuffer, Gtk::TextIter* insertIter,
                                   std::list<CtAnchoredWidget*>& anchoredWidgets,
-                                  xmlpp::Node* pNodeParent)
+                                  xmlpp::Node* pNodeParent, int forceCharOffset /*=-1*/)
 {
     CtXmlNodeType xmlNodeType = _xmlNodeGetTypeFromName(pNodeParent->get_name());
     if (CtXmlNodeType::RichText == xmlNodeType)
@@ -161,7 +161,7 @@ void CtXmlRead::getTextBufferIter(Glib::RefPtr<Gsv::Buffer>& rTextBuffer, Gtk::T
     else if (CtXmlNodeType::None != xmlNodeType)
     {
         xmlpp::Element* pNodeElement = static_cast<xmlpp::Element*>(pNodeParent);
-        const int charOffset = std::stoi(pNodeElement->get_attribute_value("char_offset"));
+        const int charOffset = forceCharOffset != -1 ? forceCharOffset : std::stoi(pNodeElement->get_attribute_value("char_offset"));
         Glib::ustring justification = pNodeElement->get_attribute_value(CtConst::TAG_JUSTIFICATION);
         if (justification.empty())
         {


### PR DESCRIPTION
(ref to keep progress: #444)
1. Add -lstdc++fs to work with std::filesystem
2. Add paste rich text/codebox/table/image/uri for the main viewer
3. More actions: text_row_selection_duplicate,  text_row_up, text_row_down

There is a small issue with tables. If copy & paste a table (through duplicate row, for example), then the pasted table takes several lines in the viewer, not one. But if click on the table and then click out of it, this fixes the table. Maybe it needs some redraw function after inserting, have you ever seen that bug?

As for my plans, I'm going to add signals and menus for anchored widgets, it should help with clipboard testing. And do you mind if I fix compiler warnings? It would be a separate pull request.
