### PR TITLE
Add removable-media plug. Fixes #758

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,6 +43,7 @@ apps:
       - desktop
       - desktop-legacy
       - gsettings
+      - removable-media
     desktop: share/applications/cherrytree.desktop
     common-id: com.giuspen.cherrytree
     environment:


### PR DESCRIPTION
Fixes #758 

Allows user to access files on removable media devices like flash drives. In order to use this though, the user will need to manually make the connection with the command:

```
$ sudo snap connect cherrytree:removable-media
```

This step is needed because the removable-media plug is not auto-connected but once this PR is accepted and built in LP (automatically), I'll petition for this plug to be auto-connected so the user doesn't need to do anything.