### PR TITLE
(Port to C++) exec_code

### DIFF
--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -198,6 +198,7 @@ private:
         CtTextView*                     text_view;
         Glib::RefPtr<Gtk::TextBuffer>   text_buffer;
         std::string                     syntax_highl;
+        CtCodebox*                      codebox;
         bool                            from_codebox;
     };
     text_view_n_buffer_codebox_proof _get_text_view_n_buffer_codebox_proof();

--- a/future/src/ct/ct_actions_format.cc
+++ b/future/src/ct/ct_actions_format.cc
@@ -349,11 +349,13 @@ CtActions::text_view_n_buffer_codebox_proof CtActions::_get_text_view_n_buffer_c
         return text_view_n_buffer_codebox_proof{&codebox->get_text_view(),
                     codebox->get_text_view().get_buffer(),
                     codebox->get_syntax_highlighting(),
+                    codebox,
                     true};
     else
         return text_view_n_buffer_codebox_proof{&_pCtMainWin->get_text_view(),
                     _pCtMainWin->get_text_view().get_buffer(),
                     _pCtMainWin->curr_tree_iter().get_node_syntax_highlighting(),
+                    nullptr,
                     false};
 }
 

--- a/future/src/ct/ct_const.cc
+++ b/future/src/ct/ct_const.cc
@@ -306,6 +306,15 @@ const std::unordered_map<std::string, std::string> CtConst::CODE_EXEC_TYPE_CMD_D
     {"python3",  "python3 "+CtConst::CODE_EXEC_TMP_SRC},
     {"sh",       "sh "+CtConst::CODE_EXEC_TMP_SRC}
 };
+const std::unordered_map<std::string, std::string> CtConst::CODE_EXEC_TYPE_EXT_DEFAULT {
+    {"c",        "c"},
+    {"cpp",      "cpp"},
+    {"dosbatch", "bat"},
+    {"perl",     "pl"},
+    {"python",   "py"},
+    {"python3",  "py"},
+    {"sh",       "sh"}
+};
 const std::unordered_map<std::string, std::string> CtConst::CODE_EXEC_TERM_RUN_DEFAULT {
     {"linux", "xterm -hold -geometry 180x45 -e \""+CtConst::CODE_EXEC_COMMAND+"\""},
     {"win",   "start cmd /k \""+CtConst::CODE_EXEC_COMMAND+"\""}

--- a/future/src/ct/ct_const.h
+++ b/future/src/ct/ct_const.h
@@ -186,6 +186,7 @@ extern const std::string CODE_EXEC_TMP_SRC;
 extern const std::string CODE_EXEC_TMP_BIN;
 extern const std::string CODE_EXEC_COMMAND;
 extern const std::unordered_map<std::string, std::string> CODE_EXEC_TYPE_CMD_DEFAULT;
+extern const std::unordered_map<std::string, std::string> CODE_EXEC_TYPE_EXT_DEFAULT;
 extern const std::unordered_map<std::string, std::string> CODE_EXEC_TERM_RUN_DEFAULT;
 
 std::string getStockIdForCodeType(std::string code_type);

--- a/future/src/ct/ct_dialogs.cc
+++ b/future/src/ct/ct_dialogs.cc
@@ -227,7 +227,7 @@ bool CtDialogs::question_dialog(const Glib::ustring& message,
                               Gtk::MESSAGE_QUESTION,
                               Gtk::BUTTONS_OK_CANCEL,
                               true/* modal */);
-    dialog.set_secondary_text(message);
+    dialog.set_secondary_text(message, true);
     dialog.set_position(Gtk::WindowPosition::WIN_POS_CENTER_ON_PARENT);
     return (Gtk::RESPONSE_OK == dialog.run());
 }

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -87,7 +87,7 @@ void CtMenu::init_actions(CtApp *pApp, CtActions* pActions)
     _actions.push_back(CtAction{file_cat, "ct_vacuum", "clear", _("Save and _Vacuum"), None, _("Save File and Vacuum"), sigc::mem_fun(*pActions, &CtActions::file_vacuum)});
     _actions.push_back(CtAction{file_cat, "ct_save_as", "save-as", _("Save _As"), KB_CONTROL+KB_SHIFT+"S", _("Save File As"), sigc::mem_fun(*pActions, &CtActions::file_save_as)});
     _actions.push_back(CtAction{file_cat, "command_palette", "execute", _("Command Palette"), KB_CONTROL+KB_SHIFT+"P", _("Command Palette"), sigc::signal<void>() /* dad.export_to_pdf */});
