### PR TITLE
Add the `make` step to build the binaries

### DIFF
--- a/future/README.md
+++ b/future/README.md
@@ -45,6 +45,7 @@ git clone https://github.com/giuspen/cherrytree.git
 mkdir cherrytree/build
 cd cherrytree/build
 cmake ../future
+make
 ./cherrytree
 ```
 Install documentation:
@@ -75,6 +76,7 @@ git clone https://github.com/giuspen/cherrytree.git
 mkdir cherrytree/build
 cd cherrytree/build
 cmake ../future
+make
 ./cherrytree
 ```
 
@@ -102,6 +104,7 @@ git clone https://github.com/giuspen/cherrytree.git
 mkdir cherrytree/build
 cd cherrytree/build
 cmake ../future
+make
 ./cherrytree
 ```
 


### PR DESCRIPTION
Replaces #776 by:

1. Preserving the `cd` to comply with cmake's instructions
2. Add the `make` step to all Linuxes