### PR TITLE
(Port to C++) zoom_text, zoom_tree, node_go_back, node_go_forward

### DIFF
--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -102,6 +102,7 @@ public:
     void file_vacuum();
     void file_save_as();
     void folder_cfg_open();
+    void online_help();
 
 private:
     // helpers for tree actions

--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -132,6 +132,8 @@ public:
     void tree_sort_descending();
     void node_siblings_sort_ascending();
     void node_siblings_sort_descending();
+    void node_go_back();    // was as go_back
+    void node_go_forward(); // was as go_forward
 
     void bookmark_curr_node();
     void bookmark_curr_node_remove();

--- a/future/src/ct/ct_actions_file.cc
+++ b/future/src/ct/ct_actions_file.cc
@@ -261,3 +261,8 @@ void CtActions::folder_cfg_open()
 {
     CtFileSystem::external_folderpath_open(Glib::build_filename(Glib::get_user_config_dir(), CtConst::APP_NAME));
 }
+
+void CtActions::online_help()
+{
+    g_app_info_launch_default_for_uri("http://giuspen.com/cherrytreemanual/", nullptr, nullptr);
+}

--- a/future/src/ct/ct_actions_tree.cc
+++ b/future/src/ct/ct_actions_tree.cc
@@ -478,6 +478,38 @@ void CtActions::node_siblings_sort_descending()
     }
 }
 
