### PR TITLE
C++,  some keyboard shortcuts for node tree should not work in text buffer

### DIFF
--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -173,6 +173,7 @@ public:
     void node_right();
     void node_left();
     void node_change_father();
+    bool node_move(Gtk::TreeModel::Path src_path, Gtk::TreeModel::Path dest_path);
     void tree_sort_ascending();
     void tree_sort_descending();
     void node_siblings_sort_ascending();

--- a/future/src/ct/ct_actions_tree.cc
+++ b/future/src/ct/ct_actions_tree.cc
@@ -479,6 +479,12 @@ void CtActions::node_change_father()
     _pCtMainWin->get_tree_store().update_nodes_icon(_pCtMainWin->curr_tree_iter(), true);
 }
 
+bool CtActions::node_move(Gtk::TreeModel::Path src_path, Gtk::TreeModel::Path dest_path)
+{
+    //CtTreeIter src_iter = _pCtMainWin->get_tree_store().get_iter(src_path);
+    //CtTreeIter dest_iter = _pCtMainWin->get_tree_store().get_iter(dest_path);
+}
+
 //"""Sorts the Tree Ascending"""
 void CtActions::tree_sort_ascending()
 {

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -464,6 +464,10 @@ void CtMainWin::_reset_CtTreestore_CtTreeview()
     _uCtTreeview->signal_scroll_event().connect(sigc::mem_fun(*this, &CtMainWin::_on_treeview_scroll_event));
     _uCtTreeview->signal_popup_menu().connect(sigc::mem_fun(*this, &CtMainWin::_on_treeview_popup_menu));
 
+    //_uCtTreeview->set_reorderable(true); // tree store handles insert/removing rows
+    _uCtTreeview->enable_model_drag_dest(Gdk::ACTION_MOVE);
+    _uCtTreeview->enable_model_drag_source();
+
     _uCtTreeview->get_style_context()->add_class("ct-tree-panel");
 }
 

--- a/future/src/ct/ct_menu.h
+++ b/future/src/ct/ct_menu.h
@@ -59,17 +59,20 @@ public:
     const std::string KB_ALT     = "<alt>";
 
     enum POPUP_MENU_TYPE {Node, Text, Code, Link, TableHeaderCell, TableCell, Codebox, Image, Anchor, EmbFile, PopupMenuNum };
+    enum ACCEL_TYPE {Menu, TreeView };
 
 public:
    static Gtk::MenuItem* create_menu_item(GtkWidget* pMenu, const char* name, const char* image, const char* desc);
 
 public:
     void init_actions(CtActions* pActions);
-    CtMenuAction* find_action(const std::string& id);
+
+    CtMenuAction*  find_action(const std::string& id);
     const std::list<CtMenuAction>& get_actions() { return _actions; }
 
     GtkAccelGroup* default_accel_group();
 
+    static ACCEL_TYPE     get_accel_type(const std::string& action_name);
     static Gtk::MenuItem* find_menu_item(Gtk::MenuBar* menuBar, std::string name);
 
     Gtk::Toolbar* build_toolbar(Gtk::MenuToolButton*& pRecentDocsMenuToolButton);

--- a/future/src/ct/ct_treestore.h
+++ b/future/src/ct/ct_treestore.h
@@ -122,6 +122,25 @@ private:
     CtMainWin*                _pCtMainWin{nullptr};
 };
 
+
+class CtDragStore : public Gtk::TreeStore
+{
+public:
+    static Glib::RefPtr<CtDragStore> create(CtMainWin* pCtMainWin, const Gtk::TreeModelColumnRecord& columns);
+
+private:
+    CtDragStore(CtMainWin* pCtMainWin, const Gtk::TreeModelColumnRecord& columns);
+
+protected:
+    bool drag_data_get_vfunc(const Gtk::TreeModel::Path& path, Gtk::SelectionData& selection_data) const override;
+    bool drag_data_received_vfunc(const Gtk::TreeModel::Path& dest, const Gtk::SelectionData& selection_data) override;
+    bool drag_data_delete_vfunc(const Gtk::TreeModel::Path& path) override;
+
+private:
+    CtMainWin* _pCtMainWin;
+
+};
+
 class CtTextView;
 
 class CtTreeStore : public sigc::trackable
@@ -171,12 +190,13 @@ public:
 
 
 
-    Glib::RefPtr<Gtk::TreeStore>    get_store();
+    Glib::RefPtr<CtDragStore>       get_store();
     Gtk::TreeIter                   get_iter_first();
     CtTreeIter                      get_ct_iter_first();
     Gtk::TreeIter                   get_tree_iter_last_sibling(const Gtk::TreeNodeChildren& children);
     Gtk::TreeIter                   get_tree_iter_prev_sibling(Gtk::TreeIter tree_iter);
     Gtk::TreePath                   get_path(Gtk::TreeIter tree_iter);
+    CtTreeIter                      get_iter(Gtk::TreePath& path);
     CtTreeIter                      to_ct_tree_iter(Gtk::TreeIter tree_iter);
 
     void nodes_sequences_fix(Gtk::TreeIter father_iter,  bool process_children);
@@ -195,8 +215,10 @@ protected:
     void _on_textbuffer_insert(const Gtk::TextBuffer::iterator& pos, const Glib::ustring& text, int bytes); // pygtk: on_text_insertion
     void _on_textbuffer_erase(const Gtk::TextBuffer::iterator& range_start, const Gtk::TextBuffer::iterator& range_end); // pygtk: on_text_removal
 
+
+private:
     CtTreeModelColumns              _columns;
-    Glib::RefPtr<Gtk::TreeStore>    _rTreeStore;
+    Glib::RefPtr<CtDragStore>   _rTreeStore;
     std::list<gint64>               _bookmarks;
     std::set<Glib::ustring>         _usedTags;
     std::map<gint64, Glib::ustring> _nodes_names_dict; // for link tooltips


### PR DESCRIPTION
(ref to keep progress: #444)

The fix is almost a hack, but I don't see the better solution currently. Or we need to give users ability to setup the scope of shortcuts (where they can be applied)