### PR TITLE
Add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: c
+language: c++
 cache: apt
 os: linux
 dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: c
+cache: apt
+os: linux
+dist: bionic
+
+compiler:
+  - gcc
+
+before_install:
+  - >
+    sudo apt install build-essential libtool autoconf libgtkmm-3.0-dev
+    libgtksourceviewmm-3.0-dev libxml++2.6-dev libsqlite3-dev
+    libcpputest-dev autopoint gettext intltool python3-lxml libxml2-utils
+addons:
+  apt:
+    update: true
+
+script:
+  - cd future
+  - ./build.sh


### PR DESCRIPTION
This add a travis-ci script for the new C version of cherrytree.

I didn't modify the README to include the badge (since it's not ready yet) and you'll need to setup travis for the repository since I can't do that from an MR.

You can see the results of the build [here](https://travis-ci.org/github/steveno/cherrytree/builds/676766508).