### PR TITLE
Ensure the CtConst::AVAILABLE_LANGS array is the correct size

### DIFF
--- a/future/src/ct/ct_const.cc
+++ b/future/src/ct/ct_const.cc
@@ -206,7 +206,7 @@ const std::vector<std::string> CtConst::TOOLBAR_VEC_BLACKLIST {
     "img_link_edit", "img_link_dismiss", "toggle_show_mainwin"
 };
 
-const gchar* CtConst::AVAILABLE_LANGS[20] {
+const gchar* CtConst::AVAILABLE_LANGS[21] {
     "default", "cs", "de", "el", "en", "es", "fi", "fr", "hy", "it",
     "ja", "lt", "nl", "pl", "pt_BR", "ru", "sl", "sv", "tr", "uk", "zh_CN"
 };

--- a/future/src/ct/ct_const.h
+++ b/future/src/ct/ct_const.h
@@ -175,7 +175,7 @@ extern const std::unordered_set<const gchar*> TEXT_SYNTAXES;
 extern const std::unordered_set<const gchar*> TAG_PROPERTIES;
 extern const gchar    TOOLBAR_VEC_DEFAULT[];
 extern const std::vector<std::string> TOOLBAR_VEC_BLACKLIST;
-extern const gchar*   AVAILABLE_LANGS[20];
+extern const gchar*   AVAILABLE_LANGS[21];
 extern const std::unordered_map<int, std::string> NODES_STOCKS;
 extern const std::unordered_map<int, std::string> NODES_ICONS;
 extern const std::unordered_map<std::string, std::string> CODE_ICONS;


### PR DESCRIPTION
In [this commit](https://github.com/giuspen/cherrytree/commit/f8dc01ccc4713355148b7c793bea7639f435eca8), the `sv` language identifier was added (per localization [done here](https://github.com/giuspen/cherrytree/pull/610)), but the array size was not increased, which causes a build failure. This PR increases the size.