### PR TITLE
workaround for dead_diaeresis, dead_acute on win32

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -63,6 +63,7 @@ class CherryTree:
         self.filetype = ""
         self.user_active = True
         self.ctrl_down = False
+        self.dead_key = ""
         self.window = gtk.Window()
         self.window.set_title("CherryTree")
         self.window.set_default_size(963, 630)

--- a/modules/support.py
+++ b/modules/support.py
@@ -344,6 +344,20 @@ def on_sourceview_event_after_key_press(dad, text_view, event, syntax_highl):
     """Called after every gtk.gdk.KEY_PRESS on the SourceView"""
     text_buffer = text_view.get_buffer()
     keyname = gtk.gdk.keyval_name(event.keyval)
+
+    # fix wrong diaeresis on win32 Internation keyboard after pressing SPACE
+    if cons.IS_WIN_OS:
+        if keyname == "dead_diaeresis" or keyname == "dead_acute":
+            dad.dead_key = keyname
+        elif dad.dead_key != "" and keyname == cons.STR_KEY_SPACE:
+            iter_insert = text_buffer.get_iter_at_mark(text_buffer.get_insert())
+            if iter_insert and iter_insert.backward_char():
+                if dad.dead_key == "dead_diaeresis" and '¨' == iter_insert.get_char():
+                    dad.replace_text_at_offset('"', iter_insert.get_offset(), iter_insert.get_offset()+1, text_buffer)
+                elif dad.dead_key == "dead_acute" and '´' == iter_insert.get_char():
+                    dad.replace_text_at_offset("'", iter_insert.get_offset(), iter_insert.get_offset()+1, text_buffer)
+            dad.dead_key = ""
+
     if not dad.ctrl_down:
         if keyname in cons.STR_KEYS_CONTROL:
             dad.ctrl_down = True


### PR DESCRIPTION
Partly fixes #427, #688 by replacing wrong 'apostrophe' and 'quotation mark' by the right ones. 
It only works for the main text buffer and codeboxes, text inputs and tables still are affected by the bug.