+// Go to the Previous Visited Node
+void CtActions::node_go_back()
+{
+    _pCtMainWin->get_state_machine().set_go_bk_fw_click(true);
+    auto on_scope_exit = scope_guard([&](void*) { _pCtMainWin->get_state_machine().set_go_bk_fw_click(false); });
+
+    auto new_node_id = _pCtMainWin->get_state_machine().requested_visited_previous();
+    if (new_node_id > 0) {
+        auto node_iter = _pCtMainWin->curr_tree_store().get_node_from_node_id(new_node_id);
+        if (node_iter)
+            _pCtMainWin->curr_tree_view().set_cursor_safe(node_iter);
+        else
+            node_go_back();
+    }
+}
+
+// Go to the Next Visited Node
+void CtActions::node_go_forward()
+{
+    _pCtMainWin->get_state_machine().set_go_bk_fw_click(true);
+    auto on_scope_exit = scope_guard([&](void*) { _pCtMainWin->get_state_machine().set_go_bk_fw_click(false); });
+
+    auto new_node_id = _pCtMainWin->get_state_machine().requested_visited_next();
+    if (new_node_id > 0) {
+        auto node_iter = _pCtMainWin->curr_tree_store().get_node_from_node_id(new_node_id);
+        if (node_iter)
+            _pCtMainWin->curr_tree_view().set_cursor_safe(node_iter);
+        else
+            node_go_forward();
+    }
+}
+
 void CtActions::bookmark_curr_node()
 {
     if (!_is_there_selected_node_or_error()) return;

--- a/future/src/ct/ct_codebox.cc
+++ b/future/src/ct/ct_codebox.cc
@@ -129,12 +129,13 @@ CtCodebox::CtCodebox(CtMainWin* pCtMainWin,
         return false;
     });
     _ctTextview.signal_scroll_event().connect([this](GdkEventScroll* event){
-        if (event->state & GDK_CONTROL_MASK and (event->direction == GDK_SCROLL_UP or event->direction == GDK_SCROLL_DOWN))
-        {
+        if (!(event->state & GDK_CONTROL_MASK))
+            return false;
+        if  (event->direction == GDK_SCROLL_UP || event->direction == GDK_SCROLL_DOWN)
             _ctTextview.zoom_text(event->direction == GDK_SCROLL_UP);
-            return true;
-        }
-        return false;
+        if  (event->direction == GDK_SCROLL_SMOOTH && event->delta_y != 0)
+            _ctTextview.zoom_text(event->delta_y > 0);
+        return true;
     });
     _ctTextview.get_buffer()->signal_insert().connect([this](const Gtk::TextBuffer::iterator& pos, const Glib::ustring& text, int bytes) {
         if (_pCtMainWin->user_active())
@@ -291,6 +292,14 @@ bool CtCodebox::_on_key_press_event(GdkEventKey* event)
             text_iter.forward_char();
             _pCtMainWin->get_ct_actions()->getCtMainWin()->get_text_view().get_buffer()->place_cursor(text_iter);
             _pCtMainWin->get_ct_actions()->getCtMainWin()->get_text_view().grab_focus();
+            return true;
+        }
+        if (event->keyval == GDK_KEY_plus || event->keyval == GDK_KEY_KP_Add || event->keyval == GDK_KEY_equal) {
+            _ctTextview.zoom_text(true);
+            return true;
+        }
+        else if (event->keyval == GDK_KEY_minus|| event->keyval == GDK_KEY_KP_Subtract) {
+            _ctTextview.zoom_text(false);
             return true;
         }
     }

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -92,15 +92,8 @@ CtMainWin::CtMainWin(CtConfig*        pCtConfig,
     _ctTextview.signal_size_allocate().connect(sigc::mem_fun(*this, &CtMainWin::_on_textview_size_allocate));
     _ctTextview.signal_event().connect(sigc::mem_fun(*this, &CtMainWin::_on_textview_event));
     _ctTextview.signal_event_after().connect(sigc::mem_fun(*this, &CtMainWin::_on_textview_event_after));
-    _ctTextview.signal_scroll_event().connect([this](GdkEventScroll* event)
-    {
-        if (event->state & GDK_CONTROL_MASK and (event->direction == GDK_SCROLL_UP or event->direction == GDK_SCROLL_DOWN))
-        {
-            _ctTextview.zoom_text(event->direction == GDK_SCROLL_UP);
-            return true;
-        }
-        return false;
-    });
+    _ctTextview.signal_scroll_event().connect(sigc::mem_fun(*this, &CtMainWin::_on_textview_scroll_event));
+
     _uCtPairCodeboxMainWin.reset(new CtPairCodeboxMainWin{nullptr, this});
     g_signal_connect(G_OBJECT(_ctTextview.gobj()), "cut-clipboard", G_CALLBACK(CtClipboard::on_cut_clipboard), _uCtPairCodeboxMainWin.get());
     g_signal_connect(G_OBJECT(_ctTextview.gobj()), "copy-clipboard", G_CALLBACK(CtClipboard::on_copy_clipboard), _uCtPairCodeboxMainWin.get());
@@ -380,35 +373,6 @@ bool CtMainWin::apply_tag_try_automatic_bounds(Glib::RefPtr<Gtk::TextBuffer> tex
         return true;
     }
     return false;
-}
-
-std::string CtMainWin::get_font_css(const std::string& fontStr)
-{
-    g_autofree gchar* pFontCss = g_strdup_printf(
-        "textview text {"
-        "    font-family: %s;"
-        "    font-size: %spx;"
-        "}", CtFontUtil::get_font_family(fontStr).c_str(), CtFontUtil::get_font_size_str(fontStr).c_str());
-    std::string fontCss(pFontCss);
-    return fontCss;
-}
-
-const std::string& CtMainWin::get_font_for_syntax_highlighting(const std::string& syntaxHighlighting)
-{
-    if (0 == syntaxHighlighting.compare(CtConst::RICH_TEXT_ID))
-    {
-        return _pCtConfig->rtFont;
-    }
-    if (0 == syntaxHighlighting.compare(CtConst::PLAIN_TEXT_ID))
-    {
-        return _pCtConfig->ptFont;
-    }
-    return _pCtConfig->codeFont;
-}
-
-std::string CtMainWin::get_font_css_for_syntax_highlighting(const std::string& syntaxHighlighting)
-{
-    return get_font_css(get_font_for_syntax_highlighting(syntaxHighlighting));
 }
 
 void CtMainWin::_reset_CtTreestore_CtTreeview()
@@ -1056,7 +1020,6 @@ bool CtMainWin::_on_treeview_button_release_event(GdkEventButton* event)
 
 bool CtMainWin::_on_window_key_press_event(GdkEventKey* event)
 {
-    // todo:
     if (event->state & GDK_CONTROL_MASK) {
         if (event->keyval == GDK_KEY_Tab) {
             _pCtActions->toggle_tree_text();
@@ -1374,6 +1337,17 @@ bool CtMainWin::_on_textview_event(GdkEvent* event)
             }
         }
     }
