### PR TITLE
fixing "RuntimeError: returned character can not be represented in 16-bit unicode"

### DIFF
--- a/modules/findreplace.py
+++ b/modules/findreplace.py
@@ -742,35 +742,38 @@ class FindReplace:
 
     def parse_node_content_iter(self, tree_iter, text_buffer, pattern, forward, first_fromsel, all_matches, first_node):
         """Returns True if pattern was find, False otherwise"""
-        buff_start_iter = text_buffer.get_start_iter()
-        if buff_start_iter.get_char() != cons.CHAR_NEWLINE:
-            self.newline_trick = True
-            if not text_buffer.get_modified(): restore_modified = True
-            else: restore_modified = False
-            text_buffer.insert(buff_start_iter, cons.CHAR_NEWLINE)
-        else:
-            self.newline_trick = False
-            restore_modified = False
-        if (first_fromsel and first_node)\
-        or (all_matches and not self.all_matches_first_in_node):
-            node_id = self.dad.get_node_id_from_tree_iter(tree_iter)
-            start_iter = self.get_inner_start_iter(text_buffer, forward, node_id)
-        else:
-            if forward: start_iter = text_buffer.get_start_iter()
-            else: start_iter = text_buffer.get_end_iter()
-            if all_matches: self.all_matches_first_in_node = False
-        if self.is_node_within_time_filter(tree_iter):
-            pattern_found = self.find_pattern(tree_iter, text_buffer, pattern, start_iter, forward, all_matches)
-        else:
-            pattern_found = False
-        if self.newline_trick:
+        try:
             buff_start_iter = text_buffer.get_start_iter()
-            buff_step_iter = buff_start_iter.copy()
-            if buff_step_iter.forward_char(): text_buffer.delete(buff_start_iter, buff_step_iter)
-            if restore_modified: text_buffer.set_modified(False)
-        if self.replace_active and pattern_found:
-            self.dad.update_window_save_needed("nbuf", given_tree_iter=tree_iter)
-        return pattern_found
+            if buff_start_iter.get_char() != cons.CHAR_NEWLINE:
+                self.newline_trick = True
+                if not text_buffer.get_modified(): restore_modified = True
+                else: restore_modified = False
+                text_buffer.insert(buff_start_iter, cons.CHAR_NEWLINE)
+            else:
+                self.newline_trick = False
+                restore_modified = False
+            if (first_fromsel and first_node)\
+            or (all_matches and not self.all_matches_first_in_node):
+                node_id = self.dad.get_node_id_from_tree_iter(tree_iter)
+                start_iter = self.get_inner_start_iter(text_buffer, forward, node_id)
+            else:
+                if forward: start_iter = text_buffer.get_start_iter()
+                else: start_iter = text_buffer.get_end_iter()
+                if all_matches: self.all_matches_first_in_node = False
+            if self.is_node_within_time_filter(tree_iter):
+                pattern_found = self.find_pattern(tree_iter, text_buffer, pattern, start_iter, forward, all_matches)
+            else:
+                pattern_found = False
+            if self.newline_trick:
+                buff_start_iter = text_buffer.get_start_iter()
+                buff_step_iter = buff_start_iter.copy()
+                if buff_step_iter.forward_char(): text_buffer.delete(buff_start_iter, buff_step_iter)
+                if restore_modified: text_buffer.set_modified(False)
+            if self.replace_active and pattern_found:
+                self.dad.update_window_save_needed("nbuf", given_tree_iter=tree_iter)
+            return pattern_found
+        except: # caused by bad symbol, #664
+            return False
 
     def parse_given_node_content(self, node_iter, pattern, forward, first_fromsel, all_matches):
         """Returns True if pattern was found, False otherwise"""
@@ -881,25 +884,31 @@ class FindReplace:
 
     def get_line_content(self, text_buffer, text_iter):
         """Returns the Line Content Given the Text Iter"""
-        line_start = text_iter.copy()
-        line_end = text_iter.copy()
-        if not line_start.backward_char(): return ""
-        while line_start.get_char() != cons.CHAR_NEWLINE:
-            if not line_start.backward_char(): break
-        else: line_start.forward_char()
-        while line_end.get_char() != cons.CHAR_NEWLINE:
-            if not line_end.forward_char(): break
-        return text_buffer.get_text(line_start, line_end)
+        try:
+            line_start = text_iter.copy()
+            line_end = text_iter.copy()
+            if not line_start.backward_char(): return ""
+            while line_start.get_char() != cons.CHAR_NEWLINE:
+                if not line_start.backward_char(): break
+            else: line_start.forward_char()
+            while line_end.get_char() != cons.CHAR_NEWLINE:
+                if not line_end.forward_char(): break
+            return text_buffer.get_text(line_start, line_end)
+        except: # caused by bad symbol, #664
+            return u''
 
     def get_first_line_content(self, text_buffer):
         """Returns the First Not Empty Line Content Given the Text Buffer"""
