### PR TITLE
(Port to C++) paste html from clipboard

### DIFF
--- a/future/src/ct/ct_clipboard.cc
+++ b/future/src/ct/ct_clipboard.cc
@@ -564,9 +564,12 @@ void CtClipboard::_on_received_to_table(const Gtk::SelectionData& selection_data
 }
 
 // From Clipboard to HTML Text
-void CtClipboard::_on_received_to_html(const Gtk::SelectionData& /*selection_data*/, Gtk::TextView* /*pTextView*/, bool)
+void CtClipboard::_on_received_to_html(const Gtk::SelectionData& selection_data, Gtk::TextView* pTextView, bool)
 {
-    // todo:
+    CtHtml2Xml parser(_pCtMainWin);
+    parser.feed(selection_data.get_data_as_string());
+    from_xml_string_to_buffer(pTextView->get_buffer(), parser.to_string());
+    pTextView->scroll_to(pTextView->get_buffer()->get_insert());
 }
 
 // From Clipboard to Image

--- a/future/src/ct/ct_codebox.cc
+++ b/future/src/ct/ct_codebox.cc
@@ -168,6 +168,7 @@ void CtCodebox::apply_width_height(const int parentTextWidth)
 
 void CtCodebox::to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment)
 {
+    // todo: fix code duplicates in void CtHtml2Xml::_insert_codebox()
     xmlpp::Element* p_codebox_node = p_node_parent->add_child("codebox");
     p_codebox_node->set_attribute("char_offset", std::to_string(_charOffset+offset_adjustment));
     p_codebox_node->set_attribute(CtConst::TAG_JUSTIFICATION, _justification);

--- a/future/src/ct/ct_imports.cc
+++ b/future/src/ct/ct_imports.cc
@@ -206,7 +206,7 @@ void CtHtml2Xml::handle_starttag(std::string_view tag, const char** atts)
                     int colon_pos = str::indexOf(style_attribute, CtConst::CHAR_COLON);
                     if (colon_pos < 0) continue;
                     auto attr_name = str::trim(style_attribute.substr(0, colon_pos).lowercase());
-                    auto attr_value = str::trim(style_attribute.substr(colon_pos + 1, style_attribute.size() - colon_pos).lowercase());
+                    Glib::ustring attr_value = str::trim(style_attribute.substr(colon_pos + 1, style_attribute.size() - colon_pos).lowercase());
                     if (attr_name == "color") {
                         auto color = _convert_html_color(attr_value);
                         if (!color.empty())
@@ -226,6 +226,19 @@ void CtHtml2Xml::handle_starttag(std::string_view tag, const char** atts)
                     } else if (attr_name == "font-style") {
                         if (attr_value == CtConst::TAG_PROP_VAL_ITALIC)
                             _add_tag_style(CtConst::TAG_STYLE, CtConst::TAG_PROP_VAL_ITALIC);
+                    } else if (attr_name == "font-size") {
+                        try
+                        {
+                            attr_value = str::replace(attr_value, "pt", "");
+                            int font_size = std::stoi(attr_value, nullptr);
+                            if (font_size > 7 && font_size < 11)
+                                _add_tag_style(CtConst::TAG_SCALE, CtConst::TAG_PROP_VAL_SMALL);
+                            else if (font_size > 13 && font_size < 19)
+                                _add_tag_style(CtConst::TAG_SCALE, CtConst::TAG_PROP_VAL_H3);
+                            else if (font_size >= 19)
+                                _add_tag_style(CtConst::TAG_SCALE, CtConst::TAG_PROP_VAL_H2);
+
+                        } catch (...) {}
                     }
                 }
             }
@@ -306,7 +319,7 @@ void CtHtml2Xml::handle_starttag(std::string_view tag, const char** atts)
             int rowspan = 1;
             for (auto& tag_attr: char2list_attrs(atts))
                 if (tag_attr.name == "rowspan")
-                    rowspan = atoi(tag_attr.value.begin());
+                    rowspan = std::atoi(tag_attr.value.begin());
             _table.back().push_back(table_cell{rowspan, ""});
         }
         else if (tag == "img" || tag == "v:imagedata") {

--- a/future/src/ct/ct_imports.cc
+++ b/future/src/ct/ct_imports.cc
@@ -22,8 +22,13 @@
 #include "ct_imports.h"
 #include "ct_misc_utils.h"
 #include "ct_const.h"
+#include "ct_main_win.h"
 #include <libxml2/libxml/SAX.h>
 #include <iostream>
+#include <glibmm/base64.h>
+
+const std::set<std::string> CtHtml2Xml::HTML_A_TAGS{"p", "b", "i", "u", "s", CtConst::TAG_PROP_VAL_H1,
+            CtConst::TAG_PROP_VAL_H2, CtConst::TAG_PROP_VAL_H3, "span", "font"};
 
 // Parse plain text for possible web links
 std::vector<std::pair<int, int>> CtImports::get_web_links_offsets_from_plain_text(const Glib::ustring& plain_text)
@@ -49,6 +54,14 @@ std::vector<std::pair<int, int>> CtImports::get_web_links_offsets_from_plain_tex
     }
     return web_links;
 }
