### PR TITLE
(Port to C++) Undo\Redo

### DIFF
--- a/future/Makefile.am
+++ b/future/Makefile.am
@@ -73,7 +73,8 @@ COMMON_SOURCES = \
 	src/ct/ct_imports.cc \
 	src/ct/ct_widgets.cc \
 	src/ct/ct_print.cc \
-	src/ct/ct_export.cc
+        src/ct/ct_export.cc \
+        src/ct/ct_state_machine.cc
 
 cherrytree_SOURCES = \
 	src/ct/ct_main.cc \

--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -105,7 +105,7 @@ public:
 private:
     // helpers for tree actions
     void          _node_add(bool duplicate, bool add_child);
-    void          _node_add_with_data(Gtk::TreeIter curr_iter, CtNodeData& nodeData, bool add_child);
+    void          _node_add_with_data(Gtk::TreeIter curr_iter, CtNodeData& nodeData, bool add_child, std::shared_ptr<CtNodeState> node_state);
     void          _node_child_exist_or_create(Gtk::TreeIter parentIter, const std::string& nodeName);
     void          _node_move_after(Gtk::TreeIter iter_to_move, Gtk::TreeIter father_iter,
                                    Gtk::TreeIter brother_iter = Gtk::TreeIter(), bool set_first = false);

--- a/future/src/ct/ct_actions_edit.cc
+++ b/future/src/ct/ct_actions_edit.cc
@@ -34,14 +34,26 @@ void CtActions::insert_spec_char_action(gunichar ch)
     proof.text_buffer->insert_at_cursor(Glib::ustring(1, ch));
 }
 
+// Step Back for the Current Node, if Possible
 void CtActions::requested_step_back()
 {
-    // todo
+    if (!_pCtMainWin->curr_tree_iter()) return;
+    if (not _is_curr_node_not_read_only_or_error()) return;
+
+    auto step_back = _pCtMainWin->get_state_machine().requested_state_previous(_pCtMainWin->curr_tree_iter().get_node_id());
+    if (step_back)
+        _pCtMainWin->load_buffer_from_state(step_back, _pCtMainWin->curr_tree_iter());
 }
 
+// Step Ahead for the Current Node, if Possible
 void CtActions::requested_step_ahead()
 {
-    // todo
+    if (!_pCtMainWin->curr_tree_iter()) return;
+    if (not _is_curr_node_not_read_only_or_error()) return;
+
+    auto step_ahead = _pCtMainWin->get_state_machine().requested_state_subsequent(_pCtMainWin->curr_tree_iter().get_node_id());
+    if (step_ahead)
+        _pCtMainWin->load_buffer_from_state(step_ahead, _pCtMainWin->curr_tree_iter());
 }
 
 // Insert/Edit Image

--- a/future/src/ct/ct_actions_edit.cc
+++ b/future/src/ct/ct_actions_edit.cc
@@ -93,10 +93,10 @@ void CtActions::codebox_handle()
                                           (int)_pCtMainWin->get_ct_config()->codeboxWidth,
                                           (int)_pCtMainWin->get_ct_config()->codeboxHeight,
                                           iter_insert.get_offset(),
-                                          justification);
-    pCtCodebox->set_width_in_pixels(_pCtMainWin->get_ct_config()->codeboxWidthPixels);
-    pCtCodebox->set_highlight_brackets(_pCtMainWin->get_ct_config()->codeboxMatchBra);
-    pCtCodebox->set_show_line_numbers(_pCtMainWin->get_ct_config()->codeboxLineNum);
+                                          justification,
+                                          _pCtMainWin->get_ct_config()->codeboxWidthPixels,
+                                          _pCtMainWin->get_ct_config()->codeboxMatchBra,
+                                          _pCtMainWin->get_ct_config()->codeboxLineNum);
     Glib::RefPtr<Gsv::Buffer> gsv_buffer = Glib::RefPtr<Gsv::Buffer>::cast_dynamic(_curr_buffer());
     pCtCodebox->insertInTextBuffer(gsv_buffer);
 

--- a/future/src/ct/ct_actions_edit.cc
+++ b/future/src/ct/ct_actions_edit.cc
@@ -232,7 +232,7 @@ void CtActions::text_row_delete()
     CtTextRange range = CtList(_pCtMainWin, proof.text_buffer).get_paragraph_iters();
     if (not range.iter_end.forward_char() and !range.iter_start.backward_char()) return;
     proof.text_buffer->erase(range.iter_start, range.iter_end);
-    // todo: self.state_machine.update_state()
+    _pCtMainWin->get_state_machine().update_state();
 }
 
 // Duplicates the Whole Row or a Selection
@@ -297,7 +297,7 @@ void CtActions::text_row_selection_duplicate()
             }
         }
     }
-    // todo: self.state_machine.update_state()
+    _pCtMainWin->get_state_machine().update_state();
 }
 
 // Moves Up the Current Row/Selected Rows
@@ -380,7 +380,7 @@ void CtActions::text_row_up()
         // selection
         proof.text_view->set_selection_at_offset_n_delta(destination_offset, diff_offsets-1);
     }
-    // todo: self.state_machine.update_state()
+    _pCtMainWin->get_state_machine().update_state();
 }
 
 // Moves Down the Current Row/Selected Rows
@@ -473,7 +473,7 @@ void CtActions::text_row_down()
         else
             proof.text_view->set_selection_at_offset_n_delta(destination_offset+1, diff_offsets-2);
     }
-    // self.state_machine.update_state()
+    _pCtMainWin->get_state_machine().update_state();
 }
 
 // Remove trailing spaces/tabs

--- a/future/src/ct/ct_actions_export.cc
+++ b/future/src/ct/ct_actions_export.cc
@@ -146,7 +146,7 @@ void CtActions::_export_to_html(Glib::ustring auto_path, bool auto_overwrite)
             if (_pCtMainWin->get_curr_doc_file_type() == CtDocType::SQLite && _pCtMainWin->curr_tree_iter())
             {
                 _pCtMainWin->get_state_machine().update_state();
-                _pCtMainWin->objects_buffer_refresh();
+                // todo: _pCtMainWin->objects_buffer_refresh();
             }
         }
     }
@@ -160,7 +160,7 @@ void CtActions::_export_to_html(Glib::ustring auto_path, bool auto_overwrite)
             if (_pCtMainWin->get_curr_doc_file_type() == CtDocType::SQLite && _pCtMainWin->curr_tree_iter())
             {
                 _pCtMainWin->get_state_machine().update_state();
-                _pCtMainWin->objects_buffer_refresh();
+                // todo: _pCtMainWin->objects_buffer_refresh();
             }
         }
     }

