### PR TITLE
update makefile to use flag -std=c++17

### DIFF
--- a/future/Makefile.am
+++ b/future/Makefile.am
@@ -26,6 +26,7 @@ AM_CPPFLAGS = ${CHERRYTREE_CFLAGS} \
 	-D_UNITTEST_DATA_DIR=\"${top_srcdir}/tests/data\" \
 	-Wno-deprecated \
 	-Wno-cpp
+	-std=c++17
 
 bin_PROGRAMS = cherrytree
 


### PR DESCRIPTION
ct_actions.h and ct_actions_format.cc both use std::optional and include the optional header. This is a c++17 way of implementing it. Before it has to be std::experimental::optional from experimental/optional. Since I believe this was intended for c++17 I would say tell gcc to actually use c++17