+    else if (event->key.state & Gdk::CONTROL_MASK)
+    {
+        if (event->key.keyval == GDK_KEY_plus || event->key.keyval == GDK_KEY_KP_Add || event->key.keyval == GDK_KEY_equal) {
+            _ctTextview.zoom_text(true);
+            return true;
+        }
+        else if (event->key.keyval == GDK_KEY_minus|| event->key.keyval == GDK_KEY_KP_Subtract) {
+            _ctTextview.zoom_text(false);
+            return true;
+        }
+    }
     return false;
 }
 
@@ -1409,6 +1383,17 @@ void CtMainWin::_on_textview_event_after(GdkEvent* event)
             }
         }
     }
+}
+
+bool CtMainWin::_on_textview_scroll_event(GdkEventScroll* event)
+{
+    if (!(event->state & GDK_CONTROL_MASK))
+        return false;
+    if  (event->direction == GDK_SCROLL_UP || event->direction == GDK_SCROLL_DOWN)
+        _ctTextview.zoom_text(event->direction == GDK_SCROLL_UP);
+    if  (event->direction == GDK_SCROLL_SMOOTH && event->delta_y != 0)
+        _ctTextview.zoom_text(event->delta_y > 0);
+    return true;
 }
 
 void CtMainWin::_title_update(const bool saveNeeded)

--- a/future/src/ct/ct_main_win.h
+++ b/future/src/ct/ct_main_win.h
@@ -141,9 +141,6 @@ public:
     const std::string get_text_tag_name_exist_or_create(const std::string& propertyName, const std::string& propertyValue);
     Glib::ustring sourceview_hovering_link_get_tooltip(const Glib::ustring& link);
     bool apply_tag_try_automatic_bounds(Glib::RefPtr<Gtk::TextBuffer> text_buffer, Gtk::TextIter iter_start);
-    std::string get_font_css(const std::string& fontStr);
-    const std::string& get_font_for_syntax_highlighting(const std::string& syntaxHighlighting);
-    std::string get_font_css_for_syntax_highlighting(const std::string& syntaxHighlighting);
 
 private:
     Gtk::HBox&     _init_status_bar();
@@ -183,6 +180,7 @@ private:
     void                _on_textview_size_allocate(Gtk::Allocation& allocation);
     bool                _on_textview_event(GdkEvent* event); // pygtk: on_sourceview_event
     void                _on_textview_event_after(GdkEvent* event); // pygtk: on_sourceview_event_after
+    bool                _on_textview_scroll_event(GdkEventScroll* event);
 
     void                _title_update(const bool saveNeeded); // pygtk: window_title_update
     void                _set_new_curr_doc(const Glib::RefPtr<Gio::File>& r_file, const std::string& password);

--- a/future/src/ct/ct_main_win.h
+++ b/future/src/ct/ct_main_win.h
@@ -173,6 +173,7 @@ private:
     bool                _on_treeview_button_release_event(GdkEventButton* event);
     bool                _on_treeview_key_press_event(GdkEventKey* event);
     bool                _on_treeview_popup_menu();
+    bool                _on_treeview_scroll_event(GdkEventScroll* event);
 
     void                _on_textview_populate_popup(Gtk::Menu* menu);
     bool                _on_textview_motion_notify_event(GdkEventMotion* event);
@@ -186,6 +187,7 @@ private:
     void                _set_new_curr_doc(const Glib::RefPtr<Gio::File>& r_file, const std::string& password);
     void                _reset_CtTreestore_CtTreeview();
     void                _ensure_curr_doc_in_recent_docs();
+    void                _zoom_tree(bool is_increase);
 
 private:
     CtConfig*                    _pCtConfig;

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -95,7 +95,7 @@ void CtMenu::init_actions(CtApp *pApp, CtActions* pActions)
     _actions.push_back(CtAction{file_cat, "exit_app", "quit-app", _("_Exit CherryTree"), KB_CONTROL+KB_SHIFT+"Q", _("Exit from CherryTree"), sigc::signal<void>() /* dad.quit_application_totally */});
     _actions.push_back(CtAction{file_cat, "preferences_dlg", "preferences", _("_Preferences"), KB_CONTROL+KB_ALT+"P", _("Preferences"), sigc::mem_fun(*pApp, &CtApp::dialog_preferences) });
     _actions.push_back(CtAction{file_cat, "ct_check_newer", "network", _("_Check Newer Version"), None, _("Check for a Newer Version"), sigc::signal<void>() /* dad.check_for_newer_version */});
