### PR TITLE
Importing KeepNote to your cherry project take a long time

### DIFF
--- a/modules/imports.py
+++ b/modules/imports.py
@@ -366,7 +366,7 @@ class KeepnoteHandler(HTMLParser.HTMLParser):
         self.nodes_list[-1].appendChild(dom_iter)
         text_iter = self.dom.createTextNode(text_data)
         dom_iter.appendChild(text_iter)
-        self.prev_attributes = self.curr_attributes
+        self.prev_attributes = self.curr_attributes.copy()
 
     def start_parsing(self):
         """Start the Parsing"""

--- a/modules/imports.py
+++ b/modules/imports.py
@@ -340,16 +340,39 @@ class KeepnoteHandler(HTMLParser.HTMLParser):
         self.dad = dad
         self.folderpath = folderpath
         self.xml_handler = machines.XMLHandler(self)
+        self.prev_attributes = {}
+        self.prev_accumulator = []
 
     def rich_text_serialize(self, text_data):
         """Appends a new part to the XML rich text"""
+        # special condition when a lot of spaces and &nbsp;
+        # don't create a new element but add to the previous
+        #if text_data == u' ' or text_data == u'\xa0':
+            # if last element is made of spaces
+        #    if self.nodes_list[-1].lastChild.firstChild.data.replace(u' ', u'') == u'':
+        #        self.nodes_list[-1].lastChild.firstChild.data += u' '
+        #        return
+        # accumulate data (+= string is to slow) to udpate element lately
+        if self.prev_attributes == self.curr_attributes:
+            if self.nodes_list[-1].lastChild != None:
+                self.prev_accumulator.append(text_data)
+                return
+
+        # attributes changes, so finally can update prev element
+        if (self.prev_accumulator):
+            self.nodes_list[-1].lastChild.firstChild.data += "".join(self.prev_accumulator)
+            self.prev_accumulator = []
+
         dom_iter = self.dom.createElement("rich_text")
+        if self.curr_attributes:
         for tag_property in cons.TAG_PROPERTIES:
+                if tag_property in self.curr_attributes:
             if self.curr_attributes[tag_property] != "":
                 dom_iter.setAttribute(tag_property, self.curr_attributes[tag_property])
         self.nodes_list[-1].appendChild(dom_iter)
         text_iter = self.dom.createTextNode(text_data)
         dom_iter.appendChild(text_iter)
+        self.prev_attributes = self.curr_attributes
 
     def start_parsing(self):
         """Start the Parsing"""
@@ -377,12 +400,19 @@ class KeepnoteHandler(HTMLParser.HTMLParser):
         self.curr_state = 0
         # curr_state 0: standby, taking no data
         # curr_state 1: waiting for node content, take many data
-        for tag_property in cons.TAG_PROPERTIES: self.curr_attributes[tag_property] = ""
+        #for tag_property in cons.TAG_PROPERTIES: self.curr_attributes[tag_property] = ""
+        self.curr_attributes = {}
+        self.prev_attributes = {}
+        self.prev_accumulator = []
         self.latest_span = []
         self.pixbuf_vector = []
         self.curr_folder = node_folder
         self.chars_counter = 0
         self.feed(node_string.decode(cons.STR_UTF8, cons.STR_IGNORE))
+        # after parsing
+        if (self.prev_accumulator):
+            self.nodes_list[-1].lastChild.firstChild.data += "".join(self.prev_accumulator)
+
         for pixbuf_element in self.pixbuf_vector:
             self.xml_handler.pixbuf_element_to_xml(pixbuf_element, self.nodes_list[-1], self.dom)
         # check if the node has children

--- a/modules/imports.py
+++ b/modules/imports.py
@@ -358,10 +358,11 @@ class KeepnoteHandler(HTMLParser.HTMLParser):
 
         dom_iter = self.dom.createElement("rich_text")
         if self.curr_attributes:
-        for tag_property in cons.TAG_PROPERTIES:
+            for tag_property in cons.TAG_PROPERTIES:
                 if tag_property in self.curr_attributes:
-            if self.curr_attributes[tag_property] != "":
-                dom_iter.setAttribute(tag_property, self.curr_attributes[tag_property])
+                    if self.curr_attributes[tag_property] != "":
+                        dom_iter.setAttribute(tag_property, self.curr_attributes[tag_property])
+                        
         self.nodes_list[-1].appendChild(dom_iter)
         text_iter = self.dom.createTextNode(text_data)
         dom_iter.appendChild(text_iter)

--- a/modules/imports.py
+++ b/modules/imports.py
@@ -345,13 +345,6 @@ class KeepnoteHandler(HTMLParser.HTMLParser):
 
     def rich_text_serialize(self, text_data):
         """Appends a new part to the XML rich text"""
-        # special condition when a lot of spaces and &nbsp;
-        # don't create a new element but add to the previous
-        #if text_data == u' ' or text_data == u'\xa0':
-            # if last element is made of spaces
-        #    if self.nodes_list[-1].lastChild.firstChild.data.replace(u' ', u'') == u'':
-        #        self.nodes_list[-1].lastChild.firstChild.data += u' '
-        #        return
         # accumulate data (+= string is to slow) to udpate element lately
         if self.prev_attributes == self.curr_attributes:
             if self.nodes_list[-1].lastChild != None:


### PR DESCRIPTION
Resolve #643
It's quite big changes in core but one of them fixes a serious issue. Sorry, for the long text.

 There are two problems:
1.  **Really slow inserting of new nodes**. The problem is with finding a spare id, the algorithm `node_id_get` has O(n^2), when there are 20 nodes - it is fast, when 200 - it takes a second, when 800 - hmm.
So, firstly, I made it O(n) by finding max_node_id without checking every id.
Secondly, if it's import, first node uses (max_node_id + 1), second gets +1 without checking the whole tree (only checking `nodes_to_rm_set` just in case)
As a result 800 nodes are inserted in less a second. I think it will also make difference for other imports.
2. **Eating gigabits of memory by creating a lot of xml elements**. One of KeepNote documents is huge (5mb) and has a lot of space symbols and tags which generate a lot of elements. Because mostly elements have the same attributes, I can use the same xml element other and other without creating a new one. I has to use accumulator because just adding text by += is unbelievably slow.