--- a/future/src/ct/ct_actions_export.cc
+++ b/future/src/ct/ct_actions_export.cc
@@ -140,21 +140,29 @@ void CtActions::_export_to_html(Glib::ustring auto_path, bool auto_overwrite)
     {
         Glib::ustring folder_name = CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter());
         if (export2html.prepare_html_folder("", folder_name, false))
+        {
             export2html.nodes_all_export_to_html(false, _export_options);
-        // todo:
-        // if self.filetype in ["b", "x"] and self.curr_tree_iter:
-        //   self.state_machine.update_state()
-        //   self.objects_buffer_refresh()
+            // todo: why is it here? need to remove?
+            if (_pCtMainWin->get_curr_doc_file_type() == CtDocType::SQLite && _pCtMainWin->curr_tree_iter())
+            {
+                _pCtMainWin->get_state_machine().update_state();
+                _pCtMainWin->objects_buffer_refresh();
+            }
+        }
     }
     else if (export_type == CtDialogs::CtProcessNode::ALL_TREE)
     {
         Glib::ustring folder_name = _pCtMainWin->get_curr_doc_file_name();
         if (export2html.prepare_html_folder(auto_path, folder_name, auto_overwrite))
+        {
             export2html.nodes_all_export_to_html(true, _export_options);
-        // todo:
-        // if self.filetype in ["b", "x"] and self.curr_tree_iter:
-        //     self.state_machine.update_state()
-        //     self.objects_buffer_refresh()
+            // todo: why is it here? need to remove?
+            if (_pCtMainWin->get_curr_doc_file_type() == CtDocType::SQLite && _pCtMainWin->curr_tree_iter())
+            {
+                _pCtMainWin->get_state_machine().update_state();
+                _pCtMainWin->objects_buffer_refresh();
+            }
+        }
     }
     else if (export_type == CtDialogs::CtProcessNode::SELECTED_TEXT)
     {

--- a/future/src/ct/ct_actions_file.cc
+++ b/future/src/ct/ct_actions_file.cc
@@ -40,7 +40,7 @@ void CtActions::_file_save(const bool run_vacuum)
                  _file_write(doc_filepath, _pCtMainWin->get_curr_doc_password(), false/*firstWrite*/, nullptr/*ppReturnCtSQLite*/, run_vacuum) )
             {
                 _pCtMainWin->update_window_save_not_needed();
-                // ? self.state_machine.update_state()
+                _pCtMainWin->get_state_machine().update_state();
             }
             _pCtMainWin->curr_file_mod_time_update_value(true/*doEnable*/);
         }
@@ -100,7 +100,7 @@ void CtActions::file_save_as()
         _pCtMainWin->set_new_curr_doc(filepath, storageSelArgs.password, pReturnCtSQLite);
         // support.add_recent_document(self, filepath)
         _pCtMainWin->update_window_save_not_needed();
-        // ? self.state_machine.update_state()
+        _pCtMainWin->get_state_machine().update_state();
     }
     _pCtMainWin->curr_file_mod_time_update_value(true/*doEnable*/);
 }

--- a/future/src/ct/ct_actions_find.cc
+++ b/future/src/ct/ct_actions_find.cc
@@ -909,8 +909,7 @@ bool CtActions::_find_pattern(CtTreeIter tree_iter, Glib::RefPtr<Gtk::TextBuffer
         text_buffer->insert_at_cursor(replacer_text);
         if (!all_matches)
             _pCtMainWin->get_text_view().set_selection_at_offset_n_delta(match_offsets.first + num_objs, (int)replacer_text.size());
-        // todo:
-        //self.dad.state_machine.update_state();
+        _pCtMainWin->get_state_machine().update_state();
         tree_iter.pending_edit_db_node_buff();
     }
     return true;

--- a/future/src/ct/ct_clipboard.cc
+++ b/future/src/ct/ct_clipboard.cc
@@ -246,7 +246,7 @@ void CtClipboard::from_xml_string_to_buffer(Glib::RefPtr<Gtk::TextBuffer> text_b
     {
         throw std::invalid_argument("rich text from clipboard error");
     }
-    //todo: self.dad.state_machine.not_undoable_timeslot_set(True)
+    _pCtMainWin->get_state_machine().not_undoable_timeslot_set(true);
     std::list<CtAnchoredWidget*> widgets;
     for (xmlpp::Node* slot_node: doc->get_root_node()->get_children())
     {
@@ -264,9 +264,9 @@ void CtClipboard::from_xml_string_to_buffer(Glib::RefPtr<Gtk::TextBuffer> text_b
         _get_CtMainWin()->curr_tree_store().addAnchoredWidgets(
                     _get_CtMainWin()->curr_tree_iter(),
                     widgets, &_get_CtMainWin()->get_text_view());
-        // ? self.state_machine.update_state()
+        _pCtMainWin->get_state_machine().update_state();
     }
-    // todo: self.dad.state_machine.not_undoable_timeslot_set(False)
+    _pCtMainWin->get_state_machine().not_undoable_timeslot_set(false);
 }
 
 // Write the Selected Content to the Clipboard
@@ -489,7 +489,7 @@ void CtClipboard::_on_received_to_codebox(const Gtk::SelectionData& selection_da
         _get_CtMainWin()->curr_tree_store().addAnchoredWidgets(
                     _get_CtMainWin()->curr_tree_iter(),
                     widgets, &_get_CtMainWin()->get_text_view());
-        // ? self.state_machine.update_state()
+        _pCtMainWin->get_state_machine().update_state();
     }
     pTextView->scroll_to(pTextView->get_buffer()->get_insert());
 }
@@ -522,7 +522,7 @@ void CtClipboard::_on_received_to_table(const Gtk::SelectionData& selection_data
         _get_CtMainWin()->curr_tree_store().addAnchoredWidgets(
                     _get_CtMainWin()->curr_tree_iter(),
                     widgets, &_get_CtMainWin()->get_text_view());
-        // ? self.state_machine.update_state()
+        _pCtMainWin->get_state_machine().update_state();
     }
 
     pTextView->scroll_to(pTextView->get_buffer()->get_insert());

--- a/future/src/ct/ct_codebox.cc
+++ b/future/src/ct/ct_codebox.cc
@@ -136,6 +136,14 @@ CtCodebox::CtCodebox(CtMainWin* pCtMainWin,
         }
         return false;
     });
