### PR TITLE
Snap 7za not found

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,6 +46,9 @@ apps:
     desktop: share/applications/cherrytree.desktop
     environment:
       PATH: $SNAP/usr/lib/p7zip:$PATH
+      GTK_PATH: $SNAP/lib/gtk-2.0
+      GTK_DATA_PREFIX: $SNAP
+      XDG_DATA_DIRS: $SNAP/share:$XDG_DATA_DIRS
 
 parts:
   desktop-gtk:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: Hierarchical note taking application
 description: |
   A hierarchical note taking application, featuring rich text and syntax highlighting, storing data in a single XML or SQLite file. The project home page is giuspen.com/cherrytree.
 
-grade: devel
+grade: stable
 confinement: strict
 base: core18
 
@@ -44,6 +44,8 @@ apps:
       - desktop-legacy
       - gsettings
     desktop: share/applications/cherrytree.desktop
+    environment:
+      PATH: $SNAP/usr/lib/p7zip:$PATH
 
 parts:
   desktop-gtk:
@@ -110,3 +112,5 @@ parts:
       - python-dbus
       - python-enchant
       - python-chardet
+    prime:
+      - -usr/bin/7za


### PR DESCRIPTION
A few updates were needed
* change grade to stable so it can be in the snapstore
* add 7za to path
* remove unnecessary /usr/bin/7za to avoid confusion
* fix gtk2 themeing