### PR TITLE
Simplify node_date method and Fix visited nodes history

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -2984,25 +2984,9 @@ iter_end, exclude_iter_sel_end=True)
         now_year = support.get_timestamp_str("%Y", curr_time)
         now_month = support.get_timestamp_str("%B", curr_time)
         now_day = support.get_timestamp_str(self.journal_day_format, curr_time)
-        #print now_year, now_month, now_day
-        if self.curr_tree_iter:
-            curr_depth = self.treestore.iter_depth(self.curr_tree_iter)
-            if curr_depth == 0:
-                if self.treestore[self.curr_tree_iter][1] == now_year:
-                    self.node_child_exist_or_create(self.curr_tree_iter, now_month)
-                    self.node_date()
-                    return
-            else:
-                if self.treestore[self.curr_tree_iter][1] == now_month\
-                and self.treestore[self.treestore.iter_parent(self.curr_tree_iter)][1] == now_year:
-                    self.node_child_exist_or_create(self.curr_tree_iter, now_day)
-                    return
-                if self.treestore[self.curr_tree_iter][1] == now_year:
-                    self.node_child_exist_or_create(self.curr_tree_iter, now_month)
-                    self.node_date()
-                    return
         self.node_child_exist_or_create(None, now_year)
-        self.node_date()
+        self.node_child_exist_or_create(self.curr_tree_iter, now_month)
+        self.node_child_exist_or_create(self.curr_tree_iter, now_day)
 
     def get_node_children_list(self, father_tree_iter, level):
         """Return a string listing the node children"""

--- a/modules/core.py
+++ b/modules/core.py
@@ -2984,8 +2984,10 @@ iter_end, exclude_iter_sel_end=True)
         now_year = support.get_timestamp_str("%Y", curr_time)
         now_month = support.get_timestamp_str("%B", curr_time)
         now_day = support.get_timestamp_str(self.journal_day_format, curr_time)
+        list_before_start = list(self.state_machine.visited_nodes_list)
         self.node_child_exist_or_create(None, now_year)
         self.node_child_exist_or_create(self.curr_tree_iter, now_month)
+        self.state_machine.visited_nodes_list = list_before_start
         self.node_child_exist_or_create(self.curr_tree_iter, now_day)
 
     def get_node_children_list(self, father_tree_iter, level):


### PR DESCRIPTION
**Ctrl+T** is mapped to **Insert Today's Node**

**Before Fix**: Going to today's node adds Year, Month and Day nodes to visited history.
![before_fix_history](https://user-images.githubusercontent.com/13846618/74097245-e8d46080-4b2f-11ea-96d6-16629246b22c.gif)

**After Fix**: Just add Day node to visited nodes history.
![after_fix_history](https://user-images.githubusercontent.com/13846618/74097249-eeca4180-4b2f-11ea-8673-14d73c471f71.gif)