+
+std::string CtImports::get_internal_link_from_http_url(std::string link_url)
+{
+    if (str::startswith(link_url, "http"))          return "webs " + link_url;
+    else if (str::startswith(link_url, "file://"))  return "file " + Glib::Base64::encode(link_url.substr(7));
+    else                                            return "webs http://" + link_url;
+}
+
 
 
 void CtHtmlParser::feed(const std::string& html)
@@ -83,20 +96,14 @@ void CtHtmlParser::feed(const std::string& html)
     htmlSAXParseDoc((xmlChar*)html.c_str(), "UTF-8", &sax2Handler, this);
 }
 
-std::string CtHtmlParser::fix_body(const std::string& html)
+void CtHtmlParser::handle_starttag(std::string_view tag, const char **atts)
 {
-    return "<!doctype html><html><head><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\"></head><body>"
-            + html + "</body></html>";
+    std::cout << "SAX tag: " << tag << std::endl;
 }
 
-void CtHtmlParser::handle_starttag(std::string_view name, const char **atts)
+void CtHtmlParser::handle_endtag(std::string_view tag)
 {
-    std::cout << "SAX tag: " << name << std::endl;
-}
-
-void CtHtmlParser::handle_endtag(std::string_view name)
-{
-    std::cout << "SAX endtag: " << name << std::endl;
+    std::cout << "SAX endtag: " << tag << std::endl;
 }
 
 void CtHtmlParser::handle_data(std::string_view text)
@@ -108,3 +115,526 @@ void CtHtmlParser::handle_charref(std::string_view name)
 {
     std::cout << "SAX ref: " << std::endl;
 }
