### PR TITLE
Add snap

### DIFF
--- a/snap/local/patches/desktop-launch.patch
+++ b/snap/local/patches/desktop-launch.patch
@@ -1,0 +1,34 @@
+diff --git a/common/desktop-exports b/common/desktop-exports
+index 1319361..cb9cd5d 100644
+--- a/common/desktop-exports
++++ b/common/desktop-exports
+@@ -94,6 +94,7 @@ append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/libunity
+ 
+ # Pulseaudio export
+ append_dir LD_LIBRARY_PATH $RUNTIME/usr/lib/$ARCH/pulseaudio
++append_dir LD_LIBRARY_PATH $SNAP/usr/lib/alsa-lib
+ 
+ # EGL vendor files on glvnd enabled systems
+ [ -d /var/lib/snapd/lib/glvnd/egl_vendor.d ] && \
+@@ -424,3 +425,6 @@ IBUS_CONFIG_PATH=$XDG_CONFIG_HOME/ibus
+ mkdir -p $IBUS_CONFIG_PATH
+ [ -d $IBUS_CONFIG_PATH/bus ] && rm -rf $IBUS_CONFIG_PATH/bus
+ ln -sfn $REALHOME/.config/ibus/bus $IBUS_CONFIG_PATH
++
++prepend_dir LD_LIBRARY_PATH $SNAP/usr/lib/$ARCH/blas
++prepend_dir LD_LIBRARY_PATH $SNAP/usr/lib/$ARCH/lapack
+diff --git a/gtk/launcher-specific b/gtk/launcher-specific
+index 3d2a8ff..82d5555 100644
+--- a/gtk/launcher-specific
++++ b/gtk/launcher-specific
+@@ -12,10 +12,8 @@ if [ "$USE_gtk3" = true ]; then
+     # Does not hurt to specify this as well, just in case
+     export QT_QPA_PLATFORM=wayland-egl
+   fi
+-  append_dir GTK_PATH $RUNTIME/usr/lib/$ARCH/gtk-3.0
+ else
+   [ "$wayland_available" = true ] && echo "Warning: GTK2 does not support Wayland!"
+-  append_dir GTK_PATH $RUNTIME/usr/lib/$ARCH/gtk-2.0
+ fi
+ 
+ # ibus and fcitx integration

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -95,6 +95,13 @@ parts:
     source-depth: 1
     plugin: python
     python-version: python2
+    override-build: |
+      #mkdir -p /usr/share/icons/hicolor/96x96/apps/cherrytree
+      #cp glade/cherrytree.png /usr/share/icons/hicolor/96x96/apps/cherrytree/
+      sed -i 's|^Icon=.*|Icon=${SNAP}/meta/gui/cherrytree.png|' linux/cherrytree.desktop
+      snapcraftctl build
+      mkdir -p $SNAPCRAFT_PART_INSTALL/meta/gui/
+      cp glade/cherrytree.png $SNAPCRAFT_PART_INSTALL/meta/gui/
     build-packages:
       - gettext
       - desktop-file-utils

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,8 +96,6 @@ parts:
     plugin: python
     python-version: python2
     override-build: |
-      #mkdir -p /usr/share/icons/hicolor/96x96/apps/cherrytree
-      #cp glade/cherrytree.png /usr/share/icons/hicolor/96x96/apps/cherrytree/
       sed -i 's|^Icon=.*|Icon=${SNAP}/meta/gui/cherrytree.png|' linux/cherrytree.desktop
       snapcraftctl build
       mkdir -p $SNAPCRAFT_PART_INSTALL/meta/gui/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,40 @@
