### PR TITLE
C++, delay applying syntax highlight until node shows

### DIFF
--- a/future/src/ct/ct_actions_tree.cc
+++ b/future/src/ct/ct_actions_tree.cc
@@ -105,13 +105,13 @@ void CtActions::_node_add(bool duplicate, bool add_child)
         _pCtMainWin->get_tree_store().get_node_data(_pCtMainWin->curr_tree_iter(), nodeData);
 
         if (nodeData.syntax != CtConst::RICH_TEXT_ID) {
-            nodeData.rTextBuffer = _pCtMainWin->get_new_text_buffer(nodeData.syntax, nodeData.rTextBuffer->get_text());
+            nodeData.rTextBuffer = _pCtMainWin->get_new_text_buffer(nodeData.rTextBuffer->get_text());
             nodeData.anchoredWidgets.clear();
         } else {
             _pCtMainWin->get_state_machine().update_state(_pCtMainWin->curr_tree_iter());
             node_state = _pCtMainWin->get_state_machine().requested_state_current(_pCtMainWin->curr_tree_iter().get_node_id());
             nodeData.anchoredWidgets.clear();
-            nodeData.rTextBuffer = _pCtMainWin->get_new_text_buffer(nodeData.syntax, "");
+            nodeData.rTextBuffer = _pCtMainWin->get_new_text_buffer();
         }
     }
     else
@@ -131,7 +131,7 @@ void CtActions::_node_add(bool duplicate, bool add_child)
 void CtActions::_node_add_with_data(Gtk::TreeIter curr_iter, CtNodeData& nodeData, bool add_child, std::shared_ptr<CtNodeState> node_state)
 {
     if (!nodeData.rTextBuffer)
-        nodeData.rTextBuffer = _pCtMainWin->get_new_text_buffer(nodeData.syntax);
+        nodeData.rTextBuffer = _pCtMainWin->get_new_text_buffer();
     nodeData.tsCreation = std::time(nullptr);
     nodeData.tsLastSave = nodeData.tsCreation;
     nodeData.nodeId = _pCtMainWin->get_tree_store().node_id_get();

--- a/future/src/ct/ct_codebox.cc
+++ b/future/src/ct/ct_codebox.cc
@@ -33,7 +33,7 @@ CtTextCell::CtTextCell(CtMainWin* pCtMainWin,
  : _syntaxHighlighting(syntaxHighlighting),
    _ctTextview(pCtMainWin)
 {
-    _rTextBuffer = pCtMainWin->get_new_text_buffer(syntaxHighlighting, textContent);
+    _rTextBuffer = pCtMainWin->get_new_text_buffer(textContent);
     _ctTextview.set_buffer(_rTextBuffer);
     _ctTextview.setup_for_syntax(_syntaxHighlighting);
 }
@@ -164,6 +164,11 @@ void CtCodebox::apply_width_height(const int parentTextWidth)
 {
     int frameWidth = _widthInPixels ? _frameWidth : (parentTextWidth*_frameWidth)/100;
     _scrolledwindow.set_size_request(frameWidth, _frameHeight);
+}
+
+void CtCodebox::apply_syntax_highlighting()
+{
+    _pCtMainWin->apply_syntax_highlighting(get_buffer(), _syntaxHighlighting);
 }
 
 void CtCodebox::to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment)

--- a/future/src/ct/ct_codebox.h
+++ b/future/src/ct/ct_codebox.h
@@ -73,6 +73,7 @@ public:
     virtual ~CtCodebox();
 
     void apply_width_height(const int parentTextWidth) override;
+    void apply_syntax_highlighting() override;
     void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment) override;
     bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) override;
     void set_modified_false() override { set_text_buffer_modified_false(); }

--- a/future/src/ct/ct_const.h
+++ b/future/src/ct/ct_const.h
@@ -57,6 +57,7 @@ const constexpr gchar* CHERRY_GRAY              {"cherry_grey"};
 const constexpr gchar* RICH_TEXT_ID             {"custom-colors"};
 const constexpr gchar* TABLE_CELL_TEXT_ID       {"table-cell-text"};
 const constexpr gchar* PLAIN_TEXT_ID            {"plain-text"};
+const constexpr gchar* STYLE_APPLIED_ID          {"<style-applied>"};
 const constexpr gchar* SYN_HIGHL_BASH           {"sh"};
 const constexpr gchar* STYLE_SCHEME_LIGHT       {"classic"};
 const constexpr gchar* STYLE_SCHEME_DARK        {"cobalt"};

--- a/future/src/ct/ct_image.h
+++ b/future/src/ct/ct_image.h
@@ -46,6 +46,7 @@ public:
     virtual ~CtImage() override;
 
     void apply_width_height(const int /*parentTextWidth*/) override {}
+    void apply_syntax_highlighting() override {}
     void set_modified_false() override {}
 
     void save(const Glib::ustring& file_name, const Glib::ustring& type);