+
+std::list<CtHtmlParser::html_attr> CtHtmlParser::char2list_attrs(const char** atts)
+{
+    std::list<html_attr> attr_list;
+    if (atts == nullptr)  return attr_list;
+    while (*atts != nullptr)
+    {
+        html_attr attr;
+        attr.name = *(atts++);
+        attr.value = *(atts++);
+        attr_list.push_back(attr);
+    }
+    return attr_list;
+}
+
+
+
+CtHtml2Xml::CtHtml2Xml(CtMainWin *pCtMainWin)
+    :_pCtMainWin(pCtMainWin)
+{
+
+}
+
+void CtHtml2Xml::feed(const std::string& html)
+{
+    _state = ParserState::WAIT_BODY;
+    _tag_id_generator = 0;
+    _tag_styles.clear();
+    _html_pre_tag_open = false;
+    _html_td_tag_open = false;
+    _html_a_tag_counter = 0;
+    _list_type = 'u';
+    _list_num = 0;
+    _table.clear();
+
+    _slot_root = _xml_doc.create_root_node("root")->add_child("slot");
+    _char_offset = 0;
+    _slot_text = "";
+    _slot_style_id = -1;
+    _slot_styles_cache.clear();
+
+    if (str::startswith(html, "<!doctype html>"))
+        CtHtmlParser::feed(html);
+    else {
+        // if not fixed, we can skip some items
+        std::string fixed_html = "<!doctype html><html><head><meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\"</head><body>"
+                + html + "</body></html>";
+        CtHtmlParser::feed(fixed_html);
+    }
+
+
+    _rich_text_save_pending();
+}
+
+void CtHtml2Xml::handle_starttag(std::string_view tag, const char** atts)
+{
+    _start_adding_tag_styles();
+
+    if (HTML_A_TAGS.count(tag.begin())) _html_a_tag_counter += 1;
+
+    if (_state == ParserState::WAIT_BODY)
+    {
+        if (tag == "body")
+            _state = ParserState::PARSING_BODY;
+    }
+    else if (_state == ParserState::PARSING_BODY)
+    {
+        if (tag == "table")
+        {
+            _table.clear();
+            _html_td_tag_open = false;
+            _state = ParserState::PARSING_TABLE;
+        }
+        else if (tag == "strong") _add_tag_style(CtConst::TAG_WEIGHT, CtConst::TAG_PROP_VAL_HEAVY);
+        else if (tag == "b") _add_tag_style(CtConst::TAG_WEIGHT, CtConst::TAG_PROP_VAL_HEAVY);
+        else if (tag == "i") _add_tag_style(CtConst::TAG_STYLE, CtConst::TAG_PROP_VAL_ITALIC);
+        else if (tag == "em") _add_tag_style(CtConst::TAG_STYLE, CtConst::TAG_PROP_VAL_ITALIC);
+        else if (tag == "u") _add_tag_style(CtConst::TAG_UNDERLINE, CtConst::TAG_PROP_VAL_SINGLE);
+        else if (tag == "s") _add_tag_style(CtConst::TAG_STRIKETHROUGH, CtConst::TAG_PROP_VAL_TRUE);
+        else if (tag == CtConst::TAG_STYLE) _state = ParserState::WAIT_BODY;
+        else if (tag == "span")
+        {
+            for (auto& tag_attr: char2list_attrs(atts))
+            {
+                if (tag_attr.name != CtConst::TAG_STYLE)
+                    continue;
+                for (Glib::ustring& style_attribute: str::split(Glib::ustring(tag_attr.value.begin()), ";"))
+                {
+                    int colon_pos = str::indexOf(style_attribute, CtConst::CHAR_COLON);
+                    if (colon_pos < 0) continue;
+                    auto attr_name = str::trim(style_attribute.substr(0, colon_pos).lowercase());
+                    auto attr_value = str::trim(style_attribute.substr(colon_pos + 1, style_attribute.size() - colon_pos).lowercase());
+                    if (attr_name == "color") {
+                        auto color = _convert_html_color(attr_value);
+                        if (!color.empty())
+                            _add_tag_style(CtConst::TAG_FOREGROUND, color);
+                    } else if (attr_name == CtConst::TAG_BACKGROUND || attr_name == "background-color") {
+                        auto color = _convert_html_color(attr_value);
+                        if (!color.empty())
+                            _add_tag_style(CtConst::TAG_BACKGROUND, color);
+                    } else if (attr_name == "text-decoration") {
+                        if (attr_value == CtConst::TAG_UNDERLINE || str::startswith(attr_value, "underline"))
+                            _add_tag_style(CtConst::TAG_UNDERLINE, CtConst::TAG_PROP_VAL_SINGLE);
+                        else if (attr_value == "line-through")
+                            _add_tag_style(CtConst::TAG_STRIKETHROUGH, CtConst::TAG_PROP_VAL_TRUE);
+                    } else if (attr_name == "font-weight") {
+                        if (attr_value == "bold" || attr_value == "bolder" || attr_value == "700")
+                            _add_tag_style(CtConst::TAG_WEIGHT, CtConst::TAG_PROP_VAL_HEAVY);
+                    } else if (attr_name == "font-style") {
+                        if (attr_value == CtConst::TAG_PROP_VAL_ITALIC)
+                            _add_tag_style(CtConst::TAG_STYLE, CtConst::TAG_PROP_VAL_ITALIC);
+                    }
+                }
+            }
+        }
+        else if (tag == "font")
+        {
+            for (auto& tag_attr: char2list_attrs(atts)) {
+                if (tag_attr.name == "color") {
+                    auto color = _convert_html_color(str::trim(Glib::ustring(tag_attr.value.begin())));
+                    if (color != "")
+                        _add_tag_style(CtConst::TAG_FOREGROUND, color);
+                }
+            }
+        }
+        else if (tag == CtConst::TAG_PROP_VAL_SUP || tag == CtConst::TAG_PROP_VAL_SUB)
+        {
+            _add_tag_style(CtConst::TAG_SCALE, tag.begin());
+        }
+        else if (tag  == CtConst::TAG_PROP_VAL_H1 || tag == CtConst::TAG_PROP_VAL_H2  || tag == CtConst::TAG_PROP_VAL_H3
+                 || tag == CtConst::TAG_PROP_VAL_H4  || tag == CtConst::TAG_PROP_VAL_H5  || tag == CtConst::TAG_PROP_VAL_H6)
+        {
+            _rich_text_serialize(CtConst::CHAR_NEWLINE);
+            if (tag == CtConst::TAG_PROP_VAL_H1 || tag == CtConst::TAG_PROP_VAL_H2) _add_tag_style(CtConst::TAG_SCALE, tag.begin());
+            else _add_tag_style(CtConst::TAG_SCALE, CtConst::TAG_PROP_VAL_H3);
+            for (auto& tag_attr: char2list_attrs(atts)) {
+                if (tag_attr.name == "align")
+                    _add_tag_style(CtConst::TAG_JUSTIFICATION, str::trim(Glib::ustring(tag_attr.value.begin()).lowercase()));
+            }
+        }
+        else if (tag == "a")
+        {
+            for (auto& tag_attr: char2list_attrs(atts)) {
+                if (tag_attr.name == "href" && tag_attr.value.size() > 7)
+                    _add_tag_style(CtConst::TAG_LINK, CtImports::get_internal_link_from_http_url(tag_attr.value.begin()));
+            }
+        }
+        else if (tag == "br") _rich_text_serialize(CtConst::CHAR_NEWLINE);
+        else if (tag == "ol")  { _list_type = 'o'; _list_num = 1; }
+        else if (tag == "ul")  { _list_type = 'u'; _list_num = 0; }
+        else if (tag == "li") {
+            if (_list_type == 'u') _rich_text_serialize(_pCtMainWin->get_ct_config()->charsListbul[0] + CtConst::CHAR_SPACE);
+            else {
+                _rich_text_serialize(std::to_string(_list_num) + ". ");
+                _list_num += 1;
+            }
+        }
+        else if (tag  == "img" || tag == "v:imagedata") {
+            for (auto& tag_attr: char2list_attrs(atts))
+                if (tag_attr.name == "src")
+                    _insert_image(tag_attr.value.begin(), "");
+        }
+        else if (tag == "pre") _html_pre_tag_open = true;
+        else if (tag == "code") _add_tag_style(CtConst::TAG_FAMILY, CtConst::TAG_PROP_VAL_MONOSPACE);
+        else if (tag == "dt") _rich_text_serialize(CtConst::CHAR_NEWLINE);
+        else if (tag == "dd") _rich_text_serialize(CtConst::CHAR_NEWLINE + Glib::ustring(CtConst::CHAR_TAB));
+    }
+    else if (_state == ParserState::PARSING_TABLE)
+    {
+        if (tag == "div") { // table is used as layout
+            if (_table.empty()) {
+                _table.clear();
+                _html_td_tag_open = false;
+                _state = ParserState::PARSING_BODY;
+            }
+        }
+        else if (tag == "table") { // nested tables
+            _table.clear();
+            _html_td_tag_open = false;
+        }
+        else if (tag == "tr") {
+            _table.push_back(std::list<table_cell>());
+            _html_td_tag_open = false;
+        }
+        else if (tag == "td" || tag == "th") {
+            _html_td_tag_open = true;
+            if (_table.empty()) // case of first missing <tr>, this is the header even if <td>
+                _table.push_back(std::list<table_cell>());
+            int rowspan = 1;
+            for (auto& tag_attr: char2list_attrs(atts))
+                if (tag_attr.name == "rowspan")
+                    rowspan = atoi(tag_attr.value.begin());
+            _table.back().push_back(table_cell{rowspan, ""});
+        }
+        else if (tag == "img" || tag == "v:imagedata") {
+            for (auto& tag_attr: char2list_attrs(atts))
+                if (tag_attr.name == "src")
+                    _insert_image(tag_attr.value.begin(), CtConst::CHAR_NEWLINE + CtConst::CHAR_NEWLINE);
+        }
+        else if (tag == "br" && _html_td_tag_open) _table.back().back().text += CtConst::CHAR_NEWLINE;
+        else if (tag == "ol" && _html_td_tag_open) { _list_type = 'o'; _list_num = 1; }
+        else if (tag == "ul" && _html_td_tag_open) { _list_type = 'u'; _list_num = 0; }
+        else if (tag == "li" && _html_td_tag_open) {
+            if (_list_type == 'u') _table.back().back().text += _pCtMainWin->get_ct_config()->charsListbul[0] + CtConst::CHAR_SPACE;
+            else {
+                _table.back().back().text += std::to_string(_list_num) + ". ";
+                _list_num += 1;
+            }
+        }
+    }
+    _end_adding_tag_styles();
+}
+
+void CtHtml2Xml::handle_endtag(std::string_view tag)
+{
+    _pop_tag_styles();
+
+    if (HTML_A_TAGS.count(tag.begin())) _html_a_tag_counter -= 1;
+    if (_state == ParserState::WAIT_BODY)
+    {
+        if (tag == CtConst::TAG_STYLE)
+            _state = ParserState::PARSING_BODY;
+    }
+    else if (_state == ParserState::PARSING_BODY)
+    {
+        if (tag == "p") _rich_text_serialize(CtConst::CHAR_NEWLINE);
+        else if (tag == "pre") _html_pre_tag_open = false;
+        else if (tag == CtConst::TAG_PROP_VAL_H1 || tag == CtConst::TAG_PROP_VAL_H2 || tag == CtConst::TAG_PROP_VAL_H3
+                 || tag == CtConst::TAG_PROP_VAL_H4 || tag == CtConst::TAG_PROP_VAL_H5 || tag == CtConst::TAG_PROP_VAL_H6) {
+            _rich_text_serialize(CtConst::CHAR_NEWLINE);
+        }
+        else if (tag == "li") _rich_text_serialize(CtConst::CHAR_NEWLINE);
+    }
+    else if (_state == ParserState::PARSING_TABLE)
+    {
+        if (tag == "p" || tag == "li")
+        {
+            if (_html_td_tag_open)
+                _table.back().back().text += CtConst::CHAR_NEWLINE;
+        }
+        else if (tag == "td" || tag == "th")
+        {
+            _html_td_tag_open = false;
+        }
+        else if (tag == "table")
+        {
+            _state = ParserState::PARSING_BODY;
+            if (_table.size() && _table.back().size() == 0) // case of latest <tr> without any <tr> afterwards
+                _table.pop_back();
+            if (_table.size() == 1 && _table.back().size() == 1) // it's a codebox
+                _insert_codebox();
+            else // it's a table
+                _insert_table();
+            _rich_text_serialize(CtConst::CHAR_NEWLINE);
+        }
+    }
+}
+
+void CtHtml2Xml::handle_data(std::string_view text)
+{
+    if (_state == ParserState::WAIT_BODY)
+        return;
+    if (_html_pre_tag_open) {
+         _rich_text_serialize(text.begin());
+         return;
+    }
+    Glib::ustring clean_data(text.begin());
+    if (_html_a_tag_counter > 0) clean_data = str::replace(clean_data, CtConst::CHAR_NEWLINE, CtConst::CHAR_SPACE);
+    else                         clean_data = str::replace(clean_data, CtConst::CHAR_NEWLINE, "");
+    if (clean_data.empty() || clean_data == CtConst::CHAR_TAB)
+        return;
+    clean_data = str::replace(clean_data, "\x20", CtConst::CHAR_SPACE); // replace non-breaking space
+    // not a good idea, if it's UTF-16, it should be converted
+    // clean_data = str::replace(clean_data, "\xfeff", "");
+    if (_state == ParserState::PARSING_BODY) {
+        clean_data = str::replace(clean_data, CtConst::CHAR_TAB, CtConst::CHAR_SPACE);
+        _rich_text_serialize(clean_data);
+    }
+    if (_state == ParserState::PARSING_TABLE && _html_td_tag_open) {
+        clean_data = str::replace(clean_data, CtConst::CHAR_TAB, "");
+        _table.back().back().text += clean_data;
+    }
+}
+
+// Found Entity Reference like &name;
+void CtHtml2Xml::handle_charref(std::string_view name)
+{
+    // todo: test it
+}
+
+void CtHtml2Xml::_start_adding_tag_styles()
+{
+    // every tag will have style, even if it's empty
+    _tag_styles.push_back(tag_style{++_tag_id_generator, "", ""});
+}
+
+void CtHtml2Xml::_add_tag_style(const std::string& style, const std::string& value)
+{
+    auto& current = _tag_styles.back();
+    if (current.style.empty()) {
+        current.style = style;
+        current.value = value;
+    } else {
+        _tag_styles.push_back(tag_style{current.tag_id, style, value});
+    }
+}
+
+void CtHtml2Xml::_end_adding_tag_styles()
+{
+    // actually, nothing to do here
+}
+
+void CtHtml2Xml::_pop_tag_styles()
+{
+    // every tag has at least one style
+    int tag_id = _tag_styles.back().tag_id;
+    while (_tag_styles.back().tag_id == tag_id)
+        _tag_styles.pop_back();
+}
+
+int CtHtml2Xml::_get_tag_style_id()
+{
+    // use tag id as style id because they are unique
+    for (auto tag_style = _tag_styles.rbegin(); tag_style != _tag_styles.rend(); ++tag_style)
+        if (!tag_style->style.empty()) // skip empty because they don't matter
+            return tag_style->tag_id;
+    return 0;
+}
+
+void CtHtml2Xml::_put_tag_styles_on_top_cache()
+{
+    int current_tag_style = _get_tag_style_id();
+
+    // check cache first if it exist move it on top
+    auto exists_in_cache = [&]() {
+        for (auto& style: _slot_styles_cache)
+            if (style.slot_style_id == current_tag_style)
+                return true;
+        return false;
+    };
+    if (exists_in_cache())
+    {
+        // remove others, they won't need
+        while (_slot_styles_cache.front().slot_style_id != current_tag_style)
+            _slot_styles_cache.pop_front();
+        return;
+    }
+
+    // or create and put in cache top
+    _slot_styles_cache.push_front(slot_styles());
+    auto& style = _slot_styles_cache.front();
+    style.slot_style_id = current_tag_style;
+    for (auto& tag_style: _tag_styles)
+        if (!tag_style.style.empty())
+            style.styles[tag_style.style] = tag_style.value;
+
+    // clean up cache
+    if (_slot_styles_cache.size() > 10)
+        _slot_styles_cache.pop_back();
+}
+
+std::string CtHtml2Xml::_convert_html_color(const std::string& html_color)
+{
+    Gdk::RGBA rgba;
+    if (!rgba.set(html_color))
+        return "";
+    // r+g+b black is 0
+    // r+g+b white is 3*1.0 = 3.0
+    double black_level = 3.0 / 100. * 15;    // lower is black-ish
+    double white_level = 3.0 - black_level;  // higher is white-ish
+    double sum_rgb = rgba.get_blue() + rgba.get_green() + rgba.get_red();
+    if (sum_rgb < black_level || sum_rgb > white_level)
+        return "";
+    return CtRgbUtil::rgb_any_to_24(rgba);
+}
+
+// Insert Image in Buffer
+void CtHtml2Xml::_insert_image(std::string img_path, std::string trailing_chars)
+{
+    _rich_text_save_pending();
+    // todo:
+    /*try:
+        self.dad.statusbar.push(self.dad.statusbar_context_id, _("Downloading") + " %s ..." % img_path)
+        while gtk.events_pending(): gtk.main_iteration()
+        url_desc = urllib2.urlopen(img_path, timeout=3)
+        image_file = url_desc.read()
+        pixbuf_loader = gtk.gdk.PixbufLoader()
+        pixbuf_loader.write(image_file)
+        pixbuf_loader.close()
+        pixbuf = pixbuf_loader.get_pixbuf()
+        self.dad.xml_handler.pixbuf_element_to_xml([self.chars_counter, pixbuf, cons.TAG_PROP_LEFT], self.nodes_list[-1], self.dom)
+        self.chars_counter += 1
+        self.dad.statusbar.pop(self.dad.statusbar_context_id)
+        if trailing_chars: self.rich_text_serialize(trailing_chars)
+    except:
+        if os.path.isfile(os.path.join(self.local_dir, img_path)):
+            pixbuf = gtk.gdk.pixbuf_new_from_file(os.path.join(self.local_dir, img_path))
+            self.dad.xml_handler.pixbuf_element_to_xml([self.chars_counter, pixbuf, cons.TAG_PROP_LEFT], self.nodes_list[-1], self.dom)
+            self.chars_counter += 1
+        else: print "failed download of", img_path
+        self.dad.statusbar.pop(self.dad.statusbar_context_id)
+*/
+
+    // don't forget to move offset
+    // _char_offset += 1;
+}
+
+void CtHtml2Xml::_insert_table()
+{
+    _rich_text_save_pending();
+
+    // add more cells for rowspan > 1
+    for (auto& row: _table)
+        for (auto iter = row.begin(); iter != row.end(); ++ iter)
+            if (iter->rowspan > 1)
+                row.insert(std::next(iter), iter->rowspan - 1, {1, ""});
+    // find bigger row size
+    size_t row_len = 0;
+    for (auto& row: _table)
+        row_len  = std::max(row_len, row.size());
+    // add more cell for rowspan = 0
+    for (auto& row: _table)
+        for (auto iter = row.begin(); iter != row.end(); ++ iter)
+            if (iter->rowspan == 0 && row.size() < row_len)
+                row.insert(std::next(iter), row_len - row.size(), {1, ""});
+    // add more cell just in case
+    for (auto& row: _table)
+        if (row.size() < row_len)
+            row.insert(row.end(), row_len - row.size(), {1, ""});
+
+    // todo: remove this copy-paste (table.cc)
+    xmlpp::Element* p_table_node = _slot_root->add_child("table");
+    p_table_node->set_attribute("char_offset", std::to_string(_char_offset));
+    p_table_node->set_attribute(CtConst::TAG_JUSTIFICATION, CtConst::TAG_PROP_VAL_LEFT);
+    p_table_node->set_attribute("col_min", std::to_string(40));
+    p_table_node->set_attribute("col_max", std::to_string(400));
+
+
+    auto row_to_xml = [&](const std::list<table_cell>& row) {
+        xmlpp::Element* p_row_node = p_table_node->add_child("row");
+        for (const auto& cell: row)
+        {
+            xmlpp::Element* p_cell_node = p_row_node->add_child("cell");
+            p_cell_node->add_child_text(str::trim(cell.text));
+        }
+    };
+    // put header at the end
+    bool is_header = true;
+    for (const auto& row: _table)
+    {
+        if (is_header) { is_header = false; continue; }
+        row_to_xml(row);
+    }
+    row_to_xml(_table.front());
+
+    _char_offset += 1;
+}
+
+void CtHtml2Xml::_insert_codebox()
+{
+    _rich_text_save_pending();
+
+    // todo: fix this copy-paste from codebox.cc
+    xmlpp::Element* p_codebox_node = _slot_root->add_child("codebox");
+    p_codebox_node->set_attribute("char_offset", std::to_string(_char_offset));
+    p_codebox_node->set_attribute(CtConst::TAG_JUSTIFICATION, CtConst::TAG_PROP_VAL_LEFT);
+    p_codebox_node->set_attribute("frame_width", std::to_string(300));
+    p_codebox_node->set_attribute("frame_height", std::to_string(150));
+    p_codebox_node->set_attribute("width_in_pixels", std::to_string(true));
+    p_codebox_node->set_attribute("syntax_highlighting", CtConst::PLAIN_TEXT_ID);
+    p_codebox_node->set_attribute("highlight_brackets", std::to_string(false));
+    p_codebox_node->set_attribute("show_line_numbers", std::to_string(false));
+    p_codebox_node->add_child_text(str::trim(_table.back().back().text));
+
+    _char_offset += 1;
+}
+
+// Appends a new part to the XML rich text
+void CtHtml2Xml::_rich_text_serialize(std::string text)
+{
+    if (text.empty()) return;
+    int current_tag_style_id = _get_tag_style_id();
+
+    // fist time -> put styles on cache top
+    if (_slot_style_id == -1) {
+        _put_tag_styles_on_top_cache();
+        _slot_style_id = current_tag_style_id;
+    }
+    // same style, text in the same slot
+    if (_slot_style_id == current_tag_style_id)
+    {
+        _slot_text += text;
+        return;
+    }
+
+    // styles changed, so
+    // create slot with prevous text
+    _rich_text_save_pending();
+
+    //
+    _put_tag_styles_on_top_cache();
+    _slot_text = text;
+    _slot_style_id = current_tag_style_id;
+}
+
+void CtHtml2Xml::_rich_text_save_pending()
+{
+    // the style is always on cache top
+    if (_slot_text != "")
+    {
+        auto& s_style = _slot_styles_cache.front();
+
+        xmlpp::Element* s = _slot_root->add_child("rich_text");
+        for (auto& attr: s_style.styles)
+            s->set_attribute(attr.first, attr.second);
+        s->set_child_text(_slot_text);
+        _char_offset += _slot_text.size();
+    }
+
+    _slot_text = "";
+    _slot_style_id = -1;
+}
+

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -22,27 +22,117 @@
 #pragma once
 
 #include <vector>