+name: cherrytree
+version: git
+summary: Hierarchical note taking application
+description: |
+  A hierarchical note taking application, featuring rich text and syntax highlighting, storing data in a single XML or SQLite file. The project home page is giuspen.com/cherrytree.
+
+grade: devel
+confinement: strict
+base: core18
+
+slots:
+  cherrytree:
+    interface: dbus
+    bus: session
+    name: com.giuspen.CherryTreeService
+
+apps:
+  cherrytree:
+    command: bin/cherrytree
+    extensions: [ gnome-3-34 ]
+    plugs:
+      - home
+    desktop: share/applications/cherrytree.desktop
+
+parts:
+  cherrytree:
+    source: https://github.com/giuspen/cherrytree.git
+    source-depth: 1
+    plugin: python
+    python-version: python2
+    build-packages:
+      - gettext
+      - desktop-file-utils
+    stage-packages:
+      - python-gtk2
+      - python-gtksourceview2
+      - p7zip-full
+      - python-dbus
+      - python-enchant
+      - python-chardet

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,15 +14,82 @@ slots:
     bus: session
     name: com.giuspen.CherryTreeService
 
+plugs:
+  gtk-2-engines:
+    interface: content
+    target: $SNAP/lib/gtk-2.0
+    default-provider: gtk2-common-themes
+  gtk-2-themes:
+    interface: content
+    target: $SNAP/share/themes
+    default-provider: gtk2-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes
+
 apps:
   cherrytree:
-    command: bin/cherrytree
-    extensions: [ gnome-3-34 ]
+    command: desktop-launch $SNAP/bin/cherrytree
     plugs:
       - home
+      - unity7
+      - wayland
+      - x11
+      - desktop
+      - desktop-legacy
+      - gsettings
     desktop: share/applications/cherrytree.desktop
 
 parts:
+  desktop-gtk:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: gtk
+    plugin: make
+    make-parameters: ["FLAVOR=gtk2"]
+    build-packages:
+    - libgtk2.0-dev
+    - libgtk-3-dev
+    stage-packages:
+    - libxkbcommon0  # XKB_CONFIG_ROOT
+    - ttf-ubuntu-font-family
+    - dmz-cursor-theme
+    - light-themes
+    - adwaita-icon-theme
+    - gnome-themes-standard
+    - shared-mime-info
+    - libgtk2.0-0
+    - libgtk-3-0
+    - libgdk-pixbuf2.0-0
+    - libglib2.0-bin
+    - libgtk2.0-bin
+    - libgtk-3-bin
+    - unity-gtk2-module
+    - unity-gtk3-module
+    - libappindicator3-1
+    - locales-all
+    - xdg-user-dirs
+    - ibus-gtk
+    - ibus-gtk3
+    - libibus-1.0-5
+    after: [desktop-patch]
+    override-pull: |
+      snapcraftctl pull
+      patch -Np1 < $SNAPCRAFT_STAGE/desktop-launch.patch
+    organize:
+      usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gtk-2.0: usr/lib/gtk-2.0
+      usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gtk-3.0: usr/lib/gtk-3.0
+
+  desktop-patch:
+    source: snap/local/patches
+    source-type: local
+    plugin: dump
+    prime: [-* ]
+
   cherrytree:
     source: https://github.com/giuspen/cherrytree.git
     source-depth: 1


### PR DESCRIPTION
Until the C++ version is ready for release into the wild, I'd like to add snap packaging for the python 2.7 version of cherrytree. If you're not familiar with snap, it's similar to flatpak in that it is a containerized application that bundles its dependencies (like python 2.7) in the package, for use only by the app. 

Once the snap metadata is included in the project, I can setup an automatic launchpad build that will upload the cherrytree snap to the snap store. This is a great platform to distribute your package to users. In the future, when the C++ version is ready for release, we can change the launchpad build to build that version instead and even have it build automatically on every new commit added to master, so that the snap users are being provided the newest changes via the store in the edge branch (I would manually promote whichever build to the stable branch).

Snaps can be installed on any linux distribution with snapd installed (available from the distro repositories) and then run from the usual desktop icon or from the command line.

To build:
* the developer will need `snapd` installed
* the developer will need to use snap to install snapcraft and multipass from the snap store: `$ sudo snap install snapcraft multipass`
* then from the project root directory: `$ snapcraft`
* The result will be something like `cherrytree_0.36.6+git<id>_amd64.snap`

To test the build:
* Install the locally-built snap: `$ sudo snap install cherrytree_0.36.6+git<id>_amd64.snap --dangerous`
* Run cherrytree either from the desktop icon or from the command line: `$ snap run cherrytree`