-        start_iter = text_buffer.get_start_iter()
-        while start_iter.get_char() == cons.CHAR_NEWLINE:
-            if not start_iter.forward_char(): return ""
-        end_iter = start_iter.copy()
-        while end_iter.get_char() != cons.CHAR_NEWLINE:
-            if not end_iter.forward_char(): break
-        return text_buffer.get_text(start_iter, end_iter)
+        try:
+            start_iter = text_buffer.get_start_iter()
+            while start_iter.get_char() == cons.CHAR_NEWLINE:
+                if not start_iter.forward_char(): return ""
+            end_iter = start_iter.copy()
+            while end_iter.get_char() != cons.CHAR_NEWLINE:
+                if not end_iter.forward_char(): break
+            return text_buffer.get_text(start_iter, end_iter)
+        except: # caused by bad symbol, #664
+            return u''
 
     def allmatchesdialog_show(self):
         """Create the All Matches Dialog"""

--- a/modules/lists.py
+++ b/modules/lists.py
@@ -288,11 +288,14 @@ class ListsHandler:
 
     def is_list_todo_beginning(self, square_bracket_open_iter):
         """Check if ☐ or ☑ or ☒"""
-        if square_bracket_open_iter.get_char() in self.dad.chars_todo:
-            list_info = self.get_paragraph_list_info(square_bracket_open_iter)
-            if list_info and list_info["num"] == 0:
-                return True
-        return False
+        try:
+            if square_bracket_open_iter.get_char() in self.dad.chars_todo:
+                list_info = self.get_paragraph_list_info(square_bracket_open_iter)
+                if list_info and list_info["num"] == 0:
+                    return True
+            return False
+        except: # caused by bad symbol, #664
+            return False
 
     def todo_list_rotate_status(self, todo_char_iter, text_buffer):
         """Rotate status between ☐ and ☑ and ☒"""

--- a/modules/support.py
+++ b/modules/support.py
@@ -102,55 +102,58 @@ def apply_tag_try_node_name(dad, iter_start, iter_end):
 
 def apply_tag_try_link(dad, iter_end, offset_cursor=None):
     """Try and apply link to previous word (after space or newline)"""
-    tag_applied = False
-    iter_start = iter_end.copy()
-    if iter_start.backward_char() and iter_start.get_char() == cons.CHAR_SQ_BR_CLOSE\
-    and iter_start.backward_char() and iter_start.get_char() == cons.CHAR_SQ_BR_CLOSE:
-        curr_state = 0
-        end_offset = iter_start.get_offset()
-        while iter_start.backward_char():
-            curr_char = iter_start.get_char()
-            if curr_char == cons.CHAR_NEWLINE:
-                break
-            if curr_char == cons.CHAR_SQ_BR_OPEN:
-                if curr_state == 0:
-                    curr_state = 1
-                else:
-                    curr_state = 2
-                    break
-        if curr_state == 2:
-            start_offset = iter_start.get_offset()+2
-            end_offset = iter_end.get_offset()-2
-            if apply_tag_try_node_name(dad, dad.curr_buffer.get_iter_at_offset(start_offset),
-                                       dad.curr_buffer.get_iter_at_offset(end_offset)):
-                tag_applied = True
-                dad.curr_buffer.delete(dad.curr_buffer.get_iter_at_offset(end_offset),
-                                       dad.curr_buffer.get_iter_at_offset(end_offset+2))
-                dad.curr_buffer.delete(dad.curr_buffer.get_iter_at_offset(start_offset-2),
-                                       dad.curr_buffer.get_iter_at_offset(start_offset))
-                if offset_cursor != None:
-                    offset_cursor -= 4
-    else:
+    try:
+        tag_applied = False
         iter_start = iter_end.copy()
