### PR TITLE
Add Collapse and Expand functionality in node tree of exported HTML

### DIFF
--- a/glade/script.js
+++ b/glade/script.js
@@ -1,7 +1,36 @@
 function changeFrame(file_path){
-	console.log(file_path);
 	var iframe = document.getElementById("page_frame");
 	iframe.src = file_path;
+}
+
+function toggleSubTree(element){
+	var nextSibling = element.parentElement.nextElementSibling;
+	if(nextSibling.tagName == 'UL'){
+		nextSibling.classList.toggle('hide');
+		if(element.textContent == '+'){
+			element.textContent = '-'
+		}else{
+			element.textContent = '+'
+		}
+	}
+}
+
+function expandAllSubtrees(element){
+	var subtrees = document.getElementsByClassName("subtree");
+	for(var i=0; i<subtrees.length; i++){
+		var subtree = subtrees[i];
+		subtree.classList.remove('hide');
+		subtree.previousElementSibling.firstChild.textContent = '-';
+	}
+}
+
+function collapseAllSubtrees(element){
+	var subtrees = document.getElementsByClassName("subtree");
+	for(var i=0; i<subtrees.length; i++){
+		var subtree = subtrees[i];
+		subtree.classList.add('hide');
+		subtree.previousElementSibling.firstChild.textContent = '+';
+	}
 }
 
 window.onload = function(){ 

--- a/glade/styles.css
+++ b/glade/styles.css
@@ -79,6 +79,7 @@ iframe.page {
 div.tree {
     font-size: 12px;
     color: #666666;
+    border-right: 3px solid;
 }
 
 div.tree a, div.tree a:visited {
@@ -90,24 +91,27 @@ div.tree a:hover {
     text-decoration: underline;
 }
 
-div.tree ol {
-    padding-left: 1em;
-    list-style-type: square;
+div.tree ul {
+    padding-inline-start: 20px;
+    list-style-type: none;
 }
 
-div.tree ol ol {
-    list-style-type: circle;
+div.tree ul.outermost {
+    padding-inline-start: 0;
 }
 
-div.tree ol ol ol {
-    list-style-type: disc;
+div.tree li {
+    padding-inline-start: 0;
 }
-
-div.tree ol ol ol ol, div.tree ol ol ol ol ol, div.tree ol ol ol ol ol ol {
-    list-style-type: disc;
+div.tree li.leaf {
+    padding-inline-start: 10px;
 }
 
 div.tree a.show, div.tree a.hide { display: none; }
+
+.hide {
+    display: none;
+}
 
 /*******************************************************************************
  * NODE PAGES

--- a/glade/styles.css
+++ b/glade/styles.css
@@ -94,6 +94,7 @@ div.tree a:hover {
 div.tree ul {
     padding-inline-start: 20px;
     list-style-type: none;
+    line-height: 0.3;
 }
 
 div.tree ul.outermost {
@@ -105,6 +106,7 @@ div.tree li {
 }
 div.tree li.leaf {
     padding-inline-start: 10px;
+    line-height: 2;
 }
 
 div.tree a.show, div.tree a.hide { display: none; }

--- a/modules/exports.py
+++ b/modules/exports.py
@@ -652,9 +652,9 @@ class Export2Html:
         child_tree_iter = self.dad.treestore.iter_children(tree_iter)
         if(not child_tree_iter):
             return '''<li class="leaf"><a href="#" onclick="changeFrame('%s')">%s</a></li>\n''' % (href, node_name)
-        html = '''<li><button onclick="toggleSubTree(this)">+</button> <a href="#" onclick="changeFrame('%s')">%s</a></li>
+        html = '''<li><button onclick="toggleSubTree(this)">-</button> <a href="#" onclick="changeFrame('%s')">%s</a></li>
 ''' % (href, node_name)
-        html += '<ul class="hide subtree">\n'
+        html += '<ul class="subtree">\n'
         while child_tree_iter:
             html += self.tree_links_text_iter(child_tree_iter)
             child_tree_iter = self.dad.treestore.iter_next(child_tree_iter)


### PR DESCRIPTION
When exporting tree to HTML, by default all the nodes are collapsed,
and the collapsed nodes have a '+' button which can be clicked to expand the
node.
* Expand/Collapse nodes in HTML
* ExpandAll/CollapseAll buttons included

![improve_tree_in_exported_html](https://user-images.githubusercontent.com/13846618/74584026-a01b1c80-4ff3-11ea-9e22-dfc9a2472715.gif)