+    _ctTextview.get_buffer()->signal_insert().connect([this](const Gtk::TextBuffer::iterator& pos, const Glib::ustring& text, int bytes) {
+        if (_pCtMainWin->user_active())
+            _pCtMainWin->get_state_machine().text_variation(_pCtMainWin->curr_tree_iter().get_node_id(), text);
+    });
+    _ctTextview.get_buffer()->signal_erase().connect([this](const Gtk::TextBuffer::iterator& range_start, const Gtk::TextBuffer::iterator& range_end) {
+        if (_pCtMainWin->user_active())
+          _pCtMainWin->get_state_machine().text_variation(_pCtMainWin->curr_tree_iter().get_node_id(), range_start.get_text(range_end));
+    });
     _uCtPairCodeboxMainWin.reset(new CtPairCodeboxMainWin{this, _pCtMainWin});
     g_signal_connect(G_OBJECT(_ctTextview.gobj()), "cut-clipboard", G_CALLBACK(CtClipboard::on_cut_clipboard), _uCtPairCodeboxMainWin.get());
     g_signal_connect(G_OBJECT(_ctTextview.gobj()), "copy-clipboard", G_CALLBACK(CtClipboard::on_copy_clipboard), _uCtPairCodeboxMainWin.get());

--- a/future/src/ct/ct_codebox.cc
+++ b/future/src/ct/ct_codebox.cc
@@ -73,7 +73,10 @@ CtCodebox::CtCodebox(CtMainWin* pCtMainWin,
                      const int frameWidth,
                      const int frameHeight,
                      const int charOffset,
-                     const std::string& justification)
+                     const std::string& justification,
+                     const bool widthInPixels,
+                     const bool highlightBrackets,
+                     const bool showLineNumbers)
  : CtAnchoredWidget(pCtMainWin, charOffset, justification),
    CtTextCell(pCtMainWin, textContent, syntaxHighlighting),
    _frameWidth(frameWidth),
@@ -88,6 +91,10 @@ CtCodebox::CtCodebox(CtMainWin* pCtMainWin,
     show_all();
 
     _ctTextview.set_monospace(true); // todo: remove than styles are implemented
+
+    set_width_in_pixels(widthInPixels);
+    set_highlight_brackets(highlightBrackets);
+    set_show_line_numbers(showLineNumbers);
 
     // signals
     _ctTextview.signal_populate_popup().connect([this](Gtk::Menu* menu){
@@ -192,6 +199,30 @@ bool CtCodebox::to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_a
         sqlite3_finalize(p_stmt);
     }
     return retVal;
+}
+
+CtAnchoredWidget* CtCodebox::clone()
+{
+    return new CtCodebox(_pCtMainWin, get_text_content(), _syntaxHighlighting, _frameWidth, _frameHeight,
+                         _charOffset, _justification,
+                         _widthInPixels, _highlightBrackets, _showLineNumbers);
+}
+
+bool CtCodebox::equal(CtAnchoredWidget* other)
+{
+    if (get_type() != other->get_type()) return false;
+    if (CtCodebox* other_codebox = dynamic_cast<CtCodebox*>(other))
+        if (_syntaxHighlighting == other_codebox->_syntaxHighlighting
+            && _frameWidth == other_codebox->_frameWidth
+            && _frameHeight == other_codebox->_frameHeight
+            && _charOffset == other_codebox->_charOffset
+            && _justification == other_codebox->_justification
+            && _widthInPixels == other_codebox->_widthInPixels
+            && _highlightBrackets == other_codebox->_highlightBrackets
+            && _showLineNumbers == other_codebox->_showLineNumbers
+            && get_text_content() == other_codebox->get_text_content())
+        return true;
+    return false;
 }
 
 void CtCodebox::set_show_line_numbers(const bool showLineNumbers)

--- a/future/src/ct/ct_codebox.h
+++ b/future/src/ct/ct_codebox.h
@@ -66,7 +66,10 @@ public:
               const int frameWidth,
               const int frameHeight,
               const int charOffset,
-              const std::string& justification);
+              const std::string& justification,
+              const bool widthInPixels,
+              const bool highlightBrackets,
+              const bool showLineNumbers);
     virtual ~CtCodebox();
 
     void apply_width_height(const int parentTextWidth) override;
@@ -74,6 +77,8 @@ public:
     bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) override;
     void set_modified_false() override { set_text_buffer_modified_false(); }
     CtAnchWidgType get_type() override { return CtAnchWidgType::CodeBox; }
+    CtAnchoredWidget* clone() override;
+    bool equal(CtAnchoredWidget* other) override;
 
     void set_width_height(int newWidth, int newHeight);
     void set_width_in_pixels(const bool widthInPixels) { _widthInPixels = widthInPixels; }

--- a/future/src/ct/ct_config.cc
+++ b/future/src/ct/ct_config.cc
@@ -335,7 +335,7 @@ void CtConfig::_populate_data_from_keyfile()
             savedFromPyGtk = true;
         }
     }
-    for (guint i=0; i<recentDocsFilepaths.maxSize; ++i)
+    for (int i=0; i<recentDocsFilepaths.maxSize; ++i)
     {
         snprintf(_tempKey, _maxTempKeySize, "doc_%d", i);
         std::string filepath;

--- a/future/src/ct/ct_image.cc
+++ b/future/src/ct/ct_image.cc
@@ -72,6 +72,17 @@ CtImage::~CtImage()
 {
 }
 
+bool CtImage::equal(CtAnchoredWidget* other)
+{
+    if (get_type() != other->get_type()) return false;
+    if (CtImage* other_image = dynamic_cast<CtImage*>(other))
+        if (_rPixbuf == other_image->_rPixbuf
+                && _charOffset == other_image->_charOffset
+                && _justification == other_image->_justification)
+            return true;
+    return false;
+}
+
 void CtImage::save(const Glib::ustring& file_name, const Glib::ustring& type)
 {
     _rPixbuf->save(file_name, type);
@@ -152,6 +163,20 @@ bool CtImagePng::to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_
         sqlite3_finalize(p_stmt);
     }
     return retVal;
+}
+
+CtAnchoredWidget* CtImagePng::clone()
+{
+    return new CtImagePng(_pCtMainWin, _rPixbuf, _link, _charOffset, _justification);
+}
+
+bool CtImagePng::equal(CtAnchoredWidget* other)
+{
+    if (get_type() != other->get_type()) return false;
+    if (CtImagePng* other_png = dynamic_cast<CtImagePng*>(other))
+        if (CtImage::equal(other) && _link == other_png->_link)
+            return true;
+    return false;
 }
 
 void CtImagePng::update_label_widget()