--- a/future/src/ct/ct_main_win.h
+++ b/future/src/ct/ct_main_win.h
@@ -140,11 +140,12 @@ public:
     Glib::RefPtr<Gdk::Pixbuf> get_icon(const std::string& name, int size);
     std::string               get_code_icon_name(std::string code_type);
     Gtk::Image*               new_image_from_stock(const std::string& stockImage, Gtk::BuiltinIconSize size);
-    Glib::RefPtr<Gsv::Buffer> get_new_text_buffer(const std::string& syntax, const Glib::ustring& textContent=""); // pygtk: buffer_create
-    const std::string get_text_tag_name_exist_or_create(const std::string& propertyName, const std::string& propertyValue);
-    Glib::ustring sourceview_hovering_link_get_tooltip(const Glib::ustring& link);
-    bool apply_tag_try_automatic_bounds(Glib::RefPtr<Gtk::TextBuffer> text_buffer, Gtk::TextIter iter_start);
-    void apply_tag_try_automatic_bounds_triple_click(Glib::RefPtr<Gtk::TextBuffer> text_buffer, Gtk::TextIter iter_start);
+    void                      apply_syntax_highlighting(Glib::RefPtr<Gsv::Buffer> text_buffer, const std::string& syntax);
+    Glib::RefPtr<Gsv::Buffer> get_new_text_buffer(const Glib::ustring& textContent=""); // pygtk: buffer_create
+    const std::string         get_text_tag_name_exist_or_create(const std::string& propertyName, const std::string& propertyValue);
+    Glib::ustring             sourceview_hovering_link_get_tooltip(const Glib::ustring& link);
+    bool                      apply_tag_try_automatic_bounds(Glib::RefPtr<Gtk::TextBuffer> text_buffer, Gtk::TextIter iter_start);
+    void                      apply_tag_try_automatic_bounds_triple_click(Glib::RefPtr<Gtk::TextBuffer> text_buffer, Gtk::TextIter iter_start);
 
 private:
     Gtk::HBox&     _init_status_bar();

--- a/future/src/ct/ct_storage_sqlite.cc
+++ b/future/src/ct/ct_storage_sqlite.cc
@@ -350,7 +350,7 @@ Glib::RefPtr<Gsv::Buffer> CtStorageSqlite::get_delayed_text_buffer(const gint64&
     const char* textContent = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
     if (CtConst::RICH_TEXT_ID != syntax)
     {
-        rRetTextBuffer = _pCtMainWin->get_new_text_buffer(syntax, textContent);
+        rRetTextBuffer = _pCtMainWin->get_new_text_buffer(textContent);
     }
     else
     {

--- a/future/src/ct/ct_storage_xml.cc
+++ b/future/src/ct/ct_storage_xml.cc
@@ -157,10 +157,11 @@ Gtk::TreeIter CtStorageXml::_node_from_xml(xmlpp::Element* xml_element, Gtk::Tre
 
     // because of widgets which are slow to insert for now, delay creating buffers
     // save node data in a separate document
-    //node_data.rTextBuffer = CtStorageXmlHelper(_pCtMainWin).create_buffer_and_widgets_from_xml(xml_element, node_data.syntax, node_data.anchoredWidgets, nullptr, -1);
     auto node_buffer = std::make_shared<xmlpp::Document>();
     node_buffer->create_root_node("root")->import_node(xml_element);
     _delayed_text_buffers[node_data.nodeId] = node_buffer;
+    // old code to profile performande
+    // node_data.rTextBuffer = CtStorageXmlHelper(_pCtMainWin).create_buffer_and_widgets_from_xml(xml_element, node_data.syntax, node_data.anchoredWidgets, nullptr, -1);
 
     return _pCtMainWin->get_tree_store().append_node(&node_data, &parent_iter);
 }
@@ -211,7 +212,7 @@ xmlpp::Element* CtStorageXmlHelper::node_to_xml(CtTreeIter* ct_tree_iter, xmlpp:
 Glib::RefPtr<Gsv::Buffer> CtStorageXmlHelper::create_buffer_and_widgets_from_xml(xmlpp::Element* parent_xml_element, const Glib::ustring& syntax,
                                                                     std::list<CtAnchoredWidget*>& widgets, Gtk::TextIter* text_insert_pos, int force_offset)
 {
-    Glib::RefPtr<Gsv::Buffer> buffer = _pCtMainWin->get_new_text_buffer(syntax);
+    Glib::RefPtr<Gsv::Buffer> buffer = _pCtMainWin->get_new_text_buffer();
     buffer->begin_not_undoable_action();
     for (xmlpp::Node* xml_slot : parent_xml_element->get_children())
         get_text_buffer_one_slot_from_xml(buffer, xml_slot, widgets, text_insert_pos, force_offset);

--- a/future/src/ct/ct_table.cc
+++ b/future/src/ct/ct_table.cc
@@ -48,7 +48,7 @@ CtTable::CtTable(CtMainWin* pCtMainWin,
    _colMin(colMin),
    _colMax(colMax)
 {
-    _setup_new_matrix(tableMatrix);
+    _setup_new_matrix(tableMatrix, false /* apply style when node shows */);
 
     _grid.set_column_spacing(1);
     _grid.set_row_spacing(1);
@@ -63,7 +63,7 @@ CtTable::~CtTable()
     // no need for deleting cells, _grid will clean up cells
 }
 
-void CtTable::_setup_new_matrix(const CtTableMatrix& tableMatrix)
+void CtTable::_setup_new_matrix(const CtTableMatrix& tableMatrix, bool apply_style /* = true*/)
 {
     for (auto widget: _grid.get_children())
         _grid.remove(*widget);
@@ -96,7 +96,21 @@ void CtTable::_setup_new_matrix(const CtTableMatrix& tableMatrix)
             _grid.attach(*pTableCell, col, row, 1 /*1 cell horiz*/, 1 /*1 cell vert*/);
         }
     }
+    if (apply_style)
+        _apply_styles_to_cells();
     _grid.show_all();
+}
+
+void CtTable::_apply_styles_to_cells()
+{
+    for (CtTableRow& tableRow : _tableMatrix)
+        for (CtTableCell* pTableCell : tableRow)
+            _pCtMainWin->apply_syntax_highlighting(pTableCell->get_buffer(), pTableCell->get_syntax_highlighting());
+}
+
+void CtTable::apply_syntax_highlighting()
+{
+    _apply_styles_to_cells();
 }
 
 void CtTable::to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment)

--- a/future/src/ct/ct_table.h
+++ b/future/src/ct/ct_table.h
@@ -49,6 +49,7 @@ public:
     virtual ~CtTable();
 
     void apply_width_height(const int /*parentTextWidth*/) override {}
+    void apply_syntax_highlighting() override;
     void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment) override;
     bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) override;
     void set_modified_false() override;
