### PR TITLE
Files with russian names won't open through command line under Windows #33

### DIFF
--- a/cherrytree
+++ b/cherrytree
@@ -28,6 +28,35 @@ try:
 except:
     ARGPARSE_OK = False
 
+def win32_unicode_argv():
+    """Uses shell32.GetCommandLineArgvW to get sys.argv as a list of Unicode
+    strings.
+
+    Versions 2.x of Python don't support Unicode in sys.argv on
+    Windows, with the underlying Windows API instead replacing multi-byte
+    characters with '?'.
+    """
+
+    from ctypes import POINTER, byref, cdll, c_int, windll
+    from ctypes.wintypes import LPCWSTR, LPWSTR
+
+    GetCommandLineW = cdll.kernel32.GetCommandLineW
+    GetCommandLineW.argtypes = []
+    GetCommandLineW.restype = LPCWSTR
+
+    CommandLineToArgvW = windll.shell32.CommandLineToArgvW
+    CommandLineToArgvW.argtypes = [LPCWSTR, POINTER(c_int)]
+    CommandLineToArgvW.restype = POINTER(LPWSTR)
+
+    cmd = GetCommandLineW()
+    argc = c_int(0)
+    argv = CommandLineToArgvW(cmd, byref(argc))
+    if argc.value > 0:
+        # Remove Python executable and commands if present
+        start = argc.value - len(sys.argv)
+        return [argv[i].encode('utf-8') for i in # use 'utf-8', so gtk2 doesn't give warnings about argv
+                xrange(start, argc.value)]
+            
 def f_main(args):
     if hasattr(sys, 'frozen'):
         # windows, py2exe
@@ -48,6 +77,10 @@ def f_main(args):
     sys.path.insert(0, MODULES_PATH)
     import main
     main.main(args)
+
+
+if sys.platform.startswith("win"):
+    sys.argv = win32_unicode_argv()
 
 if ARGPARSE_OK:
     parser = argparse.ArgumentParser()

--- a/modules/core.py
+++ b/modules/core.py
@@ -1489,7 +1489,7 @@ iter_end, exclude_iter_sel_end=True)
         """Try to load a file if there are the conditions"""
         #print "file_startup_load '%s' ('%s', '%s')" % (open_with_file, self.file_name, self.file_dir)
         if open_with_file:
-            open_with_file = open_with_file.decode(sys.getfilesystemencoding()).encode(cons.STR_UTF8, cons.STR_IGNORE)
+            open_with_file = unicode(open_with_file, cons.STR_UTF8, cons.STR_IGNORE)
             self.file_name = os.path.basename(open_with_file)
             self.file_dir = os.path.dirname(open_with_file)
             #print "open_with_file -> file_name '%s', file_dir '%s'" % (self.file_name, self.file_dir)

--- a/modules/main.py
+++ b/modules/main.py
@@ -215,7 +215,9 @@ def initializations():
 def arg_filepath_fix(filepath):
     """Fix a FilePath to an Absolute Path"""
     if not filepath: return ""
-    filepath = filepath.decode(sys.getfilesystemencoding()).encode(cons.STR_UTF8, cons.STR_IGNORE)
+    # for win32 it is already utf-8
+    if not sys.platform.startswith("win"):
+        filepath = filepath.decode(sys.getfilesystemencoding()).encode(cons.STR_UTF8, cons.STR_IGNORE)
     if not os.path.dirname(filepath):
         filepath = os.path.join(os.getcwd(), filepath)
     else:


### PR DESCRIPTION
Fix for #33, I suppose, for another languages it also will be work

- Code `win32_unicode_argv()` was found in Internet and quite popular, so I suppose it's safe to use
- It is not related to the issue, but I replaced in `file_startup_load()`
```python
open_with_file = open_with_file.decode(sys.getfilesystemencoding()).encode(cons.STR_UTF8, cons.STR_IGNORE)
```
with 'unicode()' because in `main.py` `arg_filepath_fix` already did the job for `open_with_file `.