### PR TITLE
Fix visited nodes history going to todays node using key binding

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -2980,6 +2980,7 @@ iter_end, exclude_iter_sel_end=True)
 
     def node_date(self, *args):
         """Insert Date Node in Tree"""
+        self.last_command = "node_date"
         curr_time = time.time()
         now_year = support.get_timestamp_str("%Y", curr_time)
         now_month = support.get_timestamp_str("%B", curr_time)
@@ -2991,18 +2992,22 @@ iter_end, exclude_iter_sel_end=True)
                 if self.treestore[self.curr_tree_iter][1] == now_year:
                     self.node_child_exist_or_create(self.curr_tree_iter, now_month)
                     self.node_date()
+                    self.last_command = ""
                     return
             else:
                 if self.treestore[self.curr_tree_iter][1] == now_month\
                 and self.treestore[self.treestore.iter_parent(self.curr_tree_iter)][1] == now_year:
                     self.node_child_exist_or_create(self.curr_tree_iter, now_day)
+                    self.last_command = ""
                     return
                 if self.treestore[self.curr_tree_iter][1] == now_year:
                     self.node_child_exist_or_create(self.curr_tree_iter, now_month)
                     self.node_date()
+                    self.last_command = ""
                     return
         self.node_child_exist_or_create(None, now_year)
         self.node_date()
+        self.last_command = ""
 
     def get_node_children_list(self, father_tree_iter, level):
         """Return a string listing the node children"""

--- a/modules/machines.py
+++ b/modules/machines.py
@@ -29,6 +29,7 @@ import cons
 import config
 import support
 import exports
+import time
 
 
 def get_blob_buffer_from_pixbuf(pixbuf):
@@ -845,6 +846,22 @@ class StateMachine:
             #print "last_index",  len(self.visited_nodes_list) - 1
             return None
 
+    def is_today_node(self, dad, node_id):
+        self = dad
+        curr_depth = self.treestore.iter_depth(self.curr_tree_iter)
+        if(curr_depth !=2 ): return False
+
+        curr_time = time.time()
+        now_day = support.get_timestamp_str(self.journal_day_format, curr_time)
+        curr_node_name = self.treestore[self.curr_tree_iter][1]
+        if (curr_node_name != now_day): return False
+
+        now_year = support.get_timestamp_str("%Y", curr_time)
+        now_month = support.get_timestamp_str("%B", curr_time)
+        p_node_name = self.treestore[self.treestore.iter_parent(self.curr_tree_iter)][1]
+        pp_node_name = self.treestore[self.treestore.iter_parent(self.treestore.iter_parent(self.curr_tree_iter))][1]
+        return (p_node_name == now_month) and (pp_node_name == now_year)
+
     def node_selected_changed(self, node_id):
         """When a New Node is Selected"""
         if self.dad.user_active and not self.dad.go_bk_fw_click:
@@ -852,6 +869,9 @@ class StateMachine:
             if self.visited_nodes_idx != last_index: del self.visited_nodes_list[self.visited_nodes_idx+1:last_index+1]
             if node_id in self.visited_nodes_list:
                 self.visited_nodes_list.remove(node_id)
+            # Todo: Do this in node_date method
+            if (hasattr(self.dad, 'last_command')) and (self.dad.last_command == "node_date") and (self.is_today_node(self.dad, node_id)):
+                self.visited_nodes_list = self.visited_nodes_list[:-2]
             self.visited_nodes_list.append(node_id)
             self.visited_nodes_idx = len(self.visited_nodes_list) - 1
         if node_id not in self.nodes_vectors:


### PR DESCRIPTION
**Ctrl+T** is mapped to **Insert Today's Node**

**Before Fix**: Going to today's node adds Year, Month and Day nodes to visited history.
![before_fix_history](https://user-images.githubusercontent.com/13846618/74097245-e8d46080-4b2f-11ea-96d6-16629246b22c.gif)

**After Fix**: Just add Day node to visited nodes history.
![after_fix_history](https://user-images.githubusercontent.com/13846618/74097249-eeca4180-4b2f-11ea-8673-14d73c471f71.gif)