@@ -237,6 +262,21 @@ bool CtImageAnchor::to_sqlite(sqlite3* pDb, const gint64 node_id, const int offs
     return retVal;
 }
 
+CtAnchoredWidget* CtImageAnchor::clone()
+{
+    return new CtImageAnchor(_pCtMainWin, _anchorName, _charOffset, _justification);
+}
+
+bool CtImageAnchor::equal(CtAnchoredWidget* other)
+{
+    if (get_type() != other->get_type()) return false;
+    if (CtImageAnchor* other_anchor = dynamic_cast<CtImageAnchor*>(other))
+        if (CtImage::equal(other) && _anchorName == other_anchor->_anchorName)
+            return true;
+    return false;
+}
+
+
 void CtImageAnchor::update_tooltip()
 {
     set_tooltip_text(_anchorName);
@@ -310,6 +350,23 @@ bool CtImageEmbFile::to_sqlite(sqlite3* pDb, const gint64 node_id, const int off
         sqlite3_finalize(p_stmt);
     }
     return retVal;
+}
+
+CtAnchoredWidget* CtImageEmbFile::clone()
+{
+    return new CtImageEmbFile(_pCtMainWin, _fileName, _rawBlob, _timeSeconds, _charOffset, _justification);
+}
+
+bool CtImageEmbFile::equal(CtAnchoredWidget* other)
+{
+    if (get_type() != other->get_type()) return false;
+    if (CtImageEmbFile* other_emb = dynamic_cast<CtImageEmbFile*>(other))
+        if (CtImage::equal(other)
+                && _fileName == other_emb->_fileName
+                && _rawBlob == other_emb->_rawBlob
+                && _timeSeconds == other_emb->_timeSeconds)
+            return true;
+    return false;
 }
 
 void CtImageEmbFile::update_label_widget()

--- a/future/src/ct/ct_image.h
+++ b/future/src/ct/ct_image.h
@@ -47,6 +47,7 @@ public:
 
     void apply_width_height(const int /*parentTextWidth*/) override {}
     void set_modified_false() override {}
+    bool equal(CtAnchoredWidget* other) override;
 
     void save(const Glib::ustring& file_name, const Glib::ustring& type);
     Glib::RefPtr<Gdk::Pixbuf> get_pixbuf() { return _rPixbuf; }
@@ -74,6 +75,8 @@ public:
     void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment) override;
     bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) override;
     CtAnchWidgType get_type() override { return CtAnchWidgType::ImagePng; }
+    CtAnchoredWidget* clone() override;
+    bool equal(CtAnchoredWidget* other) override;
 
     const std::string get_raw_blob();
     void update_label_widget();
@@ -99,6 +102,8 @@ public:
     void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment) override;
     bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) override;
     CtAnchWidgType get_type() override { return CtAnchWidgType::ImageAnchor; }
+    CtAnchoredWidget* clone() override;
+    bool equal(CtAnchoredWidget* other) override;
 
     const Glib::ustring& get_anchor_name() { return _anchorName; }
 
@@ -125,6 +130,8 @@ public:
     void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment) override;
     bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) override;
     CtAnchWidgType get_type() override { return CtAnchWidgType::ImageEmbFile; }
+    CtAnchoredWidget* clone() override;
+    bool equal(CtAnchoredWidget* other) override;
 
     const Glib::ustring& get_file_name() { return _fileName; }
     const std::string&   get_raw_blob() { return _rawBlob; }

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -964,7 +964,8 @@ void CtMainWin::update_window_save_needed(const CtSaveNeededUpdType update_type,
             std::vector<gint64> rm_node_ids = treeIter.get_children_node_ids();
             rm_node_ids.push_back(top_node_id);
             _uCtTreestore->pending_rm_db_nodes(rm_node_ids);
-            get_state_machine().delete_states(rm_node_ids);
+            for (auto node_id: rm_node_ids)
+                get_state_machine().delete_states(node_id);
         } break;
         case CtSaveNeededUpdType::book:
         {
@@ -984,7 +985,7 @@ void CtMainWin::_on_treeview_cursor_changed()
         {
             _fileSaveNeeded = true;
             rTextBuffer->set_modified(false);
-            get_state_machine().update_state(_prevTreeIter.get_node_id());
+            get_state_machine().update_state(_prevTreeIter);
         }
     }
     CtTreeIter treeIter = curr_tree_iter();

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -47,7 +47,8 @@ CtMainWin::CtMainWin(CtConfig*        pCtConfig,
    _rGtkCssProvider(rGtkCssProvider),
    _pGsvLanguageManager(pGsvLanguageManager),
    _pGsvStyleSchemeManager(pGsvStyleSchemeManager),
-   _ctTextview(this)
+   _ctTextview(this),
+   _ctStateMachine(this)
 {
     set_icon(_pGtkIconTheme->load_icon(CtConst::APP_NAME, 48));
     _scrolledwindowTree.set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC);
@@ -708,8 +709,7 @@ bool CtMainWin::reset(const bool force_reset)
     _set_new_curr_doc(Glib::RefPtr<Gio::File>{nullptr}, "");
 
     update_window_save_not_needed();
-    //todo
-    //self.state_machine.reset()
+    get_state_machine().reset();
     return true;
 }
 
@@ -964,8 +964,7 @@ void CtMainWin::update_window_save_needed(const CtSaveNeededUpdType update_type,
             std::vector<gint64> rm_node_ids = treeIter.get_children_node_ids();
             rm_node_ids.push_back(top_node_id);
             _uCtTreestore->pending_rm_db_nodes(rm_node_ids);
-            //todo
-            //self.state_machine.delete_states(node_id) 
+            get_state_machine().delete_states(rm_node_ids);
         } break;
         case CtSaveNeededUpdType::book:
         {
@@ -985,7 +984,7 @@ void CtMainWin::_on_treeview_cursor_changed()
         {
             _fileSaveNeeded = true;
             rTextBuffer->set_modified(false);
-            //self.state_machine.update_state()
+            get_state_machine().update_state(_prevTreeIter.get_node_id());
         }
     }
     CtTreeIter treeIter = curr_tree_iter();
