### PR TITLE
(Port to C++) some fixes; theme for tree and textview

### DIFF
--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -286,6 +286,10 @@ private:
 
 public:
     // others actions
+    void link_cut();
+    void link_copy();
+    void link_dismiss();
+    void link_delete();
     void anchor_cut();
     void anchor_copy();
     void anchor_delete();

--- a/future/src/ct/ct_actions_others.cc
+++ b/future/src/ct/ct_actions_others.cc
@@ -27,6 +27,40 @@
 #include <fstream>
 #include <cstdlib>
 
+// Cut Link
+void CtActions::link_cut()
+{
+    if (!_is_curr_node_not_read_only_or_error()) return;
+    if (!_link_check_around_cursor().empty())
+        g_signal_emit_by_name(G_OBJECT(_pCtMainWin->get_text_view().gobj()), "cut-clipboard");
+}
+
+// Copy Link
+void CtActions::link_copy()
+{
+    if (!_link_check_around_cursor().empty())
+        g_signal_emit_by_name(G_OBJECT(_pCtMainWin->get_text_view().gobj()), "copy-clipboard");
+}
+
+//Dismiss Link
+void CtActions::link_dismiss()
+{
+    if (!_is_curr_node_not_read_only_or_error()) return;
+    if (!_link_check_around_cursor().empty())
+        remove_text_formatting();
+}
+
+// Delete Link
+void CtActions::link_delete()
+{
+    if (!_is_curr_node_not_read_only_or_error()) return;
+    if (!_link_check_around_cursor().empty())
+    {
+        _curr_buffer()->erase_selection(true, _pCtMainWin->get_text_view().get_editable());
+        _pCtMainWin->get_text_view().grab_focus();
+    }
+}
+
 // Cut Anchor
 void CtActions::anchor_cut()
 {

--- a/future/src/ct/ct_clipboard.h
+++ b/future/src/ct/ct_clipboard.h
@@ -38,7 +38,6 @@ struct CtClipboardData
 class CtClipboard
 {
 public:
-    CtClipboard() {} // use from static, need to set pCtMainWin manually just before usage
     CtClipboard(CtMainWin* pCtMainWin);
 
 public:
@@ -46,10 +45,8 @@ public:
     static void on_copy_clipboard(GtkTextView* pTextView, gpointer codebox);
     static void on_paste_clipboard(GtkTextView* pTextView, gpointer codebox);
     static void force_plain_text() { _static_force_plain_text = true; }
-    static CtMainWin* pCtMainWin;
 
 private:
-    CtMainWin* _get_CtMainWin();
     void _cut_clipboard(Gtk::TextView* pTextView, CtCodebox* pCodebox);
     void _copy_clipboard(Gtk::TextView* pTextView, CtCodebox* pCodebox);
     void _paste_clipboard(Gtk::TextView* pTextView, CtCodebox* pCodebox);

--- a/future/src/ct/ct_codebox.cc
+++ b/future/src/ct/ct_codebox.cc
@@ -84,6 +84,7 @@ CtCodebox::CtCodebox(CtMainWin* pCtMainWin,
    _key_down(false)
 {
     _ctTextview.get_style_context()->add_class("codebox");
+    _ctTextview.set_border_width(1);
 
     _scrolledwindow.set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC);
     _scrolledwindow.add(_ctTextview);

--- a/future/src/ct/ct_dialogs.cc
+++ b/future/src/ct/ct_dialogs.cc
@@ -735,6 +735,9 @@ bool CtDialogs::link_handle_dialog(CtMainWin& ctMainWin,
                                    Gtk::TreeIter sel_tree_iter,
                                    CtLinkEntry& link_entries)
 {
+    if (link_entries.type == "")
+        link_entries.type = CtConst::LINK_TYPE_WEBS;
+
     CtTreeStore& ctTreestore = ctMainWin.curr_tree_store();
     Gtk::Dialog dialog(title,
                        ctMainWin,

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -66,6 +66,7 @@ CtMainWin::CtMainWin(CtConfig*        pCtConfig,
         _hPaned.add1(_scrolledwindowTree);
         _hPaned.add2(_vboxText);
     }
+    _hPaned.property_wide_handle() = true;
 
     _pMenuBar = pCtMenu->build_menubar();
     _pMenuBar->set_name("MenuBar");
@@ -436,7 +437,7 @@ void CtMainWin::config_update_data_from_curr_status()
 }
 
 void CtMainWin::configure_theme()
-{
+{ 
     auto font_to_string = [](Pango::FontDescription font)
     {
         return " { font-family: " + font.get_family() +
@@ -449,13 +450,6 @@ void CtMainWin::configure_theme()
     std::string codeFont = font_to_string(Pango::FontDescription(_pCtConfig->codeFont));
     std::string treeFont = font_to_string(Pango::FontDescription(_pCtConfig->treeFont));
 
-    auto screen = get_screen();
-    if (_css_provider_theme_font)
-    {
-        Gtk::StyleContext::remove_provider_for_screen(screen, _css_provider_theme_font);
-    }
-    _css_provider_theme_font = Gtk::CssProvider::create();
-
     std::string font_css;
     font_css += ".ct_textview.rich-text" + rtFont;
     font_css += ".ct_textview.plain-text" + plFont;
@@ -465,26 +459,19 @@ void CtMainWin::configure_theme()
     font_css += ".codebox.code" + codeFont;
     font_css += ".ct_node_view" + treeFont;
 
-    _css_provider_theme_font->load_from_data(font_css);
-    get_style_context()->add_provider_for_screen(screen, _css_provider_theme_font, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-
-
-    // can do more complicated things than just changing colors
-    if (_css_provider_theme)
-    {
-        Gtk::StyleContext::remove_provider_for_screen(screen, _css_provider_theme);
-    }
-    _css_provider_theme = Gtk::CssProvider::create();
     std::string theme_css;
-    // todo: rich text fix light selected line with dark theme
-    //theme_css += ".ct_textview.rich-text > text { color: " + _pCtConfig->rtDefFg + "; background-color: " + _pCtConfig->rtDefBg + "; } ";
-    // todo: tree selected node highlight no longer working
     theme_css += ".ct_node_view { color: " + _pCtConfig->ttDefFg + "; background-color: " + _pCtConfig->ttDefBg + "; } ";
     theme_css += ".ct_node_view:selected { background: #5294e2;  } ";
     theme_css += ".ct_header { background-color: " + _pCtConfig->ttDefBg + "; } ";
 
+    if (!_css_provider_theme)
+    {
+        Gtk::StyleContext::remove_provider_for_screen(get_screen(), _css_provider_theme);
+    }
+    _css_provider_theme = Gtk::CssProvider::create();
+    _css_provider_theme->load_from_data(font_css);
     _css_provider_theme->load_from_data(theme_css);
-    get_style_context()->add_provider_for_screen(screen, _css_provider_theme, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+    get_style_context()->add_provider_for_screen(get_screen(), _css_provider_theme, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
 }
 
 Gtk::HBox& CtMainWin::_init_status_bar()
@@ -494,6 +481,9 @@ Gtk::HBox& CtMainWin::_init_status_bar()
     _ctStatusBar.frame.set_border_width(1);
     _ctStatusBar.frame.add(_ctStatusBar.progressBar);
     _ctStatusBar.stopButton.set_image_from_icon_name("stop", Gtk::ICON_SIZE_MENU);
+    _ctStatusBar.statusBar.set_margin_top(0);
+    _ctStatusBar.statusBar.set_margin_bottom(0);
+    _ctStatusBar.hbox.set_border_width(0);
     _ctStatusBar.hbox.pack_start(_ctStatusBar.statusBar, true, true);
     _ctStatusBar.hbox.pack_start(_ctStatusBar.frame, false, true);
     _ctStatusBar.hbox.pack_start(_ctStatusBar.stopButton, false, true);

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -136,7 +136,15 @@ Glib::RefPtr<Gsv::Buffer> CtMainWin::get_new_text_buffer(const std::string& synt
     Glib::RefPtr<Gsv::Buffer> rRetTextBuffer;
     rRetTextBuffer = Gsv::Buffer::create(_rGtkTextTagTable);
     rRetTextBuffer->set_max_undo_levels(_pCtConfig->limitUndoableSteps);
-    if (CtConst::RICH_TEXT_ID != syntax)
+    if (CtConst::RICH_TEXT_ID == syntax)
+    {
+        // dark theme
+        if (get_ct_config()->rtDefFg == CtConst::RICH_TEXT_DARK_FG && get_ct_config()->rtDefBg == CtConst::RICH_TEXT_DARK_BG)
+            rRetTextBuffer->set_style_scheme(_pGsvStyleSchemeManager->get_scheme("cobalt"));
+        else
+            rRetTextBuffer->set_style_scheme(_pGsvStyleSchemeManager->get_scheme("classic"));
+    }
+    else
     {
         rRetTextBuffer->set_style_scheme(_pGsvStyleSchemeManager->get_scheme(_pCtConfig->styleSchemeId));
         if (CtConst::PLAIN_TEXT_ID == syntax)

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -468,7 +468,7 @@ void CtMainWin::configure_theme()
     _css_provider_theme_font->load_from_data(font_css);
     get_style_context()->add_provider_for_screen(screen, _css_provider_theme_font, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
 
-#ifdef THEME_FIXES_REQUIRED
+
     // can do more complicated things than just changing colors
     if (_css_provider_theme)
     {
@@ -477,14 +477,14 @@ void CtMainWin::configure_theme()
     _css_provider_theme = Gtk::CssProvider::create();
     std::string theme_css;
     // todo: rich text fix light selected line with dark theme
-    theme_css += ".ct_textview.rich-text > text { color: " + _pCtConfig->rtDefFg + "; background-color: " + _pCtConfig->rtDefBg + "; } ";
+    //theme_css += ".ct_textview.rich-text > text { color: " + _pCtConfig->rtDefFg + "; background-color: " + _pCtConfig->rtDefBg + "; } ";
     // todo: tree selected node highlight no longer working
     theme_css += ".ct_node_view { color: " + _pCtConfig->ttDefFg + "; background-color: " + _pCtConfig->ttDefBg + "; } ";
+    theme_css += ".ct_node_view:selected { background: #5294e2;  } ";
     theme_css += ".ct_header { background-color: " + _pCtConfig->ttDefBg + "; } ";
 
     _css_provider_theme->load_from_data(theme_css);
     get_style_context()->add_provider_for_screen(screen, _css_provider_theme, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-#endif // THEME_FIXES_REQUIRED
 }
 
 Gtk::HBox& CtMainWin::_init_status_bar()

--- a/future/src/ct/ct_main_win.h
+++ b/future/src/ct/ct_main_win.h
@@ -228,7 +228,6 @@ private:
     CtCurrFile _ctCurrFile;
 
     Glib::RefPtr<Gtk::CssProvider> _css_provider_theme;
-    Glib::RefPtr<Gtk::CssProvider> _css_provider_theme_font;
 
 private:
     bool                _userActive{true}; // pygtk: user_active

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -249,11 +249,11 @@ void CtMenu::init_actions(CtApp *pApp, CtActions* pActions)
 
     // for popup menus
     const char* link_cat = "";
-    _actions.push_back(CtAction{link_cat, "apply_tag_link", "link_handle", _("Edit _Link"), None, _("Edit the Underlying Link"), sigc::signal<void>() /*dad.apply_tag_link*/});
-    _actions.push_back(CtAction{link_cat, "link_cut", "edit_cut", _("C_ut Link"), None, _("Cut the Selected Link"), sigc::signal<void>() /*dad.link_cut*/});
-    _actions.push_back(CtAction{link_cat, "link_copy", "edit_copy", _("_Copy Link"), None, _("Copy the Selected Link"), sigc::signal<void>() /*dad.link_copy*/});
-    _actions.push_back(CtAction{link_cat, "link_dismiss", "clear", _("D_ismiss Link"), None, _("Dismiss the Selected Link"), sigc::signal<void>() /*dad.link_dismiss*/});
-    _actions.push_back(CtAction{link_cat, "link_delete", "edit_delete", _("_Delete Link"), None, _("Delete the Selected Link"), sigc::signal<void>() /*dad.link_delete*/});
+    _actions.push_back(CtAction{link_cat, "apply_tag_link", "link_handle", _("Edit _Link"), None, _("Edit the Underlying Link"), sigc::mem_fun(*pActions, &CtActions::apply_tag_link)});
+    _actions.push_back(CtAction{link_cat, "link_cut", "edit_cut", _("C_ut Link"), None, _("Cut the Selected Link"), sigc::mem_fun(*pActions, &CtActions::link_cut)});
+    _actions.push_back(CtAction{link_cat, "link_copy", "edit_copy", _("_Copy Link"), None, _("Copy the Selected Link"), sigc::mem_fun(*pActions, &CtActions::link_cut)});
+    _actions.push_back(CtAction{link_cat, "link_dismiss", "clear", _("D_ismiss Link"), None, _("Dismiss the Selected Link"), sigc::mem_fun(*pActions, &CtActions::link_dismiss)});
+    _actions.push_back(CtAction{link_cat, "link_delete", "edit_delete", _("_Delete Link"), None, _("Delete the Selected Link"), sigc::mem_fun(*pActions, &CtActions::link_delete)});
     const char* table_cat = "";
     _actions.push_back(CtAction{table_cat, "table_cut", "edit_cut", _("C_ut Table"), None, _("Cut the Selected Table"), sigc::signal<void>() /*dad.tables_handler.table_cut*/});
     _actions.push_back(CtAction{table_cat, "table_copy", "edit_copy", _("_Copy Table"), None, _("Copy the Selected Table"), sigc::signal<void>() /*dad.tables_handler.table_copy*/});

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -251,7 +251,7 @@ void CtMenu::init_actions(CtApp *pApp, CtActions* pActions)
     const char* link_cat = "";
     _actions.push_back(CtAction{link_cat, "apply_tag_link", "link_handle", _("Edit _Link"), None, _("Edit the Underlying Link"), sigc::mem_fun(*pActions, &CtActions::apply_tag_link)});
     _actions.push_back(CtAction{link_cat, "link_cut", "edit_cut", _("C_ut Link"), None, _("Cut the Selected Link"), sigc::mem_fun(*pActions, &CtActions::link_cut)});
-    _actions.push_back(CtAction{link_cat, "link_copy", "edit_copy", _("_Copy Link"), None, _("Copy the Selected Link"), sigc::mem_fun(*pActions, &CtActions::link_cut)});
+    _actions.push_back(CtAction{link_cat, "link_copy", "edit_copy", _("_Copy Link"), None, _("Copy the Selected Link"), sigc::mem_fun(*pActions, &CtActions::link_copy)});
     _actions.push_back(CtAction{link_cat, "link_dismiss", "clear", _("D_ismiss Link"), None, _("Dismiss the Selected Link"), sigc::mem_fun(*pActions, &CtActions::link_dismiss)});
     _actions.push_back(CtAction{link_cat, "link_delete", "edit_delete", _("_Delete Link"), None, _("Delete the Selected Link"), sigc::mem_fun(*pActions, &CtActions::link_delete)});
     const char* table_cat = "";

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -657,7 +657,7 @@ guint32 CtRgbUtil::get_rgb24int_from_str_any(const char* rgbStrAny)
 std::string CtRgbUtil::rgb_to_string(Gdk::RGBA color)
 {
     char rgbStrOut[16];
-    sprintf(rgbStrOut, "#%.2x%.2x%.2x", color.get_red_u(), color.get_green_u(), color.get_blue_u());
+    sprintf(rgbStrOut, "#%.4x%.4x%.4x", color.get_red_u(), color.get_green_u(), color.get_blue_u());
     return rgbStrOut;
 }
 

--- a/future/src/ct/ct_pref_dlg.cc
+++ b/future/src/ct/ct_pref_dlg.cc
@@ -449,20 +449,10 @@ Gtk::Widget* CtPrefDlg::build_tab_rich_text()
     colorbutton_text_fg->signal_color_set().connect([this, pConfig, colorbutton_text_fg](){
         pConfig->rtDefFg = CtRgbUtil::rgb_any_to_24(colorbutton_text_fg->get_rgba());
         _pCtMainWin->configure_theme();
-        //if dad.curr_tree_iter and dad.syntax_highlighting == cons.RICH_TEXT_ID:
-        //    dad.widget_set_colors(dad.sourceview, dad.rt_def_fg, dad.rt_def_bg, False)
-        //    support.rich_text_node_modify_codeboxes_color(dad.curr_buffer.get_start_iter(), dad)
     });
     colorbutton_text_bg->signal_color_set().connect([this, pConfig, colorbutton_text_bg](){
         pConfig->rtDefBg = CtRgbUtil::rgb_any_to_24(colorbutton_text_bg->get_rgba());
         _pCtMainWin->configure_theme();
-        //if dad.curr_tree_iter and dad.syntax_highlighting == cons.RICH_TEXT_ID:
-        //    if dad.rt_highl_curr_line:
-        //        dad.set_sourcebuffer_with_style_scheme()
-        //        dad.sourceview.set_buffer(dad.curr_buffer)
-        //        dad.objects_buffer_refresh()
-        //    dad.widget_set_colors(dad.sourceview, dad.rt_def_fg, dad.rt_def_bg, False)
-        //    support.rich_text_node_modify_codeboxes_color(dad.curr_buffer.get_start_iter(), dad)
     });
     radiobutton_rt_col_light->signal_toggled().connect([radiobutton_rt_col_light, colorbutton_text_fg, colorbutton_text_bg](){
         if (!radiobutton_rt_col_light->get_active()) return;
@@ -779,31 +769,35 @@ Gtk::Widget* CtPrefDlg::build_tab_tree_1()
     pMainBox->pack_start(*frame_nodes_icons, false, false);
     pMainBox->pack_start(*frame_nodes_startup, false, false);
 
-    colorbutton_tree_fg->signal_color_set().connect([this, pConfig, colorbutton_tree_fg](){
+    auto update_tree_color = [this, pConfig, colorbutton_tree_fg, colorbutton_tree_bg]() {
         pConfig->ttDefFg = CtRgbUtil::rgb_any_to_24(colorbutton_tree_fg->get_rgba());
-        _pCtMainWin->configure_theme();
-    });
-    colorbutton_tree_bg->signal_color_set().connect([this, pConfig, colorbutton_tree_bg](){
         pConfig->ttDefBg = CtRgbUtil::rgb_any_to_24(colorbutton_tree_bg->get_rgba());
         _pCtMainWin->configure_theme();
+    };
+
+    colorbutton_tree_fg->signal_color_set().connect([update_tree_color, radiobutton_tt_col_custom](){
+        if (!radiobutton_tt_col_custom->get_active()) return;
+        update_tree_color();
     });
-    radiobutton_tt_col_light->signal_toggled().connect([radiobutton_tt_col_light, colorbutton_tree_fg, colorbutton_tree_bg](){
+    colorbutton_tree_bg->signal_color_set().connect([update_tree_color, radiobutton_tt_col_custom](){
+        if (!radiobutton_tt_col_custom->get_active()) return;
+        update_tree_color();
+    });
+    radiobutton_tt_col_light->signal_toggled().connect([radiobutton_tt_col_light, colorbutton_tree_fg, colorbutton_tree_bg, update_tree_color](){
         if (!radiobutton_tt_col_light->get_active()) return;
         colorbutton_tree_fg->set_rgba(Gdk::RGBA(CtConst::TREE_TEXT_LIGHT_FG));
         colorbutton_tree_bg->set_rgba(Gdk::RGBA(CtConst::TREE_TEXT_LIGHT_BG));
         colorbutton_tree_fg->set_sensitive(false);
         colorbutton_tree_bg->set_sensitive(false);
-        g_signal_emit_by_name(colorbutton_tree_fg->gobj(), "color-set");
-        g_signal_emit_by_name(colorbutton_tree_bg->gobj(), "color-set");
+        update_tree_color();
     });
-    radiobutton_tt_col_dark->signal_toggled().connect([radiobutton_tt_col_dark, colorbutton_tree_fg, colorbutton_tree_bg](){
-        if (radiobutton_tt_col_dark->get_active()) return;
+    radiobutton_tt_col_dark->signal_toggled().connect([radiobutton_tt_col_dark, colorbutton_tree_fg, colorbutton_tree_bg, update_tree_color](){
+        if (!radiobutton_tt_col_dark->get_active()) return;
         colorbutton_tree_fg->set_rgba(Gdk::RGBA(CtConst::TREE_TEXT_DARK_FG));
         colorbutton_tree_bg->set_rgba(Gdk::RGBA(CtConst::TREE_TEXT_DARK_BG));
         colorbutton_tree_fg->set_sensitive(false);
         colorbutton_tree_bg->set_sensitive(false);
-        g_signal_emit_by_name(colorbutton_tree_fg->gobj(), "color-set");
-        g_signal_emit_by_name(colorbutton_tree_bg->gobj(), "color-set");
+        update_tree_color();
     });
     radiobutton_tt_col_custom->signal_toggled().connect([radiobutton_tt_col_custom, colorbutton_tree_fg, colorbutton_tree_bg](){
         if (!radiobutton_tt_col_custom->get_active()) return;


### PR DESCRIPTION
(ref to keep progress: #444)

- removed static ctMainWin from clipboard, there is no need for it
- changing colors for tree panel is working
- changing colors for textview will have two mode: light (classic) and dark (cobalt). Custom colors won't work.

CSS in terms of customizing gtksourceview is very limited and colors have to be set by theme manager (as I did now). The issue with custom colors is that bg and fg are not enough because other colors (selection, current-line, etc.) should be also changed. Gnote, for example, has a theme editor for customizing, to me, it looks easy to do, but can be postpone until first release.

It looks like, the only part to do are tables and then pre-release? 🎵 💃💃💃
