### PR TITLE
export as pdf, the picture is blurry

### DIFF
--- a/modules/support.py
+++ b/modules/support.py
@@ -1068,7 +1068,7 @@ def dialog_image_handle(father_win, title, original_pixbuf):
         spinbutton_height.set_value(img_parms.height)
         if img_parms.width <= 900 and img_parms.height <= 600:
             # original size into the dialog
-            pixbuf = img_parms.original_pixbuf.scale_simple(int(img_parms.width), int(img_parms.height), gtk.gdk.INTERP_BILINEAR)
+            pixbuf = img_parms.original_pixbuf.scale_simple(int(img_parms.width), int(img_parms.height), gtk.gdk.INTERP_HYPER)
         else:
             # reduced size visible into the dialog
             if img_parms.width > 900:
@@ -1077,7 +1077,7 @@ def dialog_image_handle(father_win, title, original_pixbuf):
             else:
                 img_parms_height = 600
                 img_parms_width = img_parms_height * img_parms.image_w_h_ration
-            pixbuf = img_parms.original_pixbuf.scale_simple(int(img_parms_width), int(img_parms_height), gtk.gdk.INTERP_BILINEAR)
+            pixbuf = img_parms.original_pixbuf.scale_simple(int(img_parms_width), int(img_parms_height), gtk.gdk.INTERP_HYPER)
         image.set_from_pixbuf(pixbuf)
     def on_button_rotate_90_cw_clicked(*args):
         img_parms.original_pixbuf = img_parms.original_pixbuf.rotate_simple(270)
@@ -1122,7 +1122,7 @@ def dialog_image_handle(father_win, title, original_pixbuf):
     response = dialog.run()
     dialog.hide()
     if response != gtk.RESPONSE_ACCEPT: return None
-    return img_parms.original_pixbuf.scale_simple(int(img_parms.width), int(img_parms.height), gtk.gdk.INTERP_BILINEAR)
+    return img_parms.original_pixbuf.scale_simple(int(img_parms.width), int(img_parms.height), gtk.gdk.INTERP_HYPER)
 
 def dialog_question_warning(father_win, warning_label):
     """Question with Warning"""


### PR DESCRIPTION
resolved #60
resolved #119 
resolved #420

- pixbuf.scale_simple with INTERP_HYPER couldn't improve the situation, so scaling is done by cairo.
- a page-wide image could cross the page right border (because of curr_x > 0), now it is taken into account.
-  I tried to used cairo for scaling during an `insert/edit image` operation, but didn't see the difference between cairo and pixbuf.scale_simple, so left it as is.
