### PR TITLE
Implement Command Palette Feature

### DIFF
--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -86,9 +86,10 @@ void CtMenu::init_actions(CtApp *pApp, CtActions* pActions)
     _actions.push_back(CtAction{file_cat, "ct_save", "gtk-save", _("_Save"), KB_CONTROL+"S", _("Save File"), sigc::mem_fun(*pActions, &CtActions::file_save)});
     _actions.push_back(CtAction{file_cat, "ct_vacuum", "gtk-clear", _("Save and _Vacuum"), None, _("Save File and Vacuum"), sigc::mem_fun(*pActions, &CtActions::file_vacuum)});
     _actions.push_back(CtAction{file_cat, "ct_save_as", "gtk-save-as", _("Save _As"), KB_CONTROL+KB_SHIFT+"S", _("Save File As"), sigc::mem_fun(*pActions, &CtActions::file_save_as)});
+    _actions.push_back(CtAction{file_cat, "command_palette", "gtk-execute", _("Command Palette"), KB_CONTROL+KB_SHIFT+"P", _("Command Palette"), sigc::signal<void>() /* dad.export_to_pdf */});
     _actions.push_back(CtAction{file_cat, "exec_code", "gtk-execute", _("_Execute Code"), "F5", _("Execute Code"), sigc::signal<void>() /* dad.exec_code */});
     _actions.push_back(CtAction{file_cat, "open_cfg_folder", "gtk-directory", _("Open Preferences _Directory"), None, _("Open the Directory with Preferences Files"), sigc::signal<void>() /* dad.folder_cfg_open */});
-    _actions.push_back(CtAction{file_cat, "print_page_setup", "gtk-print", _("Pa_ge Setup"), KB_CONTROL+KB_SHIFT+"P", _("Set up the Page for Printing"), sigc::signal<void>() /* dad.export_print_page_setup */});
+    _actions.push_back(CtAction{file_cat, "print_page_setup", "gtk-print", _("Pa_ge Setup"), None, _("Set up the Page for Printing"), sigc::signal<void>() /* dad.export_print_page_setup */});
     _actions.push_back(CtAction{file_cat, "do_print", "gtk-print", _("_Print"), KB_CONTROL+"P", _("Print"), sigc::signal<void>() /* dad.export_print */});
     _actions.push_back(CtAction{file_cat, "quit_app", "quit-app", _("_Quit"), KB_CONTROL+"Q", _("Quit the Application"), sigc::mem_fun(*pApp, &CtApp::quit_application) /* dad.quit_application */});
     _actions.push_back(CtAction{file_cat, "exit_app", "quit-app", _("_Exit CherryTree"), KB_CONTROL+KB_SHIFT+"Q", _("Exit from CherryTree"), sigc::signal<void>() /* dad.quit_application_totally */});
@@ -696,6 +697,7 @@ const char* CtMenu::_get_ui_str_menu()
     <menuitem action='print_page_setup'/>
     <menuitem action='do_print'/>
     <separator/>
+    <menuitem action='command_palette'/>
     <menuitem action='exec_code'/>
     <separator/>
     <menuitem action='quit_app'/>

--- a/modules/core.py
+++ b/modules/core.py
@@ -2228,6 +2228,78 @@ iter_end, exclude_iter_sel_end=True)
         self.export_print(args)
         self.print_handler.pdf_filepath = ""
 
+    def command_palette_dialog(self, title):
+        """Command Palette Dialog box"""
+        dialog = gtk.Dialog(title=title,
+                            parent=self.window,
+                            flags=gtk.DIALOG_MODAL|gtk.DIALOG_DESTROY_WITH_PARENT,
+                            buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_REJECT,
+                            gtk.STOCK_OK, gtk.RESPONSE_ACCEPT) )
+        dialog.set_default_size(400, 300)
+        dialog.set_position(gtk.WIN_POS_CENTER_ON_PARENT)
+        try:
+            button_ok = dialog.get_widget_for_response(gtk.RESPONSE_ACCEPT)
+        except:
+            print cons.STR_PYGTK_222_REQUIRED
+            button_ok = None
+        commands_liststore = gtk.ListStore(str,str)
+        for key in self.menudict:
+            commands_liststore.append([key,self.menudict[key]['dn']])
+        treeview = gtk.TreeView(commands_liststore)
+        treeview.set_enable_search(True)
+        def is_subsequence(x, y):
+            """Test whether x is a subsequence of y"""
+            x = list(x)
+            for letter in y:
+                if x and x[0] == letter:
+                    x.pop(0)
+            return not x
+        def search_function(model, column, key, rowiter):
+            '''
+                True: Search does not match
+            '''
+            row = model[rowiter]
+            query = key.lower()
+            data = row[1].lower()
+            return (not is_subsequence(query,data) )
+            # return (not re.search(query, data, re.IGNORECASE) )
+            # return (row[1].find(key) == -1)
+
+
+        treeview.set_search_equal_func(search_function)
+        renderer_text_node = gtk.CellRendererText()
+        renderer_text_linenum = gtk.CellRendererText()
+        renderer_text_linecontent = gtk.CellRendererText()
+        command_column = gtk.TreeViewColumn(_("Command Name"), renderer_text_node, text=1)
+        treeview.append_column(command_column)
+        # treeview.set_search_entry(search_entry)
+        # treeview.set_enable_search(True)
+        scrolledwindow_allmatches = gtk.ScrolledWindow()
+        scrolledwindow_allmatches.set_policy(gtk.POLICY_AUTOMATIC, gtk.POLICY_AUTOMATIC)
+        scrolledwindow_allmatches.add(treeview)
+
+        content_area = dialog.get_content_area()
+        content_area.add(scrolledwindow_allmatches)
+        content_area.show_all()
+        def on_entry_event_after(treeview2, event):
+            """Catches mouse buttons clicks"""
+            if event.type not in [gtk.gdk.BUTTON_PRESS, gtk.gdk.KEY_PRESS]: return
+            keyname = gtk.gdk.keyval_name(event.keyval)
+            if keyname == cons.STR_KEY_RETURN:
+                button_ok.clicked()
+        treeview.connect('event-after', on_entry_event_after)
+        response = dialog.run()
+        dialog.hide()
+        if response == gtk.RESPONSE_ACCEPT:
+            model, list_iter = treeview.get_selection().get_selected()
+            key = model[list_iter][0]
+            self.menudict[key]['cb'](self)
+            return 1
+        return None
+
+    def show_command_palette(self, *args):
+        self.command_palette_dialog("Command Palette")
+
     def export_print(self, args):
         """Start Print Operations"""
         if not self.is_there_selected_node_or_error(): return