-    _actions.push_back(CtAction{file_cat, "ct_help", "help", _("Online _Manual"), "F1", _("Application's Online Manual"), sigc::signal<void>() /* dad.on_help_menu_item_activated */});
+    _actions.push_back(CtAction{file_cat, "ct_help", "help", _("Online _Manual"), "F1", _("Application's Online Manual"), sigc::mem_fun(*pActions, &CtActions::online_help)});
     _actions.push_back(CtAction{file_cat, "ct_about", "about", _("_About"), None, _("About CherryTree"), sigc::signal<void>() /* dad.dialog_about */});
     const char* editor_cat = _("Editor");
     _actions.push_back(CtAction{editor_cat, "act_undo", "g-undo", _("_Undo"), KB_CONTROL+"Z", _("Undo Last Operation"), sigc::mem_fun(*pActions, &CtActions::requested_step_back)});

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -91,7 +91,7 @@ void CtMenu::init_actions(CtApp *pApp, CtActions* pActions)
     _actions.push_back(CtAction{file_cat, "open_cfg_folder", "directory", _("Open Preferences _Directory"), None, _("Open the Directory with Preferences Files"), sigc::mem_fun(*pActions, &CtActions::folder_cfg_open)});
     _actions.push_back(CtAction{file_cat, "print_page_setup", "print", _("Pa_ge Setup"), None, _("Set up the Page for Printing"), sigc::mem_fun(*pActions, &CtActions::export_print_page_setup)});
     _actions.push_back(CtAction{file_cat, "do_print", "print", _("_Print"), KB_CONTROL+"P", _("Print"), sigc::mem_fun(*pActions, &CtActions::export_print)});
-    _actions.push_back(CtAction{file_cat, "quit_app", "quit-app", _("_Quit"), KB_CONTROL+"Q", _("Quit the Application"), sigc::mem_fun(*pApp, &CtApp::quit_application) /* dad.quit_application */});
+    _actions.push_back(CtAction{file_cat, "quit_app", "quit-app", _("_Quit"), KB_CONTROL+"Q", _("Quit the Application"), sigc::mem_fun(*pApp, &CtApp::quit_application)});
     _actions.push_back(CtAction{file_cat, "exit_app", "quit-app", _("_Exit CherryTree"), KB_CONTROL+KB_SHIFT+"Q", _("Exit from CherryTree"), sigc::signal<void>() /* dad.quit_application_totally */});
     _actions.push_back(CtAction{file_cat, "preferences_dlg", "preferences", _("_Preferences"), KB_CONTROL+KB_ALT+"P", _("Preferences"), sigc::mem_fun(*pApp, &CtApp::dialog_preferences) });
     _actions.push_back(CtAction{file_cat, "ct_check_newer", "network", _("_Check Newer Version"), None, _("Check for a Newer Version"), sigc::signal<void>() /* dad.check_for_newer_version */});
@@ -169,8 +169,8 @@ void CtMenu::init_actions(CtApp *pApp, CtActions* pActions)
     _actions.push_back(CtAction{tree_cat, "node_bookmark", "pin-add", _("Add to _Bookmarks"), KB_CONTROL+KB_SHIFT+"B", _("Add the Current Node to the Bookmarks List"), sigc::mem_fun(*pActions, &CtActions::bookmark_curr_node)});
     _actions.push_back(CtAction{tree_cat, "node_unbookmark", "pin-remove", _("_Remove from Bookmarks"), KB_CONTROL+KB_ALT+"B", _("Remove the Current Node from the Bookmarks List"), sigc::mem_fun(*pActions, &CtActions::bookmark_curr_node_remove)});
     _actions.push_back(CtAction{tree_cat, "handle_bookmarks", "edit", _("_Handle Bookmarks"), None, _("Handle the Bookmarks List"), sigc::mem_fun(*pActions, &CtActions::bookmarks_handle)});