@@ -77,7 +78,9 @@ public:
     void set_col_min_max(int col_min, int col_max);
 
 private:
-    void _setup_new_matrix(const CtTableMatrix& tableMatrix);
+    void _setup_new_matrix(const CtTableMatrix& tableMatrix, bool apply_style = true);
+    void _apply_styles_to_cells();
+
     CtTableMatrix _copy_matrix(int col_add, int col_del, int row_add, int row_del, int col_move_left, int row_move_up);
 
 protected:

--- a/future/src/ct/ct_treestore.cc
+++ b/future/src/ct/ct_treestore.cc
@@ -477,6 +477,7 @@ void CtTreeStore::text_view_apply_textbuffer(const CtTreeIter& treeIter, CtTextV
     std::cout << node.get_node_name() << std::endl;
 
     Glib::RefPtr<Gsv::Buffer> rTextBuffer = node.get_node_text_buffer();
+    _pCtMainWin->apply_syntax_highlighting(rTextBuffer, node.get_node_syntax_highlighting());
     pTextView->setup_for_syntax(node.get_node_syntax_highlighting());
     pTextView->set_buffer(rTextBuffer);
     pTextView->set_spell_check(node.get_node_is_rich_text());
@@ -493,6 +494,7 @@ void CtTreeStore::text_view_apply_textbuffer(const CtTreeIter& treeIter, CtTextV
                 // Gtk::TextIter textIter = rTextBuffer->get_iter_at_child_anchor(rChildAnchor);
                 pTextView->add_child_at_anchor(*pCtAnchoredWidget, rChildAnchor);
                 pCtAnchoredWidget->apply_width_height(pTextView->get_allocation().get_width());
+                pCtAnchoredWidget->apply_syntax_highlighting();
             }
             else
             {
@@ -704,6 +706,7 @@ void CtTreeStore::addAnchoredWidgets(Gtk::TreeIter treeIter, std::list<CtAnchore
             {
                 pTextView->add_child_at_anchor(*pCtAnchoredWidget, rChildAnchor);
                 pCtAnchoredWidget->apply_width_height(pTextView->get_allocation().get_width());
+                pCtAnchoredWidget->apply_syntax_highlighting();
             }
         }
     }

--- a/future/src/ct/ct_widgets.h
+++ b/future/src/ct/ct_widgets.h
@@ -55,6 +55,7 @@ public:
     Glib::RefPtr<Gtk::TextChildAnchor> getTextChildAnchor() { return _rTextChildAnchor; }
 
     virtual void apply_width_height(const int parentTextWidth) = 0;
+    virtual void apply_syntax_highlighting() = 0;
     virtual void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment) = 0;
     virtual bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) = 0;
     virtual void set_modified_false() = 0;


### PR DESCRIPTION
**Issue**: long first save (short freezing) on big xml files.

**Reason**: although node text buffer reading is delayed for xml and sqlite until node shows, we have to read all buffers for xml (not sqlite) to save a file. The reason for freezing is applying syntax highlighting for text buffers of nodes and text buffers of codebox with tables (>1000). 
Also, the issue can affect sqlite file during text search because we also have to read all buffers.

**PR**: delays applying syntax highlighting for all kinds of buffers until a node shows.
 