@@ -1274,7 +1273,7 @@ void CtMainWin::_on_textview_event_after(GdkEvent* event)
         if (curr_tree_iter() and curr_tree_iter().get_node_syntax_highlighting() == CtConst::RICH_TEXT_ID and
             not curr_buffer()->get_modified())
         {
-            // todo: self.state_machine.update_curr_state_cursor_pos(self.treestore[self.curr_tree_iter][3])
+            get_state_machine().update_curr_state_cursor_pos(curr_tree_iter().get_node_id());
         }
         if (event->type == GDK_BUTTON_PRESS)
         {

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -992,12 +992,9 @@ void CtMainWin::load_buffer_from_state(std::shared_ptr<CtNodeState> state, CtTre
 
     text_buffer->erase(text_buffer->begin(), text_buffer->end());
     std::list<CtAnchoredWidget*> widgets;
-    for (xmlpp::Node* slot_node: state->node_xml.get_root_node()->get_children())
+    for (xmlpp::Node* text_node: state->buffer_xml.get_root_node()->get_children())
     {
-        if (slot_node->get_name() != "slot")
-            continue;
-        for (xmlpp::Node* child_node: slot_node->get_children())
-            CtXmlRead(this).get_text_buffer_slot(gsv_buffer, nullptr, widgets, child_node);
+        CtXmlRead(this).get_text_buffer_slot(gsv_buffer, nullptr, widgets, text_node);
     }
     tree_iter.remove_all_embedded_widgets();
     // CtXmlRead(this).get_text_buffer_slot didn't fill widgets, they are kept separately
@@ -1319,8 +1316,7 @@ void CtMainWin::_on_textview_event_after(GdkEvent* event)
     }
     else if (event->type == GDK_BUTTON_PRESS or event->type == GDK_KEY_PRESS)
     {
-        if (curr_tree_iter() and curr_tree_iter().get_node_syntax_highlighting() == CtConst::RICH_TEXT_ID and
-            not curr_buffer()->get_modified())
+        if (curr_tree_iter() and not curr_buffer()->get_modified())
         {
             get_state_machine().update_curr_state_cursor_pos(curr_tree_iter().get_node_id());
         }

--- a/future/src/ct/ct_main_win.h
+++ b/future/src/ct/ct_main_win.h
@@ -30,11 +30,13 @@
 #include "ct_treestore.h"
 #include "ct_misc_utils.h"
 #include "ct_menu.h"
+#include "ct_state_machine.h"
 #include "ct_widgets.h"
 #include "ct_config.h"
 #include "ct_table.h"
 #include "ct_image.h"
 #include "ct_print.h"
+
 
 struct CtStatusBar
 {
@@ -101,6 +103,7 @@ public:
     std::string get_curr_doc_file_path() { return (_ctCurrFile.rFile ? _ctCurrFile.rFile->get_path():""); }
     std::string get_curr_doc_file_name() { return (_ctCurrFile.rFile ? Glib::path_get_basename(_ctCurrFile.rFile->get_path()):""); } // pygtk: file_name
     std::string get_curr_doc_file_dir() { return (_ctCurrFile.rFile ? Glib::path_get_dirname(_ctCurrFile.rFile->get_path()):""); } // pygtk: file_dir
+    CtDocType   get_curr_doc_file_type() { return CtMiscUtil::get_doc_type(get_curr_doc_file_path()); }
     void set_new_curr_doc(const std::string& filepath,
                           const std::string& password,
                           CtSQLite* const pCtSQLite);
@@ -118,6 +121,7 @@ public:
     CtActions*               get_ct_actions()  { return _pCtActions; }
     CtTmp*                   get_ct_tmp()      { return _pCtTmp; }
     Gtk::IconTheme*          get_icon_theme()  { return _pGtkIconTheme; }
+    CtStateMachine&          get_state_machine() { return _ctStateMachine; }
     Glib::RefPtr<Gtk::TextTagTable>&  get_text_tag_table() { return _rGtkTextTagTable; }
     Glib::RefPtr<Gtk::CssProvider>&   get_css_provider()   { return _rGtkCssProvider; }
     Gsv::LanguageManager*    get_language_manager() { return _pGsvLanguageManager; }
@@ -210,6 +214,7 @@ private:
     std::unique_ptr<CtTreeStore> _uCtTreestore;
     std::unique_ptr<CtTreeView>  _uCtTreeview;
     CtTextView                   _ctTextview;
+    CtStateMachine               _ctStateMachine;
     std::unique_ptr<CtPairCodeboxMainWin> _uCtPairCodeboxMainWin;
 
     struct CtCurrFile

--- a/future/src/ct/ct_main_win.h
+++ b/future/src/ct/ct_main_win.h
@@ -97,6 +97,7 @@ public:
     void update_window_save_needed(const CtSaveNeededUpdType update_type = CtSaveNeededUpdType::None,
                                    const bool new_machine_state = false,
                                    const CtTreeIter* give_tree_iter = nullptr);
+    void load_buffer_from_state(std::shared_ptr<CtNodeState> state, CtTreeIter tree_iter);
     void update_window_save_not_needed();
     bool get_file_save_needed();
     std::string get_curr_doc_password() { return _ctCurrFile.password; }

--- a/future/src/ct/ct_print.cc
+++ b/future/src/ct/ct_print.cc
@@ -101,7 +101,7 @@ void CtPrint::_on_begin_print_text(const Glib::RefPtr<Gtk::PrintContext>& contex
     layout_newline->set_width(int(_page_width * Pango::SCALE));
     layout_newline->set_markup(CtConst::CHAR_NEWLINE);
     _layout_newline_height = _layout_line_get_width_height(layout_newline->get_line(0)).height;
-    int codebox_height, table_height; // to keep data for current slot from previous slot
+    int codebox_height = 0, table_height = 0; // to keep data for current slot from previous slot
 
     while (1)
     {

--- a/future/src/ct/ct_sqlite3_rw.cc
+++ b/future/src/ct/ct_sqlite3_rw.cc
@@ -338,10 +338,10 @@ void CtSQLite::_get_text_buffer_anchored_widgets(Glib::RefPtr<Gsv::Buffer>& rTex
                                                   frameWidth,
                                                   frameHeight,
                                                   charOffset[i],
-                                                  justification[i]);
-            pCtCodebox->set_width_in_pixels(widthInPixels);
-            pCtCodebox->set_highlight_brackets(highlightBrackets);
-            pCtCodebox->set_show_line_numbers(showLineNumbers);
+                                                  justification[i],
+                                                  widthInPixels,
+                                                  highlightBrackets,
+                                                  showLineNumbers);
             pAnchoredWidget = pCtCodebox;
             //std::cout << "codebox " << charOffset[i] << std::endl;
             charOffset[i] = cOffsetRead;

--- a/future/src/ct/ct_state_machine.cc
+++ b/future/src/ct/ct_state_machine.cc
@@ -169,7 +169,7 @@ void CtStateMachine::update_state()
 // Update the state for the given node_id
 void CtStateMachine::update_state(CtTreeIter tree_iter)
 {
-    if (!tree_iter.get_node_is_rich_text() || not_undoable_timeslot_get())
+    if (not_undoable_timeslot_get())
         return;
     gint64 node_id = tree_iter.get_node_id();
     auto& node_states = _node_states[node_id];

--- a/future/src/ct/ct_state_machine.cc
+++ b/future/src/ct/ct_state_machine.cc
@@ -26,13 +26,16 @@
 CtStateMachine::CtStateMachine(CtMainWin *pCtMainWin) : _pCtMainWin(pCtMainWin)
 {
     _word_regex = Glib::Regex::create("\\w");
+    _go_bk_fw_click = false;
+    _not_undoable_timeslot = false;
+    _visited_nodes_idx = -1;
 }
 
 // State Machine Reset
 void CtStateMachine::reset()
 {
     _visited_nodes_list.clear();
-    _visited_nodes_idx = 0;
+    _visited_nodes_idx = -1;
     _node_states.clear();
 }
 
@@ -72,8 +75,8 @@ void CtStateMachine::node_selected_changed(gint64 node_id)
     {
         auto node = _pCtMainWin->curr_tree_iter();
         auto state = std::shared_ptr<CtNodeState>(new CtNodeState());
-        state->node_xml.append_dom_node(node, nullptr/*p_node_parent*/, false/*no widgets */, true/*skip_children*/);
-        state->node_text = state->node_xml.write_to_string();
+        state->buffer_xml.append_node_buffer(node, state->buffer_xml.get_root_node(), false/*no widgets */);
+        state->buffer_xml_string = state->buffer_xml.write_to_string();
         for (auto widget: node.get_embedded_pixbufs_tables_codeboxes())
             state->widgets.push_back(widget->clone());
         state->cursor_pos = 0;
@@ -169,15 +172,15 @@ void CtStateMachine::update_state(CtTreeIter tree_iter)
     if (!tree_iter.get_node_is_rich_text() || not_undoable_timeslot_get())
         return;
     gint64 node_id = tree_iter.get_node_id();
-    auto node_states = _node_states[node_id];
+    auto& node_states = _node_states[node_id];
     if (!curr_index_is_last_index(node_id))
     {
         node_states.states.erase(node_states.states.begin() + node_states.index + 1, node_states.states.end());
     }
 
     auto new_state = std::shared_ptr<CtNodeState>(new CtNodeState());
-    new_state->node_xml.append_dom_node(tree_iter, nullptr/*p_node_parent*/, false/*no widgets*/, true/*skip_children*/);
-    new_state->node_text = new_state->node_xml.write_to_string();
+    new_state->buffer_xml.append_node_buffer(tree_iter, new_state->buffer_xml.get_root_node(), false/*no widgets*/);
+    new_state->buffer_xml_string = new_state->buffer_xml.write_to_string();
     for (auto widget: tree_iter.get_embedded_pixbufs_tables_codeboxes())
         new_state->widgets.push_back(widget->clone());
     new_state->cursor_pos = tree_iter.get_node_text_buffer()->property_cursor_position();
@@ -190,10 +193,11 @@ void CtStateMachine::update_state(CtTreeIter tree_iter)
             });
         };
         auto last_state = node_states.states.back();
-        if (new_state->node_text == last_state->node_text
-                && new_state->cursor_pos == last_state->cursor_pos
-                && compare_widgets(new_state->widgets, last_state->widgets))
+        if (new_state->buffer_xml_string == last_state->buffer_xml_string && compare_widgets(new_state->widgets, last_state->widgets))
+        {
+            last_state->cursor_pos = new_state->cursor_pos;
             return; // #print "update_state not needed"
+        }
     }
 
     node_states.states.push_back(new_state);

--- a/future/src/ct/ct_state_machine.cc
+++ b/future/src/ct/ct_state_machine.cc
@@ -1,0 +1,29 @@
+/*
+ * ct_state_machine.cc
+ *
+ * Copyright 2017-2020 Giuseppe Penone <giuspen@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "ct_state_machine.h"
+
+CtStateMachine::CtStateMachine(CtMainWin *pCtMainWin) : _pCtMainWin(pCtMainWin)
+{
+
+}
+
+

--- a/future/src/ct/ct_state_machine.h
+++ b/future/src/ct/ct_state_machine.h
@@ -32,11 +32,11 @@ class CtMainWin;
 
 struct CtNodeState
 {
-    CtNodeState() : node_xml("node") { }
+    CtNodeState() : buffer_xml("buffer") { }
     ~CtNodeState() { for (auto widget: widgets) delete widget; }
 
-    CtXmlWrite                   node_xml;
-    Glib::ustring                node_text;
+    CtXmlWrite                   buffer_xml;
+    Glib::ustring                buffer_xml_string;
     std::list<CtAnchoredWidget*> widgets;
     int                          cursor_pos;
 };

--- a/future/src/ct/ct_state_machine.h
+++ b/future/src/ct/ct_state_machine.h
@@ -21,15 +21,58 @@
 
 #pragma once
 
+#include "ct_treestore.h"
+#include <vector>
+#include <map>
+#include <glibmm/regex.h>
+#include <memory>
+
 class CtMainWin;
+
+struct CtNodeState
+{
+    int cursor_pos;
+};
+
+struct CtNodeStory
+{
+    std::vector<std::shared_ptr<CtNodeState>> states;
+    int index;
+    int indicator;
+
+    std::shared_ptr<CtNodeState> get_state() { return states[index]; }
+};
 
 class CtStateMachine
 {
 public:
     CtStateMachine(CtMainWin* pCtMainWin);
 
+    void reset();
+    gint64 requested_visited_previous();
+    gint64 requested_visited_next();
+    void node_selected_changed(gint64 node_id);
+    void text_variation(gint64 node_id, const Glib::ustring& varied_text);
+    std::shared_ptr<CtNodeState> requested_state_previous(gint64 node_id);
+    std::shared_ptr<CtNodeState> requested_state_current(gint64 node_id);
+    std::shared_ptr<CtNodeState> requested_state_subsequent(gint64 node_id);
+    void delete_states(gint64 node_id);
+    bool curr_index_is_last_index(gint64 node_id);
+    void not_undoable_timeslot_set(bool not_undoable_val);
+    bool not_undoable_timeslot_get();
+    void update_state();
+    void update_state(CtTreeIter tree_iter);
+    void update_curr_state_cursor_pos(gint64 node_id);
+
 private:
     CtMainWin* _pCtMainWin;
+    bool       _go_bk_fw_click;
+    bool       _not_undoable_timeslot;
+    int        _visited_nodes_idx;
+
+    std::vector<gint64>           _visited_nodes_list;
+    std::map<gint64, CtNodeStory> _nodes_vectors;
+    Glib::RefPtr<Glib::Regex>     _re_w;
 
 };
 

--- a/future/src/ct/ct_state_machine.h
+++ b/future/src/ct/ct_state_machine.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "ct_treestore.h"
+#include "ct_doc_rw.h"
 #include <vector>
 #include <map>
 #include <glibmm/regex.h>
@@ -31,10 +32,16 @@ class CtMainWin;
 
 struct CtNodeState
 {
-    int cursor_pos;
+    CtNodeState() : node_xml("node") { }
+    ~CtNodeState() { for (auto widget: widgets) delete widget; }
+
+    CtXmlWrite                   node_xml;
+    Glib::ustring                node_text;
+    std::list<CtAnchoredWidget*> widgets;
+    int                          cursor_pos;
 };
 
-struct CtNodeStory
+struct CtNodeStates
 {
     std::vector<std::shared_ptr<CtNodeState>> states;
     int index;
@@ -65,14 +72,14 @@ public:
     void update_curr_state_cursor_pos(gint64 node_id);
 
 private:
-    CtMainWin* _pCtMainWin;
-    bool       _go_bk_fw_click;
-    bool       _not_undoable_timeslot;
-    int        _visited_nodes_idx;
+    CtMainWin*                  _pCtMainWin;
+    Glib::RefPtr<Glib::Regex>   _word_regex;
+    bool                        _go_bk_fw_click;
+    bool                        _not_undoable_timeslot;
 
-    std::vector<gint64>           _visited_nodes_list;
-    std::map<gint64, CtNodeStory> _nodes_vectors;
-    Glib::RefPtr<Glib::Regex>     _re_w;
+    std::vector<gint64>         _visited_nodes_list;
+    int                         _visited_nodes_idx;
 
+    std::map<gint64, CtNodeStates> _node_states;
 };
 

--- a/future/src/ct/ct_state_machine.h
+++ b/future/src/ct/ct_state_machine.h
@@ -1,0 +1,35 @@
+/*
+ * ct_state_machine.h
+ *
+ * Copyright 2017-2020 Giuseppe Penone <giuspen@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#pragma once
+
+class CtMainWin;
+
+class CtStateMachine
+{
+public:
+    CtStateMachine(CtMainWin* pCtMainWin);
+
+private:
+    CtMainWin* _pCtMainWin;
+
+};
+

--- a/future/src/ct/ct_table.cc
+++ b/future/src/ct/ct_table.cc
@@ -133,6 +133,35 @@ bool CtTable::to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adj
     return retVal;
 }
 
+CtAnchoredWidget* CtTable::clone()
+{
+    return new CtTable(_pCtMainWin, _tableMatrix, _colMin, _colMax, true, _charOffset, _justification);
+}
+
+bool CtTable::equal(CtAnchoredWidget* other)
+{
+    if (get_type() != other->get_type()) return false;
+
+    auto compare_cell = [](CtTableCell* lhs, CtTableCell* rhs) {
+        return lhs->get_text_content() == rhs->get_text_content() && lhs->get_syntax_highlighting() == rhs->get_syntax_highlighting();
+    };
+    auto compare_row = [compare_cell](const CtTableRow& lhs, const CtTableRow& rhs) {
+        return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), compare_cell);
+    };
+    auto compare_table = [compare_row](const CtTableMatrix& lhs, const CtTableMatrix& rhs) {
+        return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), compare_row);
+    };
+
+    if (CtTable* other_table = dynamic_cast<CtTable*>(other))
+        if (_colMin == other_table->_colMin
+                && _colMax == other_table->_colMax
+                && _charOffset == other_table->_charOffset
+                && _justification == other_table->_justification
+                && compare_table(_tableMatrix, other_table->_tableMatrix))
+            return true;
+    return false;
+}
+
 void CtTable::set_modified_false()
 {
     for (CtTableRow& tableRow : _tableMatrix)

--- a/future/src/ct/ct_table.h
+++ b/future/src/ct/ct_table.h
@@ -53,6 +53,8 @@ public:
     bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) override;
     void set_modified_false() override;
     CtAnchWidgType get_type() override { return CtAnchWidgType::Table; }
+    CtAnchoredWidget* clone() override;
+    bool equal(CtAnchoredWidget* other) override;
 
     const CtTableMatrix& get_table_matrix() { return _tableMatrix; }
     int get_col_max() { return _colMax; }

--- a/future/src/ct/ct_treestore.cc
+++ b/future/src/ct/ct_treestore.cc
@@ -177,6 +177,15 @@ std::list<CtAnchoredWidget*> CtTreeIter::get_all_embedded_widgets()
 {
     return (*this) ? (*this)->get_value(_pColumns->colAnchoredWidgets) : std::list<CtAnchoredWidget*>();
 }
+void CtTreeIter::remove_all_embedded_widgets()
+{
+    if (*this)
+    {
+        for (auto widget: (*this)->get_value(_pColumns->colAnchoredWidgets))
+            delete widget;
+        (*this)->set_value(_pColumns->colAnchoredWidgets, std::list<CtAnchoredWidget*>());
+    }
+}
 
 std::list<CtAnchoredWidget*> CtTreeIter::get_embedded_pixbufs_tables_codeboxes(const std::pair<int,int>& offset_range)
 {
@@ -523,6 +532,7 @@ void CtTreeStore::update_node_data(const Gtk::TreeIter& treeIter, const CtNodeDa
     row[_columns.colForeground] = nodeData.foregroundRgb24;
     row[_columns.colTsCreation] = nodeData.tsCreation;
     row[_columns.colTsLastSave] = nodeData.tsLastSave;
+    // todo: should widgets be deleted?
     row[_columns.colAnchoredWidgets] = nodeData.anchoredWidgets;
 
     update_node_aux_icon(treeIter);

--- a/future/src/ct/ct_treestore.cc
+++ b/future/src/ct/ct_treestore.cc
@@ -614,12 +614,14 @@ void CtTreeStore::_on_textbuffer_modified_changed(Glib::RefPtr<Gtk::TextBuffer> 
 
 void CtTreeStore::_on_textbuffer_insert(const Gtk::TextBuffer::iterator& pos, const Glib::ustring& text, int bytes)
 {
-    // todo
+    if (_pCtMainWin->user_active())
+        _pCtMainWin->get_state_machine().text_variation(_pCtMainWin->curr_tree_iter().get_node_id(), text);
 }
 
 void CtTreeStore::_on_textbuffer_erase(const Gtk::TextBuffer::iterator& range_start, const Gtk::TextBuffer::iterator& range_end)
 {
-    // todo
+     if (_pCtMainWin->user_active())
+       _pCtMainWin->get_state_machine().text_variation(_pCtMainWin->curr_tree_iter().get_node_id(), range_start.get_text(range_end));
 }
 
 void CtTreeStore::apply_textbuffer_to_textview(const CtTreeIter& treeIter, CtTextView* pTextView)
@@ -678,6 +680,12 @@ void CtTreeStore::apply_textbuffer_to_textview(const CtTreeIter& treeIter, CtTex
         rTextBuffer->signal_modified_changed().connect(sigc::bind<Glib::RefPtr<Gtk::TextBuffer>>(
             sigc::mem_fun(*this, &CtTreeStore::_on_textbuffer_modified_changed), rTextBuffer
         ))
+    );
+    _curr_node_sigc_conn.push_back(
+        rTextBuffer->signal_insert().connect(sigc::mem_fun(*this, &CtTreeStore::_on_textbuffer_insert))
+    );
+    _curr_node_sigc_conn.push_back(
+        rTextBuffer->signal_erase().connect(sigc::mem_fun(*this, &CtTreeStore::_on_textbuffer_erase))
     );
 }
 

--- a/future/src/ct/ct_treestore.h
+++ b/future/src/ct/ct_treestore.h
@@ -103,6 +103,7 @@ public:
     Glib::RefPtr<Gsv::Buffer> get_node_text_buffer() const;
 
     std::list<CtAnchoredWidget*> get_all_embedded_widgets();
+    void                         remove_all_embedded_widgets();
     std::list<CtAnchoredWidget*> get_embedded_pixbufs_tables_codeboxes(const std::pair<int,int>& offset_range=std::make_pair(-1,-1));
 
     void pending_edit_db_node_prop();

--- a/future/src/ct/ct_types.h
+++ b/future/src/ct/ct_types.h
@@ -81,7 +81,7 @@ public:
 private:
     void _check_size()
     {
-        while (std::list<TYPE>::size() > maxSize)
+        while (std::list<TYPE>::size() > (size_t)maxSize)
         {
             std::list<TYPE>::pop_back();
         }

--- a/future/src/ct/ct_widgets.cc
+++ b/future/src/ct/ct_widgets.cc
@@ -172,26 +172,6 @@ CtTextView::~CtTextView()
 
 void CtTextView::setup_for_syntax(const std::string& syntax)
 {
-#if 0
-    get_buffer()->signal_modified_changed().connect([](){
-        // todo: elf.on_modified_changed
-
-    });
-    get_buffer()->signal_insert().connect([](const Gtk::TextIter&,const Glib::ustring&, int){
-        // todo: self.on_text_insertion
-        // if self.user_active:
-        //            self.state_machine.text_variation(self.treestore[self.curr_tree_iter][3], text_inserted)
-    });
-    get_buffer()->signal_erase().connect([](const Gtk::TextIter, const Gtk::TextIter){
-        // todo:  self.on_text_removal
-        // if self.user_active and self.curr_tree_iter:
-        //            self.state_machine.text_variation(self.treestore[self.curr_tree_iter][3], sourcebuffer.get_text(start_iter, end_iter))
-    });
-    // todo: exclude for codebox?
-    get_buffer()->signal_mark_set().connect([](const Gtk::TextIter&,const Glib::RefPtr<Gtk::TextMark>){
-        // todo: self.on_textbuffer_mark_set
-    });
-#endif // 0
     std::string new_class;
     if (CtConst::RICH_TEXT_ID == syntax)         new_class = "rich-text";
     else if (CtConst::PLAIN_TEXT_ID == syntax)   new_class = "plain-text";

--- a/future/src/ct/ct_widgets.cc
+++ b/future/src/ct/ct_widgets.cc
@@ -90,6 +90,15 @@ CtAnchoredWidget::CtAnchoredWidget(CtMainWin* pCtMainWin, const int charOffset, 
     _frame.set_shadow_type(Gtk::ShadowType::SHADOW_NONE);
     signal_button_press_event().connect([](GdkEventButton* /*pEvent*/){ return true; });
     add(_frame);