-        while iter_start.backward_char():
-            curr_char = iter_start.get_char()
-            if curr_char in cons.WEB_LINK_SEPARATORS:
-                iter_start.forward_char()
-                break
-        num_chars = iter_end.get_offset() - iter_start.get_offset()
-        if num_chars > 4 and get_next_chars_from_iter_are(iter_start, cons.WEB_LINK_STARTERS):
-            dad.curr_buffer.select_range(iter_start, iter_end)
-            link_url = dad.curr_buffer.get_text(iter_start, iter_end)
-            if link_url[0:3] not in ["htt", "ftp"]: link_url = "http://" + link_url
-            property_value = cons.LINK_TYPE_WEBS + cons.CHAR_SPACE + link_url
-            dad.apply_tag(cons.TAG_LINK, property_value=property_value)
-            tag_applied = True
-        elif num_chars > 2 and get_is_camel_case(iter_start, num_chars):
-            if apply_tag_try_node_name(dad, iter_start, iter_end):
+        if iter_start.backward_char() and iter_start.get_char() == cons.CHAR_SQ_BR_CLOSE\
+        and iter_start.backward_char() and iter_start.get_char() == cons.CHAR_SQ_BR_CLOSE:
+            curr_state = 0
+            end_offset = iter_start.get_offset()
+            while iter_start.backward_char():
+                curr_char = iter_start.get_char()
+                if curr_char == cons.CHAR_NEWLINE:
+                    break
+                if curr_char == cons.CHAR_SQ_BR_OPEN:
+                    if curr_state == 0:
+                        curr_state = 1
+                    else:
+                        curr_state = 2
+                        break
+            if curr_state == 2:
+                start_offset = iter_start.get_offset()+2
+                end_offset = iter_end.get_offset()-2
+                if apply_tag_try_node_name(dad, dad.curr_buffer.get_iter_at_offset(start_offset),
+                                        dad.curr_buffer.get_iter_at_offset(end_offset)):
+                    tag_applied = True
+                    dad.curr_buffer.delete(dad.curr_buffer.get_iter_at_offset(end_offset),
+                                        dad.curr_buffer.get_iter_at_offset(end_offset+2))
+                    dad.curr_buffer.delete(dad.curr_buffer.get_iter_at_offset(start_offset-2),
+                                        dad.curr_buffer.get_iter_at_offset(start_offset))
+                    if offset_cursor != None:
+                        offset_cursor -= 4
+        else:
+            iter_start = iter_end.copy()
+            while iter_start.backward_char():
+                curr_char = iter_start.get_char()
+                if curr_char in cons.WEB_LINK_SEPARATORS:
+                    iter_start.forward_char()
+                    break
+            num_chars = iter_end.get_offset() - iter_start.get_offset()
+            if num_chars > 4 and get_next_chars_from_iter_are(iter_start, cons.WEB_LINK_STARTERS):
+                dad.curr_buffer.select_range(iter_start, iter_end)
+                link_url = dad.curr_buffer.get_text(iter_start, iter_end)
+                if link_url[0:3] not in ["htt", "ftp"]: link_url = "http://" + link_url
+                property_value = cons.LINK_TYPE_WEBS + cons.CHAR_SPACE + link_url
+                dad.apply_tag(cons.TAG_LINK, property_value=property_value)
                 tag_applied = True
-    if tag_applied and offset_cursor != None:
-        dad.curr_buffer.place_cursor(dad.curr_buffer.get_iter_at_offset(offset_cursor))
-    return tag_applied
+            elif num_chars > 2 and get_is_camel_case(iter_start, num_chars):
+                if apply_tag_try_node_name(dad, iter_start, iter_end):
+                    tag_applied = True
+        if tag_applied and offset_cursor != None:
+            dad.curr_buffer.place_cursor(dad.curr_buffer.get_iter_at_offset(offset_cursor))
+        return tag_applied
+    except:  # caused by bad symbol, #664
+        return False
 
 def apply_tag_try_automatic_bounds(dad, text_buffer=None, iter_start=None):
     """Try to Select a Word Forward/Backward the Cursor"""
@@ -394,9 +397,12 @@ def on_sourceview_event_after_key_press(dad, text_view, event, syntax_highl):
                 # problem of event-after called twice, once before really executing
                 return False
             if not iter_start.backward_char(): return False
-            if iter_start.get_char() != cons.CHAR_NEWLINE: return False
-            if iter_start.backward_char() and iter_start.get_char() == cons.CHAR_NEWLINE:
-                return False # former was an empty row
+            try:
+                if iter_start.get_char() != cons.CHAR_NEWLINE: return False
+                if iter_start.backward_char() and iter_start.get_char() == cons.CHAR_NEWLINE:
+                    return False # former was an empty row
+            except:  # caused by bad symbol, #664
+                return False
             list_info = dad.lists_handler.get_paragraph_list_info(iter_start)
             if not list_info:
                 if dad.auto_indent:


### PR DESCRIPTION
Resolves #664 
**Tested**: on windows (didn't test on linux), fonts Sans/Segue UI (maybe not important), a random text with symbol U+1F5F9 (taken from [wiki](https://en.wikipedia.org/wiki/Check_mark))
**Issue**: `TreeIter.get_char` throws exception `RuntimeError: returned character can not be represented in 16-bit unicode` on a bad symbols.
**Fixing**: I added `try/except` to mitigate the problem in places that throw the exception while I worked with the prepared text.
Probably, the issue wouldn't repeat with Gtk3, because it has a newer codebase.

