### PR TITLE
Hardcode version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cherrytree
-version: git
+version: 0.38.11
 summary: Hierarchical note taking application
 description: |
   A hierarchical note taking application, featuring rich text and syntax highlighting, storing data in a single XML or SQLite file. The project home page is giuspen.com/cherrytree.


### PR DESCRIPTION
The snapcraft.yaml was just pulling the version from whatever git said it was, which was 0.36.6 but when you run the cherrytree snap, the about says 0.38.11. So when a user installs cherrytree from the snapstore, they might notice the mismatch.

snapstore version before this commit: `0.36.6+git601.f8dc01c`
snapstore version after this commit: `0.38.11`

Hardcoding the version fixes this as well as making it look cleaner/more "official".