### PR TITLE
C++, fix slow opening big xml files

### DIFF
--- a/future/src/ct/ct_storage_xml.h
+++ b/future/src/ct/ct_storage_xml.h
@@ -25,6 +25,7 @@
 #include <glibmm/refptr.h>
 #include <gtksourceviewmm/buffer.h>
 #include <gtkmm/treeiter.h>
+#include <libxml++/libxml++.h>
 
 namespace xmlpp {
     class Element;
@@ -37,7 +38,7 @@ class CtTreeIter;
 class CtTableCell;
 
 class CtStorageXml : public CtStorageEntity
-{
+{    
 public:
     CtStorageXml(CtMainWin* pCtMainWin);
     ~CtStorageXml() = default;
@@ -58,7 +59,8 @@ private:
     void           _nodes_to_xml(CtTreeIter* ct_tree_iter, xmlpp::Element* p_node_parent);
 
 private:
-    CtMainWin*        _pCtMainWin{nullptr};
+    CtMainWin* _pCtMainWin{nullptr};
+    mutable std::map<gint64, std::shared_ptr<xmlpp::Document>> _delayed_text_buffers;
 };
 
 


### PR DESCRIPTION
(ref to keep progress: #444)

kind of to fix #774 
It's not a fix for the issue, but it mitigates the problem with opening a document.
When cherrytree loads a lot of widgets, they are trying to adjust their sizes (a few iteration per widgets), that causes freeze in cherrytree.

This PR delays reading text for every node until a node is selected. Still, it's easy to see the issue then you try to save a changed document because cherrytree needs to read text of all nodes before saving the document. (it sounds odd, but what we have currently)

I'll be working on fixing the issue with widgets. 