-    _actions.push_back(CtAction{file_cat, "exec_code", "execute", _("_Execute Code"), "F5", _("Execute Code"), sigc::signal<void>() /* dad.exec_code */});
+    _actions.push_back(CtAction{file_cat, "exec_code", "execute", _("_Execute Code"), "F5", _("Execute Code"), sigc::mem_fun(*pActions, &CtActions::exec_code)});
     _actions.push_back(CtAction{file_cat, "open_cfg_folder", "directory", _("Open Preferences _Directory"), None, _("Open the Directory with Preferences Files"), sigc::signal<void>() /* dad.folder_cfg_open */});
     _actions.push_back(CtAction{file_cat, "print_page_setup", "print", _("Pa_ge Setup"), None, _("Set up the Page for Printing"), sigc::mem_fun(*pActions, &CtActions::export_print_page_setup)});
     _actions.push_back(CtAction{file_cat, "do_print", "print", _("_Print"), KB_CONTROL+"P", _("Print"), sigc::mem_fun(*pActions, &CtActions::export_print)});

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -542,14 +542,12 @@ int CtStrUtil::natural_compare(const Glib::ustring& left, const Glib::ustring& r
 
 std::string CtFontUtil::get_font_family(const std::string& fontStr)
 {
-    std::vector<std::string> splFont = str::split(fontStr, " ");
-    return splFont.size() > 0 ? splFont.at(0) : "";
+    return Pango::FontDescription(fontStr).get_family();
 }
 
 std::string CtFontUtil::get_font_size_str(const std::string& fontStr)
 {
-    std::vector<std::string> splFont = str::split(fontStr, " ");
-    return splFont.size() > 1 ? splFont.at(1) : "";
+    return std::to_string(Pango::FontDescription(fontStr).get_size());
 }
 
 

--- a/future/src/ct/ct_pref_dlg.cc
+++ b/future/src/ct/ct_pref_dlg.cc
@@ -589,7 +589,7 @@ Gtk::Widget* CtPrefDlg::build_tab_plain_text_n_code()
     Gtk::VBox* vbox_codexec = Gtk::manage(new Gtk::VBox());
     Gtk::HBox* hbox_term_run = Gtk::manage(new Gtk::HBox());
     Gtk::Entry* entry_term_run = Gtk::manage(new Gtk::Entry());
-    entry_term_run->set_text(get_code_exec_term_run());
+    entry_term_run->set_text(get_code_exec_term_run(_pCtMainWin));
     Gtk::Button* button_reset_term = Gtk::manage(new Gtk::Button());
     button_reset_term->set_image(*_pCtMainWin->new_image_from_stock("g-undo", Gtk::ICON_SIZE_BUTTON));
     button_reset_term->set_tooltip_text(_("Reset to Default"));
@@ -658,7 +658,7 @@ Gtk::Widget* CtPrefDlg::build_tab_plain_text_n_code()
     button_reset_term->signal_clicked().connect([this, pConfig, entry_term_run](){
         if (CtDialogs::question_dialog(reset_warning, *this)) {
             pConfig->customCodexecTerm.clear();
-            entry_term_run->set_text(get_code_exec_term_run());
+            entry_term_run->set_text(get_code_exec_term_run(_pCtMainWin));
         }
     });
 
@@ -1513,11 +1513,11 @@ void CtPrefDlg::need_restart(RESTART_REASON reason, const gchar* msg /*= nullptr
     }
 }
 
-std::string CtPrefDlg::get_code_exec_term_run()
+std::string CtPrefDlg::get_code_exec_term_run(CtMainWin* pCtMainWin)
 {
-    std::string op_sys = CtConst::IS_WIN_OS ? "linux" : "win";
-    if (!_pCtMainWin->get_ct_config()->customCodexecTerm.empty())
-        return _pCtMainWin->get_ct_config()->customCodexecTerm;
+    std::string op_sys = CtConst::IS_WIN_OS ? "win" : "linux";
+    if (!pCtMainWin->get_ct_config()->customCodexecTerm.empty())
+        return pCtMainWin->get_ct_config()->customCodexecTerm;
     else
         return CtConst::CODE_EXEC_TERM_RUN_DEFAULT.at(op_sys);
 }

--- a/future/src/ct/ct_pref_dlg.h
+++ b/future/src/ct/ct_pref_dlg.h
@@ -61,7 +61,6 @@ private:
 private:
     void need_restart(RESTART_REASON reason, const gchar* msg = nullptr);
 
-    std::string get_code_exec_term_run();
 
     void fill_commands_model(Glib::RefPtr<Gtk::ListStore> model);
     void add_new_command_in_model(Glib::RefPtr<Gtk::ListStore> model);
@@ -74,6 +73,9 @@ private:
     void fill_shortcut_model(Glib::RefPtr<Gtk::TreeStore> model);
     bool edit_shortcut(Gtk::TreeView* treeview);
     bool edit_shortcut_dialog(std::string& shortcut);
+
+public:
+    static std::string get_code_exec_term_run(CtMainWin* pCtMainWin);
 
 private:
     struct UniversalModelColumns : public Gtk::TreeModel::ColumnRecord

--- a/future/tests/tests_misc_utils.cpp
+++ b/future/tests/tests_misc_utils.cpp
@@ -108,6 +108,8 @@ TEST(MiscUtilsGroup, getFontMisc)
 {
     CHECK("Sans" == CtFontUtil::get_font_family("Sans 9"));
     CHECK("9" == CtFontUtil::get_font_size_str("Sans 9"));
+    CHECK("Noto Sans" == CtFontUtil::get_font_family("Noto Sans 9"));
+    CHECK("9" == CtFontUtil::get_font_size_str("Noto Sans 9"));
 }
 
 


### PR DESCRIPTION
(ref to keep progress: #444)

- ported exec_code
- fixed `get_font_family`, `get_font_size_str`, they didn't work with two-word font families.