+
+
+    // todo:
+    //if table_justification:
+    //    text_iter = text_buffer.get_iter_at_child_anchor(anchor)
+    //    self.dad.state_machine.apply_object_justification(text_iter, table_justification, text_buffer)
+    //elif self.dad.user_active:
+    //    # if I apply a justification, the state is already updated
+    //    self.dad.state_machine.update_state()
 }
 
 CtAnchoredWidget::~CtAnchoredWidget()

--- a/future/src/ct/ct_widgets.h
+++ b/future/src/ct/ct_widgets.h
@@ -59,6 +59,8 @@ public:
     virtual bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) = 0;
     virtual void set_modified_false() = 0;
     virtual CtAnchWidgType get_type() = 0;
+    virtual CtAnchoredWidget* clone() = 0;
+    virtual bool equal(CtAnchoredWidget*) = 0;
 
     void updateOffset(int charOffset) { _charOffset = charOffset; }
     void updateJustification(const std::string& justification) { _justification = justification; }

--- a/future/src/ct/ct_xml_rw.cc
+++ b/future/src/ct/ct_xml_rw.cc
@@ -235,10 +235,10 @@ void CtXmlRead::get_text_buffer_slot(Glib::RefPtr<Gsv::Buffer>& rTextBuffer,
                                                   frameWidth,
                                                   frameHeight,
                                                   charOffset,
-                                                  justification);
-            pCtCodebox->set_width_in_pixels(widthInPixels);
-            pCtCodebox->set_highlight_brackets(highlightBrackets);
-            pCtCodebox->set_show_line_numbers(showLineNumbers);
+                                                  justification,
+                                                  widthInPixels,
+                                                  highlightBrackets,
+                                                  showLineNumbers);
             pAnchoredWidget = pCtCodebox;
         }
         if (nullptr != pAnchoredWidget)


### PR DESCRIPTION
(ref to keep progress: #444)

Changes compared to pygtk: 
- Buffers with simple text also use machine_state, I couldn't find API for build-in undo\redo for them. Don't think it's a big deal.
- Add more parameters in Codebox constructor, so no need for additional method calls to setup codebox
- Add code to clone and compare widgets
- Didn't implemented `objects_buffer_refresh`, looks like it is a big hack for some reason, maybe code will work without it?