--- a/modules/menus.py
+++ b/modules/menus.py
@@ -34,6 +34,7 @@ CONFIG_ACTIONS_DICT = {
 "ct_save_as",
 "print_page_setup",
 "do_print",
+"command_palette",
 "exec_code",
 "quit_app",
 "exit_app",
@@ -178,7 +179,7 @@ def load_menudict(dad):
 "ct_save_as": {"sk": "gtk-save-as", "sd": _("Save _As"), "kb": KB_CONTROL+KB_SHIFT+"S", "dn": _("Save File As"), "cb": dad.file_save_as},
 "exec_code": {"sk": "gtk-execute", "sd": _("_Execute Code"), "kb": "F5", "dn": _("Execute Code"), "cb": dad.exec_code},
 "open_cfg_folder": {"sk": "gtk-directory", "sd": _("Open Preferences _Directory"), "kb": None, "dn": _("Open the Directory with Preferences Files"), "cb": dad.folder_cfg_open},
-"print_page_setup": {"sk": "gtk-print", "sd": _("Pa_ge Setup"), "kb": KB_CONTROL+KB_SHIFT+"P", "dn": _("Set up the Page for Printing"), "cb": dad.export_print_page_setup},
+"print_page_setup": {"sk": "gtk-print", "sd": _("Pa_ge Setup"), "kb": None, "dn": _("Set up the Page for Printing"), "cb": dad.export_print_page_setup},
 "do_print": {"sk": "gtk-print", "sd": _("_Print"), "kb": KB_CONTROL+"P", "dn": _("Print"), "cb": dad.export_print},
 "quit_app": {"sk": "quit-app", "sd": _("_Quit"), "kb": KB_CONTROL+"Q", "dn": _("Quit the Application"), "cb": dad.quit_application},
 "exit_app": {"sk": "quit-app", "sd": _("_Exit CherryTree"), "kb": KB_CONTROL+KB_SHIFT+"Q", "dn": _("Exit from CherryTree"), "cb": dad.quit_application_totally},
@@ -294,6 +295,7 @@ def load_menudict(dad):
 "import_tuxcards": {"sk": cons.STR_STOCK_CT_IMP, "sd": _("From _TuxCards File"), "kb": None, "dn": _("Add Nodes of a TuxCards File to the Current Tree"), "cb": dad.nodes_add_from_tuxcards_file},
 "import_zim": {"sk": cons.STR_STOCK_CT_IMP, "sd": _("From _Zim Folder"), "kb": None, "dn": _("Add Nodes of a Zim Folder to the Current Tree"), "cb": dad.nodes_add_from_zim_folder},
 "export_pdf": {"sk": "to_pdf", "sd": _("Export To _PDF"), "kb": None, "dn": _("Export To PDF"), "cb": dad.export_to_pdf},
+"command_palette": {"sk": "gtk-execute", "sd": _("Command Palette"), "kb": KB_CONTROL+KB_SHIFT+"P", "dn": _("Command Palette"), "cb": dad.show_command_palette},
 "export_html": {"sk": "to_html", "sd": _("Export To _HTML"), "kb": None, "dn": _("Export To HTML"), "cb": dad.export_to_html},
 "export_txt_multiple": {"sk": "to_txt", "sd": _("Export to Multiple Plain _Text Files"), "kb": None, "dn": _("Export to Multiple Plain Text Files"), "cb": dad.export_to_txt_multiple},
 "export_txt_single": {"sk": "to_txt", "sd": _("Export to _Single Plain Text File"), "kb": None, "dn": _("Export to Single Plain Text File"), "cb": dad.export_to_txt_single},
@@ -673,6 +675,7 @@ UI_INFO = """
       <menuitem action='print_page_setup'/>
       <menuitem action='do_print'/>
       <separator/>
+      <menuitem action='command_palette'/>
       <menuitem action='exec_code'/>
       <separator/>
       <menuitem action='quit_app'/>


### PR DESCRIPTION
**Preview**: ![cherrytree-command-pallete](https://user-images.githubusercontent.com/13846618/71779868-bb504080-2fe0-11ea-856a-fdbb1c1ea64c.gif)
**Keybinding**: Ctrl+Shift+P
Currently all the menu items are shown in the command palette. User can search the palette by simply focusing and then typing in palette dialog window.
The search used is sub sequence search on lower cased strings.
**Note**: Ctrl+Shift+P was earlier used for PrintPageSetup but now its used for Command Pallete