### PR TITLE
(Port to C++) sys tray

### DIFF
--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -34,7 +34,7 @@ class CtMainWin;
 class CtActions
 {
 public:
-    void init(CtMainWin* pCtMainWin)
+    CtActions(CtMainWin* pCtMainWin)
     {
         _pCtMainWin = pCtMainWin;
         _find_init();
@@ -83,12 +83,16 @@ private:
 
 public:
     // file actions
+    void file_new();
     void file_open();
     void file_save();
     void file_vacuum();
     void file_save_as();
     void folder_cfg_open();
     void online_help();
+    void quit_or_hide_window();
+    void quit_window();
+    void dialog_preferences();
 
 private:
     // helpers for tree actions

--- a/future/src/ct/ct_actions_file.cc
+++ b/future/src/ct/ct_actions_file.cc
@@ -20,8 +20,14 @@
  */
 
 #include "ct_actions.h"
-#include <glib/gstdio.h>
 #include "ct_storage_control.h"
+#include "ct_pref_dlg.h"
+#include <glib/gstdio.h>
+
+void CtActions::file_new()
+{
+    _pCtMainWin->signal_app_new_instance();
+}
 
 // Save the file
 void CtActions::file_save()
@@ -101,4 +107,21 @@ void CtActions::folder_cfg_open()
 void CtActions::online_help()
 {
     g_app_info_launch_default_for_uri("http://giuspen.com/cherrytreemanual/", nullptr, nullptr);
+}
+
+void CtActions::quit_or_hide_window()
+{
+    _pCtMainWin->signal_app_quit_or_hide_window(_pCtMainWin);
+}
+
+void CtActions::quit_window()
+{
+    _pCtMainWin->signal_app_quit_window(_pCtMainWin);
+}
+
+void CtActions::dialog_preferences()
+{
+    CtPrefDlg prefDlg(_pCtMainWin);
+    prefDlg.show();
+    prefDlg.run();
 }

--- a/future/src/ct/ct_app.cc
+++ b/future/src/ct/ct_app.cc
@@ -31,12 +31,10 @@ CtApp::CtApp() : Gtk::Application("com.giuspen.cherrytree", Gio::APPLICATION_HAN
 
     Glib::ustring config_dir = Glib::build_filename(Glib::get_user_config_dir(), CtConst::APP_NAME);
     if (g_mkdir_with_parents (config_dir.c_str(), 0755) < 0)
-        g_warning ("Could not create config directory\n");
+        g_warning(("Could not create config directory: " + config_dir + "\n").c_str());
 
     _uCtCfg.reset(new CtConfig());
     //std::cout << _uCtCfg->specialChars.size() << "\t" << _uCtCfg->specialChars << std::endl;
-
-    _uCtActions.reset(new CtActions());
 
     _rIcontheme = Gtk::IconTheme::get_default();
     _rIcontheme->add_resource_path("/icons/");
@@ -53,13 +51,18 @@ CtApp::CtApp() : Gtk::Application("com.giuspen.cherrytree", Gio::APPLICATION_HAN
 
     _rCssProvider = Gtk::CssProvider::create();
 
-    _uCtMenu.reset(new CtMenu(_uCtCfg.get()));
-    _uCtMenu->init_actions(this, _uCtActions.get());
-
-    _uCtPrint.reset(new CtPrint());
-
     _rStatusIcon = Gtk::StatusIcon::create(CtConst::APP_NAME);
     _rStatusIcon->set_visible(false);
+    _rStatusIcon->set_title(_("CherryTree Hierarchical Note Taking"));
+    _rStatusIcon->signal_button_press_event().connect([&](GdkEventButton* event) {
+        if (event->button == 1) { _systray_show_hide_windows(); }
+        if (event->button == 3) { _systray_show_popup(); }
+        return false;
+    });
+
+    signal_window_removed().connect([](Gtk::Window*) {
+
+    });
 }
 
 CtApp::~CtApp()
@@ -72,86 +75,12 @@ Glib::RefPtr<CtApp> CtApp::create()
     return Glib::RefPtr<CtApp>(new CtApp());
 }
 
-void CtApp::_printHelpMessage()
-{
-    std::cout << "Usage: " << GETTEXT_PACKAGE << " [filepath.ctd|.ctb|.ctz|.ctx]" << std::endl;
-}
-
-void CtApp::_printGresourceIcons()
-{
-    for (const std::string& str_icon : Gio::Resource::enumerate_children_global("/icons/", Gio::ResourceLookupFlags::RESOURCE_LOOKUP_FLAGS_NONE))
-    {
-        std::cout << str_icon << std::endl;
-    }
-}
-
-void CtApp::file_new()
-{
-    _create_appwindow()->present();
-}
-
-CtMainWin* CtApp::_create_appwindow()
-{
-    CtMainWin* pCtMainWin = new CtMainWin(_uCtCfg.get(),
-                                          _uCtActions.get(),
-                                          _uCtTmp.get(),
-                                          _uCtMenu.get(),
-                                          _uCtPrint.get(),
-                                          _rIcontheme.get(),
-                                          _rTextTagTable,
-                                          _rCssProvider,
-                                          _rLanguageManager.get(),
-                                          _rStyleSchemeManager.get(),
-                                          _rStatusIcon.get());
-    CtApp::_uCtActions->init(pCtMainWin);
-
-    add_window(*pCtMainWin);
-
-    pCtMainWin->signal_app_set_visible_exit_app.connect([&](bool visible) {
-        for (Gtk::Window* pWin : get_windows())
-            if (CtMainWin* pCtMainWin = dynamic_cast<CtMainWin*>(pWin))
-                pCtMainWin->menu_set_visible_exit_app(visible);
-    });
-    pCtMainWin->signal_hide().connect(sigc::bind<CtMainWin*>(sigc::mem_fun(*this, &CtApp::_on_hide_window), pCtMainWin));
-    return pCtMainWin;
-}
-
-CtMainWin* CtApp::_get_main_win(const std::string& filepath)
-{
-    // 1) look for exact filepath match
-    for (Gtk::Window* pWin : get_windows())
-    {
-        CtMainWin* pCtMainWin = dynamic_cast<CtMainWin*>(pWin);
-        if (filepath == pCtMainWin->get_ct_storage()->get_file_path())
-        {
-            return pCtMainWin;
-        }
-    }
-    // 2) look for window with no loaded document
-    for (Gtk::Window* pWin : get_windows())
-    {
-        CtMainWin* pCtMainWin = dynamic_cast<CtMainWin*>(pWin);
-        if (pCtMainWin->get_ct_storage()->get_file_path().empty())
-        {
-            return pCtMainWin;
-        }
-    }
-    // 3) if our filepath is empty, just get the first window
-    if (filepath.empty() and get_windows().size() > 0)
-    {
-        return dynamic_cast<CtMainWin*>(get_windows().front());
-    }
-    return nullptr;
-}
-
 void CtApp::on_activate()
 {
-    // app run without arguments
-    CtMainWin* pAppWindow = _get_main_win();
-    if (nullptr == pAppWindow)
+    CtMainWin* pAppWindow = nullptr;
+    if (get_windows().size() == 0)
     {
-        // there is not a window already running
-        pAppWindow = _create_appwindow();
+        pAppWindow = _create_window();
         if (not CtApp::_uCtCfg->recentDocsFilepaths.empty())
         {
             Glib::RefPtr<Gio::File> r_file = Gio::File::create_for_path(CtApp::_uCtCfg->recentDocsFilepaths.front());
@@ -170,14 +99,10 @@ void CtApp::on_activate()
             }
         }
     }
+    else {
+        pAppWindow = dynamic_cast<CtMainWin*>(get_windows()[0]);
+    }
     pAppWindow->present();
-}
-
-void CtApp::_on_hide_window(CtMainWin* pCtMainWin)
-{
-    pCtMainWin->config_update_data_from_curr_status();
-    _uCtCfg->write_to_file();
-    delete pCtMainWin;
 }
 
 void CtApp::on_open(const Gio::Application::type_vec_files& files, const Glib::ustring& /*hint*/)
@@ -187,11 +112,11 @@ void CtApp::on_open(const Gio::Application::type_vec_files& files, const Glib::u
     {
         if (r_file->query_exists())
         {
-            CtMainWin* pAppWindow = _get_main_win(r_file->get_path());
+            CtMainWin* pAppWindow = _get_window_by_path(r_file->get_path());
             if (nullptr == pAppWindow)
             {
                 // there is not a window already running with that document
-                pAppWindow = _create_appwindow();
+                pAppWindow = _create_window();
                 if (not pAppWindow->file_open(r_file->get_path()))
                 {
                     _printHelpMessage();
@@ -207,15 +132,117 @@ void CtApp::on_open(const Gio::Application::type_vec_files& files, const Glib::u
     }
 }
 
-void CtApp::quit_application()
+void CtApp::on_window_removed(Gtk::Window* window)
 {
-    quit();
+    // override this function, so hidden windows won't be deleted from the window list
+    // but destroy window is needed
+    if (CtMainWin* win = dynamic_cast<CtMainWin*>(window))
+        if (win->force_exit())
+        {
+            Gtk::Application::on_window_removed(window);
+            delete window;
+        }
 }
 
-void CtApp::dialog_preferences()
+CtMainWin* CtApp::_create_window()
 {
-    CtPrefDlg prefDlg(_get_main_win());
-    prefDlg.show();
-    prefDlg.run();
-    prefDlg.hide();
+    CtMainWin* pCtMainWin = new CtMainWin(_uCtCfg.get(),
+                                          _uCtTmp.get(),
+                                          _rIcontheme.get(),
+                                          _rTextTagTable,
+                                          _rCssProvider,
+                                          _rLanguageManager.get(),
+                                          _rStyleSchemeManager.get(),
+                                          _rStatusIcon.get());
+    add_window(*pCtMainWin);
+
+    pCtMainWin->signal_app_set_visible_exit_app.connect([&](bool visible) {
+        for (Gtk::Window* pWin : get_windows())
+            if (CtMainWin* pCtMainWin = dynamic_cast<CtMainWin*>(pWin))
+                pCtMainWin->menu_set_visible_exit_app(visible);
+    });
+    pCtMainWin->signal_app_new_instance.connect([this]() {
+        _create_window()->present();
+    });
+
+
+    pCtMainWin->signal_app_quit_or_hide_window.connect([&](CtMainWin* win) { _quit_or_hide_window(win, false); });
+    pCtMainWin->signal_delete_event().connect([this, pCtMainWin](GdkEventAny*) { return _quit_or_hide_window(pCtMainWin, true); });
+    pCtMainWin->signal_app_quit_window.connect([&](CtMainWin* win) { win->force_exit() = true; _quit_or_hide_window(win, false); });
+
+    return pCtMainWin;
+}
+
+CtMainWin* CtApp::_get_window_by_path(const std::string& filepath)
+{
+    for (Gtk::Window* pWin : get_windows())
+    {
+        CtMainWin* pCtMainWin = dynamic_cast<CtMainWin*>(pWin);
+        if (filepath == pCtMainWin->get_ct_storage()->get_file_path())
+            return pCtMainWin;
+    }
+    return nullptr;
+}
+
+bool CtApp::_quit_or_hide_window(CtMainWin* pCtMainWin, bool from_delete)
+{
+    pCtMainWin->config_update_data_from_curr_status();
+    _uCtCfg->write_to_file();
+
+    if (_uCtCfg->systrayOn && !pCtMainWin->force_exit() /* if came from quit_window */)
+    {
+        pCtMainWin->set_visible(false);
+        return true; // to stop deleting window
+    }
+    else
+    {
+        // trying to save changes, it show window if needed
+        if (!pCtMainWin->try_to_save())
+        {
+            pCtMainWin->force_exit() = false;
+            return true;  // to stop deleting windows
+        }
+        pCtMainWin->force_exit() = true; // this is for on_window_removed
+        if (!from_delete)                // signal from remove, no need to remove again
+            remove_window(*pCtMainWin);  // object will be destroyed in on_window_removed
+
+        return false; // continue deleting window
+    }
+}
+
+void CtApp::_systray_show_hide_windows()
+{
+    bool to_show = true;
+    for (Gtk::Window* pWin : get_windows())
+        if (pWin->has_toplevel_focus())
+            to_show = false;
+    for (Gtk::Window* pWin : get_windows())
+        if (to_show)
+        {
+            pWin->set_visible(to_show);
+            pWin->present();
+        }
+        else
+        {
+            pWin->set_visible(false);
+        }
+}
+
+void CtApp::_systray_show_popup()
+{
+
+}
+
+
+void CtApp::_printHelpMessage()
+{
+    std::cout << "Usage: " << GETTEXT_PACKAGE << " [filepath.ctd|.ctb|.ctz|.ctx]" << std::endl;
+}
+
+void CtApp::_printGresourceIcons()
+{
+    for (const std::string& str_icon : Gio::Resource::enumerate_children_global("/icons/", Gio::ResourceLookupFlags::RESOURCE_LOOKUP_FLAGS_NONE))
+    {
+        std::cout << str_icon << std::endl;
+    }
 }

--- a/future/src/ct/ct_app.cc
+++ b/future/src/ct/ct_app.cc
@@ -148,7 +148,7 @@ void CtApp::on_activate()
             Glib::RefPtr<Gio::File> r_file = Gio::File::create_for_path(CtApp::_uCtCfg->recentDocsFilepaths.front());
             if (r_file->query_exists())
             {
-                if (not pAppWindow->file_open(r_file->get_path(), false))
+                if (not pAppWindow->file_open(r_file->get_path()))
                 {
                     _printHelpMessage();
                 }
@@ -183,7 +183,7 @@ void CtApp::on_open(const Gio::Application::type_vec_files& files, const Glib::u
             {
                 // there is not a window already running with that document
                 pAppWindow = _create_appwindow();
-                if (not pAppWindow->file_open(r_file->get_path(), false))
+                if (not pAppWindow->file_open(r_file->get_path()))
                 {
                     _printHelpMessage();
                 }

--- a/future/src/ct/ct_app.cc
+++ b/future/src/ct/ct_app.cc
@@ -57,6 +57,9 @@ CtApp::CtApp() : Gtk::Application("com.giuspen.cherrytree", Gio::APPLICATION_HAN
     _uCtMenu->init_actions(this, _uCtActions.get());
 
     _uCtPrint.reset(new CtPrint());
+
+    _rStatusIcon = Gtk::StatusIcon::create(CtConst::APP_NAME);
+    _rStatusIcon->set_visible(false);
 }
 
 CtApp::~CtApp()
@@ -98,11 +101,17 @@ CtMainWin* CtApp::_create_appwindow()
                                           _rTextTagTable,
                                           _rCssProvider,
                                           _rLanguageManager.get(),
-                                          _rStyleSchemeManager.get());
+                                          _rStyleSchemeManager.get(),
+                                          _rStatusIcon.get());
     CtApp::_uCtActions->init(pCtMainWin);
 
     add_window(*pCtMainWin);
 
+    pCtMainWin->signal_app_set_visible_exit_app.connect([&](bool visible) {
+        for (Gtk::Window* pWin : get_windows())
+            if (CtMainWin* pCtMainWin = dynamic_cast<CtMainWin*>(pWin))
+                pCtMainWin->menu_set_visible_exit_app(visible);
+    });
     pCtMainWin->signal_hide().connect(sigc::bind<CtMainWin*>(sigc::mem_fun(*this, &CtApp::_on_hide_window), pCtMainWin));
     return pCtMainWin;
 }

--- a/future/src/ct/ct_app.h
+++ b/future/src/ct/ct_app.h
@@ -56,6 +56,7 @@ private:
     Glib::RefPtr<Gtk::CssProvider> _rCssProvider;
     Glib::RefPtr<Gsv::LanguageManager> _rLanguageManager;
     Glib::RefPtr<Gsv::StyleSchemeManager> _rStyleSchemeManager;
+    Glib::RefPtr<Gtk::StatusIcon> _rStatusIcon;
 
 protected:
     void on_activate() override;

--- a/future/src/ct/ct_app.h
+++ b/future/src/ct/ct_app.h
@@ -47,10 +47,7 @@ public:
 
 private:
     std::unique_ptr<CtConfig> _uCtCfg;
-    std::unique_ptr<CtActions> _uCtActions;
     std::unique_ptr<CtTmp> _uCtTmp;
-    std::unique_ptr<CtMenu> _uCtMenu;
-    std::unique_ptr<CtPrint> _uCtPrint;
     Glib::RefPtr<Gtk::IconTheme> _rIcontheme;
     Glib::RefPtr<Gtk::TextTagTable> _rTextTagTable;
     Glib::RefPtr<Gtk::CssProvider> _rCssProvider;
@@ -61,17 +58,18 @@ private:
 protected:
     void on_activate() override;
     void on_open(const Gio::Application::type_vec_files& files, const Glib::ustring& hint) override;
+    void on_window_removed(Gtk::Window* window) override;
 
     void _printHelpMessage();
     void _printGresourceIcons();
 
 public:
-    void quit_application();
-    void dialog_preferences();
-    void file_new();
 
 private:
-    CtMainWin* _create_appwindow();
-    CtMainWin* _get_main_win(const std::string& filepath="");
-    void _on_hide_window(CtMainWin* pCtMainWin);
+    CtMainWin*  _create_window();
+    CtMainWin*  _get_window_by_path(const std::string& filepath);
+    bool        _quit_or_hide_window(CtMainWin* pCtMainWin, bool from_delete);
+
+    void _systray_show_hide_windows();
+    void _systray_show_popup();
 };

--- a/future/src/ct/ct_app.h
+++ b/future/src/ct/ct_app.h
@@ -71,5 +71,5 @@ private:
     bool        _quit_or_hide_window(CtMainWin* pCtMainWin, bool from_delete);
 
     void _systray_show_hide_windows();
-    void _systray_show_popup();
+    void _systray_close_all();
 };

--- a/future/src/ct/ct_dialogs.cc
+++ b/future/src/ct/ct_dialogs.cc
@@ -1827,10 +1827,10 @@ bool CtDialogs::node_prop_dialog(const Glib::ustring &title,
 CtYesNoCancel CtDialogs::exit_save_dialog(Gtk::Window& parent)
 {
     Gtk::Dialog dialog = Gtk::Dialog(_("Warning"),
-                                     parent,
+                                      parent,
                                      Gtk::DialogFlags::DIALOG_MODAL | Gtk::DialogFlags::DIALOG_DESTROY_WITH_PARENT);
+    dialog.add_button(Gtk::Stock::DISCARD, Gtk::RESPONSE_NO);
     dialog.add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-    dialog.add_button(Gtk::Stock::CLEAR, Gtk::RESPONSE_NO);
     dialog.add_button(Gtk::Stock::SAVE, Gtk::RESPONSE_YES);
     dialog.set_default_response(Gtk::RESPONSE_YES);
     dialog.set_default_size(350, 150);

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -914,6 +914,7 @@ bool CtMainWin::try_to_save()
 {
     if (get_file_save_needed())
     {
+        set_visible(true); // window could be hidden
         const CtYesNoCancel yesNoCancel = _pCtConfig->autosaveOnQuit ? CtYesNoCancel::Yes : CtDialogs::exit_save_dialog(*this);
         if (CtYesNoCancel::Cancel == yesNoCancel)
         {

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -39,7 +39,8 @@ CtMainWin::CtMainWin(CtConfig*        pCtConfig,
                      Glib::RefPtr<Gtk::TextTagTable> rGtkTextTagTable,
                      Glib::RefPtr<Gtk::CssProvider> rGtkCssProvider,
                      Gsv::LanguageManager*    pGsvLanguageManager,
-                     Gsv::StyleSchemeManager* pGsvStyleSchemeManager)
+                     Gsv::StyleSchemeManager* pGsvStyleSchemeManager,
+                     Gtk::StatusIcon*         pGtkStatusIcon)
  : Gtk::ApplicationWindow(),
    _pCtStorage(CtStorageControl::create_dummy_storage()),
    _pCtConfig(pCtConfig),
@@ -52,6 +53,7 @@ CtMainWin::CtMainWin(CtConfig*        pCtConfig,
    _rGtkCssProvider(rGtkCssProvider),
    _pGsvLanguageManager(pGsvLanguageManager),
    _pGsvStyleSchemeManager(pGsvStyleSchemeManager),
+   _pGtkStatusIcon(pGtkStatusIcon),
    _ctTextview(this),
    _ctStateMachine(this)
 {
@@ -472,6 +474,9 @@ void CtMainWin::config_apply_after_show_all()
     _ctStatusBar.progressBar.hide();
     _ctStatusBar.stopButton.hide();
 
+    get_status_icon()->set_visible(_pCtConfig->systrayOn);
+    menu_set_visible_exit_app(_pCtConfig->systrayOn);
+
     update_theme();
 }
 
@@ -724,6 +729,11 @@ void CtMainWin::menu_set_items_special_chars()
 {
     sigc::slot<void, gunichar> spec_char_action = sigc::mem_fun(*_pCtActions, &CtActions::insert_spec_char_action);
     _pSpecialCharsSubmenu->set_submenu(*_pCtMenu->build_special_chars_menu(_pCtConfig->specialChars, spec_char_action));
+}
+
+void CtMainWin::menu_set_visible_exit_app(bool visible)
+{
+    CtMenu::find_menu_item(_pMenuBar, "exit_app")->set_visible(visible);
 }
 
 void CtMainWin::config_switch_tree_side()

--- a/future/src/ct/ct_main_win.h
+++ b/future/src/ct/ct_main_win.h
@@ -168,6 +168,9 @@ public:
 
     void resetPrevTreeIter()                { _prevTreeIter = CtTreeIter(); }
 
+    void save_position()                    { get_position(_savedXpos, _savedYpos); }
+    void restore_position()                 { if (_savedXpos != -1) move(_savedXpos, _savedYpos); }
+
 private:
     bool                _on_window_key_press_event(GdkEventKey* event);
 
@@ -235,6 +238,8 @@ private:
     bool                _fileSaveNeeded{false}; // pygtk: file_update
     std::unordered_map<gint64, gint64> _latestStatusbarUpdateTime; // pygtk: latest_statusbar_update_time
     CtTreeIter          _prevTreeIter;
+    int                 _savedXpos{-1};
+    int                 _savedYpos{-1};
 
 public:
     sigc::signal<void, bool>       signal_app_set_visible_exit_app = sigc::signal<void, bool>();

--- a/future/src/ct/ct_main_win.h
+++ b/future/src/ct/ct_main_win.h
@@ -93,12 +93,12 @@ public:
 
     void update_theme();
 
-    bool file_open(const std::string& filepath, const bool force_reset = false);
+    bool file_open(const std::string& filepath);
     void file_save();
     void file_save_as(const std::string& new_filepath, const std::string& password);
     void file_vacuum();
 
-    bool reset(const bool force_reset = false);
+    void reset();
     bool check_unsaved();
     void update_window_save_needed(const CtSaveNeededUpdType update_type = CtSaveNeededUpdType::None,
                                    const bool new_machine_state = false,

--- a/future/src/ct/ct_main_win.h
+++ b/future/src/ct/ct_main_win.h
@@ -84,7 +84,8 @@ public:
               Glib::RefPtr<Gtk::TextTagTable> rGtkTextTagTable,
               Glib::RefPtr<Gtk::CssProvider> rGtkCssProvider,
               Gsv::LanguageManager*    pGsvLanguageManager,
-              Gsv::StyleSchemeManager* pGsvStyleSchemeManager);
+              Gsv::StyleSchemeManager* pGsvStyleSchemeManager,
+              Gtk::StatusIcon*         pGtkStatusIcon);
     virtual ~CtMainWin();
 
     void config_apply_before_show_all();
@@ -127,6 +128,7 @@ public:
     Glib::RefPtr<Gtk::CssProvider>&   get_css_provider()   { return _rGtkCssProvider; }
     Gsv::LanguageManager*             get_language_manager() { return _pGsvLanguageManager; }
     Gsv::StyleSchemeManager*          get_style_scheme_manager() { return _pGsvStyleSchemeManager; }
+    Gtk::StatusIcon*                  get_status_icon() { return _pGtkStatusIcon; }
 
     bool&         user_active()     { return _userActive; } // use as a function, because it's easier to put breakpoint
     int&          cursor_key_press() { return _cursorKeyPress; }
@@ -157,6 +159,7 @@ public:
 
     void menu_set_items_recent_documents();
     void menu_set_items_special_chars();
+    void menu_set_visible_exit_app(bool visible);
 
     void config_switch_tree_side();
 
@@ -201,6 +204,8 @@ private:
     Glib::RefPtr<Gtk::CssProvider>  _rGtkCssProvider;
     Gsv::LanguageManager*        _pGsvLanguageManager;
     Gsv::StyleSchemeManager*     _pGsvStyleSchemeManager;
+    Gtk::StatusIcon*             _pGtkStatusIcon;
+
     Gtk::VBox                    _vboxMain;
     Gtk::VBox                    _vboxText;
     Gtk::HPaned                  _hPaned;
@@ -230,4 +235,7 @@ private:
     bool                _fileSaveNeeded{false}; // pygtk: file_update
     std::unordered_map<gint64, gint64> _latestStatusbarUpdateTime; // pygtk: latest_statusbar_update_time
     CtTreeIter          _prevTreeIter;
+
+public:
+    sigc::signal<void, bool> signal_app_set_visible_exit_app = sigc::signal<void, bool>();
 };

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -51,14 +51,15 @@ const std::string& CtMenuAction::get_shortcut(CtConfig* pCtConfig) const
 }
 
 
-CtMenu::CtMenu(CtConfig* pCtConfig)
+CtMenu::CtMenu(CtConfig* pCtConfig, CtActions* pActions)
  : _pCtConfig(pCtConfig)
 {
     _pAccelGroup = gtk_accel_group_new();
     _rGtkBuilder = Gtk::Builder::create();
+    init_actions(pActions);
 }
 
-void CtMenu::init_actions(CtApp *pApp, CtActions* pActions)
+void CtMenu::init_actions(CtActions* pActions)
 {
     // stubs for menu bar
     _actions.push_back(CtMenuAction{"", "FileMenu", None, _("_File"), None, None, sigc::signal<void>()});
@@ -81,7 +82,7 @@ void CtMenu::init_actions(CtApp *pApp, CtActions* pActions)
 
     // main actions
     const char* file_cat = _("File");
-    _actions.push_back(CtMenuAction{file_cat, "ct_new_inst", "new-instance", _("New _Instance"), None, _("Start a New Instance of CherryTree"), sigc::mem_fun(*pApp, &CtApp::file_new)});
+    _actions.push_back(CtMenuAction{file_cat, "ct_new_inst", "new-instance", _("New _Instance"), None, _("Start a New Instance of CherryTree"), sigc::mem_fun(*pActions, &CtActions::file_new)});
     _actions.push_back(CtMenuAction{file_cat, "ct_open_file", "open", _("_Open File"), KB_CONTROL+"O", _("Open a CherryTree Document"), sigc::mem_fun(*pActions, &CtActions::file_open)});
     _actions.push_back(CtMenuAction{file_cat, "ct_save", "save", _("_Save"), KB_CONTROL+"S", _("Save File"), sigc::mem_fun(*pActions, &CtActions::file_save)});
     _actions.push_back(CtMenuAction{file_cat, "ct_vacuum", "clear", _("Save and _Vacuum"), None, _("Save File and Vacuum"), sigc::mem_fun(*pActions, &CtActions::file_vacuum)});
@@ -91,9 +92,9 @@ void CtMenu::init_actions(CtApp *pApp, CtActions* pActions)
     _actions.push_back(CtMenuAction{file_cat, "open_cfg_folder", "directory", _("Open Preferences _Directory"), None, _("Open the Directory with Preferences Files"), sigc::mem_fun(*pActions, &CtActions::folder_cfg_open)});
     _actions.push_back(CtMenuAction{file_cat, "print_page_setup", "print", _("Pa_ge Setup"), None, _("Set up the Page for Printing"), sigc::mem_fun(*pActions, &CtActions::export_print_page_setup)});
     _actions.push_back(CtMenuAction{file_cat, "do_print", "print", _("_Print"), KB_CONTROL+"P", _("Print"), sigc::mem_fun(*pActions, &CtActions::export_print)});
-    _actions.push_back(CtMenuAction{file_cat, "quit_app", "quit-app", _("_Quit"), KB_CONTROL+"Q", _("Quit the Application"), sigc::mem_fun(*pApp, &CtApp::quit_application)});
-    _actions.push_back(CtMenuAction{file_cat, "exit_app", "quit-app", _("_Exit CherryTree"), KB_CONTROL+KB_SHIFT+"Q", _("Exit from CherryTree"), sigc::signal<void>() /* dad.quit_application_totally */});
-    _actions.push_back(CtMenuAction{file_cat, "preferences_dlg", "preferences", _("_Preferences"), KB_CONTROL+KB_ALT+"P", _("Preferences"), sigc::mem_fun(*pApp, &CtApp::dialog_preferences) });
+    _actions.push_back(CtMenuAction{file_cat, "quit_app", "quit-app", _("_Quit"), KB_CONTROL+"Q", _("Quit the Application"), sigc::mem_fun(*pActions, &CtActions::quit_or_hide_window)});
+    _actions.push_back(CtMenuAction{file_cat, "exit_app", "quit-app", _("_Exit CherryTree"), KB_CONTROL+KB_SHIFT+"Q", _("Exit from CherryTree"), sigc::mem_fun(*pActions, &CtActions::quit_window)});
+    _actions.push_back(CtMenuAction{file_cat, "preferences_dlg", "preferences", _("_Preferences"), KB_CONTROL+KB_ALT+"P", _("Preferences"), sigc::mem_fun(*pActions, &CtActions::dialog_preferences) });
     _actions.push_back(CtMenuAction{file_cat, "ct_check_newer", "network", _("_Check Newer Version"), None, _("Check for a Newer Version"), sigc::signal<void>() /* dad.check_for_newer_version */});
     _actions.push_back(CtMenuAction{file_cat, "ct_help", "help", _("Online _Manual"), "F1", _("Application's Online Manual"), sigc::mem_fun(*pActions, &CtActions::online_help)});
     _actions.push_back(CtMenuAction{file_cat, "ct_about", "about", _("_About"), None, _("About CherryTree"), sigc::signal<void>() /* dad.dialog_about */});
@@ -241,10 +242,11 @@ void CtMenu::init_actions(CtApp *pApp, CtActions* pActions)
     // add actions in the Applicaton for the toolbar
     // by default actions will have prefix 'app.'
     // (the menu uses not actions, but accelerators)
+    /*
     for (const CtMenuAction& action : _actions)
     {
         pApp->add_action(action.id, action.run_action);
-    }
+    }*/
 
 
     // for popup menus

--- a/future/src/ct/ct_menu.h
+++ b/future/src/ct/ct_menu.h
@@ -61,6 +61,9 @@ public:
     enum POPUP_MENU_TYPE {Node, Text, Code, Link, TableHeaderCell, TableCell, Codebox, Image, Anchor, EmbFile, PopupMenuNum };
 
 public:
+   static Gtk::MenuItem* create_menu_item(GtkWidget* pMenu, const char* name, const char* image, const char* desc);
+
+public:
     void init_actions(CtActions* pActions);
     CtMenuAction* find_action(const std::string& id);
     const std::list<CtMenuAction>& get_actions() { return _actions; }
@@ -87,12 +90,14 @@ private:
     void           _walk_menu_xml(GtkWidget* pMenu, xmlpp::Node* pNode);
     GtkWidget*     _add_submenu(GtkWidget* pMenu, const char* id, const char* name, const char* image);
     Gtk::MenuItem* _add_menu_item(GtkWidget* pMenu, CtMenuAction* pAction);
-    Gtk::MenuItem* _add_menu_item(GtkWidget* pMenu, const char* name, const char* image, const char*shortcut,
-                                 const char* desc, gpointer action_data,
-                                 sigc::signal<void, bool>* signal_set_sensitive = nullptr,
-                                 sigc::signal<void, bool>* signal_set_visible = nullptr);
+    static Gtk::MenuItem* _add_menu_item(GtkWidget* pMenu, const char* name, const char* image,
+                                         const char*shortcut, GtkAccelGroup* accelGroup,
+                                         const char* desc, gpointer action_data,
+                                         sigc::signal<void, bool>* signal_set_sensitive,
+                                         sigc::signal<void, bool>* signal_set_visible);
+
+    static void    _add_menu_item_image_or_label(Gtk::Widget* pMenuItem, const char* image, GtkWidget* pLabel);
     GtkWidget*     _add_separator(GtkWidget* pMenu);
-    void           _add_menu_item_image_or_label(Gtk::Widget* pMenuItem, const char* image, GtkWidget* pLabel);
 
     std::string _get_ui_str_toolbar();
     const char* _get_ui_str_menu();

--- a/future/src/ct/ct_menu.h
+++ b/future/src/ct/ct_menu.h
@@ -50,7 +50,7 @@ class CtActions;
 class CtMenu
 {
 public:
-    CtMenu(CtConfig* pCtConfig);
+    CtMenu(CtConfig* pCtConfig, CtActions* pActions);
 
 public:
     const char*       None       = "";
@@ -61,7 +61,7 @@ public:
     enum POPUP_MENU_TYPE {Node, Text, Code, Link, TableHeaderCell, TableCell, Codebox, Image, Anchor, EmbFile, PopupMenuNum };
 
 public:
-    void init_actions(CtApp* pApp, CtActions* pActions);
+    void init_actions(CtActions* pActions);
     CtMenuAction* find_action(const std::string& id);
     const std::list<CtMenuAction>& get_actions() { return _actions; }
 

--- a/future/src/ct/ct_pref_dlg.cc
+++ b/future/src/ct/ct_pref_dlg.cc
@@ -1294,10 +1294,8 @@ Gtk::Widget* CtPrefDlg::build_tab_misc()
     Gtk::VBox* vbox_system_tray = Gtk::manage(new Gtk::VBox());
     Gtk::CheckButton* checkbutton_systray = Gtk::manage(new Gtk::CheckButton(_("Enable System Tray Docking")));
     Gtk::CheckButton* checkbutton_start_on_systray = Gtk::manage(new Gtk::CheckButton(_("Start Minimized in the System Tray")));
-    Gtk::CheckButton* checkbutton_use_appind = Gtk::manage(new Gtk::CheckButton(_("Use AppIndicator for Docking")));
     vbox_system_tray->pack_start(*checkbutton_systray, false, false);
     vbox_system_tray->pack_start(*checkbutton_start_on_systray, false, false);
-    vbox_system_tray->pack_start(*checkbutton_use_appind, false, false);
 
     Gtk::Frame* frame_system_tray = Gtk::manage(new Gtk::Frame(std::string("<b>")+_("System Tray")+"</b>"));
     ((Gtk::Label*)frame_system_tray->get_label_widget())->set_use_markup(true);
@@ -1310,9 +1308,6 @@ Gtk::Widget* CtPrefDlg::build_tab_misc()
     checkbutton_systray->set_active(pConfig->systrayOn);
     checkbutton_start_on_systray->set_active(pConfig->startOnSystray);
     checkbutton_start_on_systray->set_sensitive(pConfig->systrayOn);
-    checkbutton_use_appind->set_active(pConfig->useAppInd);
-    // todo:
-    //if not cons->HAS_APPINDICATOR or not cons->HAS_SYSTRAY: checkbutton_use_appind->set_sensitive(False)
 
     Gtk::VBox* vbox_saving = Gtk::manage(new Gtk::VBox());
     Gtk::HBox* hbox_autosave = Gtk::manage(new Gtk::HBox());
@@ -1399,43 +1394,14 @@ Gtk::Widget* CtPrefDlg::build_tab_misc()
     pMainBox->pack_start(*frame_misc_misc, false, false);
     pMainBox->pack_start(*frame_language, false, false);
 
-    checkbutton_systray->signal_toggled().connect([pConfig, checkbutton_systray, checkbutton_start_on_systray](){
+    checkbutton_systray->signal_toggled().connect([this, pConfig, checkbutton_systray, checkbutton_start_on_systray](){
         pConfig->systrayOn = checkbutton_systray->get_active();
-        if (pConfig->systrayOn) {
-            //dad.ui.get_widget("/MenuBar/FileMenu/exit_app").set_property(cons.STR_VISIBLE, True)
-            checkbutton_start_on_systray->set_sensitive(true);
-        } else {
-            //dad.ui.get_widget("/MenuBar/FileMenu/exit_app").set_property(cons.STR_VISIBLE, False)
-            checkbutton_start_on_systray->set_sensitive(false);
-        }
-        //if dad.systray:
-        //    if not dad.use_appind:
-        //        if "status_icon" in dir(dad.boss): dad.boss.status_icon.set_property(cons.STR_VISIBLE, True)
-        //        else: dad.status_icon_enable()
-        //    else:
-        //        if "ind" in dir(dad.boss): dad.boss.ind.set_status(appindicator.STATUS_ACTIVE)
-        //        else: dad.status_icon_enable()
-        //else:
-        //    if not dad.use_appind: dad.boss.status_icon.set_property(cons.STR_VISIBLE, False)
-        //    else: dad.boss.ind.set_status(appindicator.STATUS_PASSIVE)
-        //dad.boss.systray_active = dad.systray
-        //if len(dad.boss.running_windows) > 1:
-        //    for runn_win in dad.boss.running_windows:
-        //        if runn_win.window == dad.window: continue
-        //        runn_win.systray = dad.boss.systray_active
+        _pCtMainWin->get_status_icon()->set_visible(checkbutton_systray->get_active());
+        _pCtMainWin->signal_app_set_visible_exit_app(checkbutton_systray->get_active());
+        checkbutton_start_on_systray->set_sensitive(checkbutton_systray->get_active());
     });
     checkbutton_start_on_systray->signal_toggled().connect([pConfig, checkbutton_start_on_systray](){
         pConfig->startOnSystray = checkbutton_start_on_systray->get_active();
-    });
-    checkbutton_use_appind->signal_toggled().connect([pConfig, checkbutton_use_appind, checkbutton_systray](){
-        bool saved_systray_active = checkbutton_systray->get_active();
-        if (saved_systray_active) checkbutton_systray->set_active(false); // todo: some hack?
-        pConfig->useAppInd = checkbutton_use_appind->get_active();
-        if (saved_systray_active) checkbutton_systray->set_active(true);
-        //if len(dad.boss.running_windows) > 1:
-        //    for runn_win in dad.boss.running_windows:
-        //        if runn_win.window == dad.window: continue
-        //        runn_win.use_appind = dad.use_appind
     });
     checkbutton_autosave->signal_toggled().connect([pConfig, checkbutton_autosave, spinbutton_autosave](){
         pConfig->autosaveOn = checkbutton_autosave->get_active();


### PR DESCRIPTION
(ref to keep progress: #444)
- moved from CtApp to CtMainWin: CtActions, CtMenu, CtPrint. CtMenu depends on CtActions, CtActions depends on current CtMainWin, so they cannot be global
- renamed `check_unsaved` to `try_to_save`
- simplified `reset`
- add systray