-    _actions.push_back(CtAction{tree_cat, "go_node_prev", "go-back", _("Go _Back"), KB_ALT+CtConst::STR_KEY_LEFT, _("Go to the Previous Visited Node"), sigc::signal<void>() /* dad.go_back */});
-    _actions.push_back(CtAction{tree_cat, "go_node_next", "go-forward", _("Go _Forward"), KB_ALT+CtConst::STR_KEY_RIGHT, _("Go to the Next Visited Node"), sigc::signal<void>() /* dad.go_forward */});
+    _actions.push_back(CtAction{tree_cat, "go_node_prev", "go-back", _("Go _Back"), KB_ALT+CtConst::STR_KEY_LEFT, _("Go to the Previous Visited Node"), sigc::mem_fun(*pActions, &CtActions::node_go_back)});
+    _actions.push_back(CtAction{tree_cat, "go_node_next", "go-forward", _("Go _Forward"), KB_ALT+CtConst::STR_KEY_RIGHT, _("Go to the Next Visited Node"), sigc::mem_fun(*pActions, &CtActions::node_go_forward)});
     const char* find_cat = _("Find/Replace");
     _actions.push_back(CtAction{find_cat, "find_in_node", "find_sel", _("_Find in Node Content"), KB_CONTROL+"F", _("Find into the Selected Node Content"), sigc::mem_fun(*pActions, &CtActions::find_in_selected_node)});
     _actions.push_back(CtAction{find_cat, "find_in_allnodes", "find_all", _("Find in _All Nodes Contents"), KB_CONTROL+KB_SHIFT+"F", _("Find into All the Tree Nodes Contents"), sigc::mem_fun(*pActions, &CtActions::find_in_all_nodes)});

--- a/future/src/ct/ct_state_machine.h
+++ b/future/src/ct/ct_state_machine.h
@@ -71,6 +71,8 @@ public:
     void update_state(CtTreeIter tree_iter);
     void update_curr_state_cursor_pos(gint64 node_id);
 
+    void set_go_bk_fw_click(bool val) { _go_bk_fw_click = val; }
+
 private:
     CtMainWin*                  _pCtMainWin;
     Glib::RefPtr<Glib::Regex>   _word_regex;

--- a/future/src/ct/ct_widgets.cc
+++ b/future/src/ct/ct_widgets.cc
@@ -173,12 +173,13 @@ CtTextView::~CtTextView()
 void CtTextView::setup_for_syntax(const std::string& syntax)
 {
     std::string new_class;
-    if (CtConst::RICH_TEXT_ID == syntax)         new_class = "rich-text";
-    else if (CtConst::PLAIN_TEXT_ID == syntax)   new_class = "plain-text";
-    else                                         new_class = "code";
-    get_style_context()->remove_class("rich-text");
-    get_style_context()->remove_class("plain-text");
-    get_style_context()->remove_class("code");
+    if (CtConst::RICH_TEXT_ID == syntax)         { new_class = "rich-text"; }
+    else if (CtConst::PLAIN_TEXT_ID == syntax)   { new_class = "plain-text"; }
+    else                                         { new_class = "code"; }
+
+    if (new_class != "rich-text") get_style_context()->remove_class("rich-text");
+    if (new_class != "plain-text") get_style_context()->remove_class("plain-text");
+    if (new_class != "code") get_style_context()->remove_class("code");
     get_style_context()->add_class(new_class);
 
     if (CtConst::RICH_TEXT_ID == syntax)
@@ -199,7 +200,6 @@ void CtTextView::setup_for_syntax(const std::string& syntax)
             set_draw_spaces(Gsv::DRAW_SPACES_ALL & ~Gsv::DRAW_SPACES_NEWLINE);
         }
     }
-    _setFontForSyntax(syntax);
 }
 
 void CtTextView::set_pixels_inside_wrap(int space_around_lines, int relative_wrapped_space)
@@ -221,14 +221,6 @@ void CtTextView::set_selection_at_offset_n_delta(int offset, int delta, Glib::Re
     } else {
         // # print "! bad offset=%s, delta=%s on node %s" % (offset, delta, self.treestore[self.curr_tree_iter][1])
     }