+#include <list>
+#include <set>
 #include <glibmm/ustring.h>
 #include <libxml2/libxml/HTMLparser.h>
+#include <libxml++/libxml++.h>
+
 
 namespace CtImports {
 
 std::vector<std::pair<int, int>> get_web_links_offsets_from_plain_text(const Glib::ustring& plain_text);
-
+std::string get_internal_link_from_http_url(std::string link_url);
 }
 
 class CtHtmlParser
 {
 public:
+    struct html_attr
+    {
+        std::string_view name;
+        std::string_view value;
+    };
+
+public:
     CtHtmlParser() = default;
     virtual ~CtHtmlParser() = default;
 
-    void feed(const std::string& html);
-    std::string fix_body(const std::string& html);
+    virtual void feed(const std::string& html);
 
-    virtual void handle_starttag(std::string_view name, const char** atts);
-    virtual void handle_endtag(std::string_view localname);
+    virtual void handle_starttag(std::string_view tag, const char** atts);
+    virtual void handle_endtag(std::string_view tag);
     virtual void handle_data(std::string_view text);
     virtual void handle_charref(std::string_view name);
+
+public:
+    std::list<html_attr> char2list_attrs(const char** atts);
 };
 
+
+
+
+// pygtk: HTMLHandler
+class CtMainWin;
+class CtHtml2Xml : public CtHtmlParser
+{
+private:
+    enum class ParserState {WAIT_BODY, PARSING_BODY, PARSING_TABLE};
+    struct tag_style
+    {
+        int         tag_id;
+        std::string style;
+        std::string value;
+    };
+    struct table_cell
+    {
+        int         rowspan;
+        std::string text;
+    };
+    struct slot_styles
+    {
+        int slot_style_id;
+        std::map<std::string, std::string> styles;
+    };
+
+
+    static const std::set<std::string> HTML_A_TAGS;
+
+public:
+    CtHtml2Xml(CtMainWin* pCtMainWin);
+
+    virtual void feed(const std::string& html);
+    virtual void handle_starttag(std::string_view tag, const char** atts);
+    virtual void handle_endtag(std::string_view tag);
+    virtual void handle_data(std::string_view text);
+    virtual void handle_charref(std::string_view name);
+
+    Glib::ustring to_string() { return _xml_doc.write_to_string(); }
+
+private:
+    void _start_adding_tag_styles();
+    void _add_tag_style(const std::string& style, const std::string& value);
+    void _end_adding_tag_styles();
+    void _pop_tag_styles();
+    int  _get_tag_style_id();
+    void _put_tag_styles_on_top_cache();
+
+    std::string _convert_html_color(const std::string& html_color);
+    void        _insert_image(std::string img_path, std::string trailing_chars);
+    void        _insert_table();
+    void        _insert_codebox();
+    void        _rich_text_serialize(std::string text);
+    void        _rich_text_save_pending();
+
+private:
+    CtMainWin*            _pCtMainWin;
+
+    // releated to parsing html
+    ParserState           _state;
+    int                   _tag_id_generator;
+    std::list<tag_style>  _tag_styles;
+    bool                  _html_pre_tag_open;
+    bool                  _html_td_tag_open;
+    int                   _html_a_tag_counter;
+    char                  _list_type;
+    int                   _list_num;
+    std::list<std::list<table_cell>> _table;
+
+    // related to generating xml
+    xmlpp::Document        _xml_doc;
+    int                    _char_offset;
+    xmlpp::Element*        _slot_root;
+    std::string            _slot_text;
+    int                    _slot_style_id;
+    std::list<slot_styles> _slot_styles_cache;
+};

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -23,9 +23,26 @@
 
 #include <vector>
 #include <glibmm/ustring.h>
