### PR TITLE
Improve UX for Exported HTML

### DIFF
--- a/future/src/ct/ct_export2html.h
+++ b/future/src/ct/ct_export2html.h
@@ -35,7 +35,7 @@ private:
       <meta http-equiv="content-type" content="text/html; charset=utf-8">
       <title>%s</title>
       <meta name="generator" content="CherryTree">
-      <link rel="stylesheet" href="styles.css" type="text/css" />
+      <link rel="stylesheet" href="res/styles.css" type="text/css" />
     </head>
     <body>)HTML";
     const Glib::ustring HTML_FOOTER = R"HTML(</body></html>)HTML";

--- a/glade/script.js
+++ b/glade/script.js
@@ -1,0 +1,9 @@
+function changeFrame(file_path){
+	console.log(file_path);
+	var iframe = document.getElementById("page_frame");
+	iframe.src = file_path;
+}
+
+window.onload = function(){ 
+	document.body.style.overflowY = 'hidden';
+}

--- a/glade/styles.css
+++ b/glade/styles.css
@@ -23,29 +23,49 @@ body {
     font-family: "Open Sans", sans-serif !important;
     padding: 20x; 
     white-space: pre-wrap;
+    margin: 0;
+    padding: 0;
+    overflow-x: hidden;
+    height: 100%;
 }
 
 div.main {
-    width: 100%;
+    width: 100vw;
+    height: inherit;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    overflow-y: hidden;
 }
 
 div.tree {
-    width: 300px;
+    flex: 19vw;
     /*background-color: #EEEEEE;
     border-top: 1px solid #DDDDDD;
     border-bottom: 1px solid #DDDDDD;
     margin-bottom: 20px;*/
-    padding: 0.75em 0 0.75em 20px;
-    float: left;
-    position: fixed;
-    height: 97%;
+    /*margin: 0.75em 0 0.75em 20px;*/
+    margin-left: 1vw;
+    height: 100vh;
     overflow: auto;
 }
 
 div.page {
-    width: 100%;
-    padding-left: 380px; /* div.tree width + L/R margins + padding */
+    flex: 80vw;
+    height: 100vh;
+    margin: 0;
+    padding: 0;
+    font-size: 0;
+}
+
+iframe.page {
+    width: 79vw;
+    margin-left: 1vw;
+    border: 0px;
+    margin-top: 0px;
+    height: 100vh;
     box-sizing: border-box;
+    overflow-y: auto;
 }
 
 .clear {

--- a/modules/cons.py
+++ b/modules/cons.py
@@ -235,7 +235,7 @@ HTML_HEADER = '''<!doctype html><html>
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
   <title>%s</title>
   <meta name="generator" content="CherryTree">
-  <link rel="stylesheet" href="styles.css" type="text/css" />
+  <link rel="stylesheet" href="res/styles.css" type="text/css" />
 </head>
 <body>'''
 HTML_FOOTER = '</body></html>'


### PR DESCRIPTION
*Does not reload page when clicking on Node
*Each node just contains its content, no tree data
*Tree data is stored just in index.html
*index.html uses IFrames to load just contents of the nodes
*Browsing feels very much like in Cherrytree

______________________________________________
**Before Fix**:
![3 before_fix_export_to_html](https://user-images.githubusercontent.com/13846618/74100381-4bd7ee80-4b54-11ea-9a59-5ece13eeb809.gif)

______________________________________________
______________________________________________
______________________________________________

**After Fix**:
![3 after_fix_export_to_html](https://user-images.githubusercontent.com/13846618/74100385-55615680-4b54-11ea-9315-a2eab17d81a4.gif)