-}
-
-void CtTextView::_setFontForSyntax(const std::string& syntaxHighlighting)
-{
-    Glib::RefPtr<Gtk::StyleContext> rStyleContext = get_style_context();
-    std::string fontCss = _pCtMainWin->get_font_css_for_syntax_highlighting(syntaxHighlighting);
-    _pCtMainWin->get_css_provider()->load_from_data(fontCss);
-    rStyleContext->add_provider(_pCtMainWin->get_css_provider(), GTK_STYLE_PROVIDER_PRIORITY_USER);
 }
 
 // Called at list indent/unindent time
@@ -658,36 +650,14 @@ void CtTextView::cursor_and_tooltips_handler(int x, int y)
 // Increase or Decrease Text Font
 void CtTextView::zoom_text(bool is_increase)
 {
-    /* todo:
-    std::vector<Glib::ustring> font_vec;
-    if (syntax_highl == CtConst::RICH_TEXT_ID)
-        font_vec = str::split(rt_font.split(cons.CHAR_SPACE)
-    elif syntax_highl == cons.PLAIN_TEXT_ID:
-        font_vec = self.pt_font.split(cons.CHAR_SPACE)
-    else:
-        font_vec = self.code_font.split(cons.CHAR_SPACE)
-    font_num = int(font_vec[-1])
-    if is_increase is True:
-        font_vec[-1] = str(font_num+1)
-    else:
-        if font_num <= 6: return # do not go under 6
-        font_vec[-1] = str(font_num-1)
-    if syntax_highl == cons.RICH_TEXT_ID:
-        self.rt_font = cons.CHAR_SPACE.join(font_vec)
-        target_font = self.rt_font
-    elif syntax_highl == cons.PLAIN_TEXT_ID:
-        self.pt_font = cons.CHAR_SPACE.join(font_vec)
-        target_font = self.pt_font
-    else:
-        self.code_font = cons.CHAR_SPACE.join(font_vec)
-        target_font = self.code_font
-    if from_codebox is True:
-        support.rich_text_node_modify_codeboxes_font(self.curr_buffer.get_start_iter(), self)
-    elif from_table is True:
-        support.rich_text_node_modify_tables_font(self.curr_buffer.get_start_iter(), self)
-    else:
-        self.sourceview.modify_font(pango.FontDescription(target_font))
-        */
+    Glib::RefPtr<Gtk::StyleContext> context = get_style_context();
+    Pango::FontDescription description = context->get_font(context->get_state());
+    auto family = description.get_family();
+    auto size = description.get_size() / Pango::SCALE + (is_increase ? 1 : -1);
+    if (size < 6) size = 6;
+    description.set_size(size * Pango::SCALE);
+    override_font(description);
+
 }
 
 // Try and apply link to previous word (after space or newline)

--- a/future/src/ct/ct_widgets.cc
+++ b/future/src/ct/ct_widgets.cc
@@ -652,12 +652,10 @@ void CtTextView::zoom_text(bool is_increase)
 {
     Glib::RefPtr<Gtk::StyleContext> context = get_style_context();
     Pango::FontDescription description = context->get_font(context->get_state());
-    auto family = description.get_family();
     auto size = description.get_size() / Pango::SCALE + (is_increase ? 1 : -1);
     if (size < 6) size = 6;
     description.set_size(size * Pango::SCALE);
     override_font(description);
-
 }
 
 // Try and apply link to previous word (after space or newline)

--- a/future/src/ct/ct_widgets.h
+++ b/future/src/ct/ct_widgets.h
@@ -109,11 +109,10 @@ private:
     bool          _apply_tag_try_link(Gtk::TextIter iter_end, int offset_cursor);
     Glib::ustring _get_former_line_indentation(Gtk::TextIter iter_start);
     void          _special_char_replace(gunichar special_char, Gtk::TextIter iter_start, Gtk::TextIter iter_insert);
-    CtMainWin* _pCtMainWin;
 
 public:
     static const double TEXT_SCROLL_MARGIN;
 
-protected:
-    void _setFontForSyntax(const std::string& syntaxHighlighting);
+private:
+    CtMainWin* _pCtMainWin;
 };


### PR DESCRIPTION
(ref to keep progress: #444)

P.S.: I removed `_setFontForSyntax` and related functions because there is no need for them, fonts are already put in style classes (like `.rich-text`, etc.). and textviews only need to change its class to change font.