+#include <libxml2/libxml/HTMLparser.h>
 
 namespace CtImports {
 
 std::vector<std::pair<int, int>> get_web_links_offsets_from_plain_text(const Glib::ustring& plain_text);
 
 }
+
+class CtHtmlParser
+{
+public:
+    CtHtmlParser() = default;
+    virtual ~CtHtmlParser() = default;
+
+    void feed(const std::string& html);
+    std::string fix_body(const std::string& html);
+
+    virtual void handle_starttag(std::string_view name, const char** atts);
+    virtual void handle_endtag(std::string_view localname);
+    virtual void handle_data(std::string_view text);
+    virtual void handle_charref(std::string_view name);
+};
+

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -664,7 +664,7 @@ std::string CtRgbUtil::rgb_to_string(Gdk::RGBA color)
 std::string CtRgbUtil::rgb_any_to_24(Gdk::RGBA color)
 {
     char rgb24StrOut[16];
-    CtRgbUtil::set_rgb24str_from_str_any(CtRgbUtil::rgb_to_string(color).c_str(), rgb24StrOut);
+    set_rgb24str_from_str_any(CtRgbUtil::rgb_to_string(color).c_str(), rgb24StrOut);
     return rgb24StrOut;
 }
 

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -126,6 +126,8 @@ std::string get_font_size_str(const std::string& fontStr);
 
 namespace CtRgbUtil {
 
+// todo: normalized color function, better use RGBA as inner presentation instead of strings
+
 void set_rgb24str_from_rgb24int(guint32 rgb24Int, char* rgb24StrOut);
 
 guint32 get_rgb24int_from_rgb24str(const char* rgb24Str);

--- a/future/src/ct/ct_table.cc
+++ b/future/src/ct/ct_table.cc
@@ -101,6 +101,7 @@ void CtTable::_setup_new_matrix(const CtTableMatrix& tableMatrix)
 
 void CtTable::to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment)
 {
+    // todo: fix a duplicate in imports.cc
     xmlpp::Element* p_table_node = p_node_parent->add_child("table");
     p_table_node->set_attribute("char_offset", std::to_string(_charOffset+offset_adjustment));
     p_table_node->set_attribute(CtConst::TAG_JUSTIFICATION, _justification);


### PR DESCRIPTION
(ref to keep progress: #444)

- rich text, tables, codebox are working, but for now images are not downloaded by url.
- changed the way to collect styles from html tags. Now, then a tag is closed, style is not dropped but reverted to the previous state.
- rich text nodes are squashed together if they have the same style.
- covert font sizes to small, H3, H2 sizes.