### PR TITLE
C++, fix warnings

### DIFF
--- a/future/src/ct/ct_actions_edit.cc
+++ b/future/src/ct/ct_actions_edit.cc
@@ -62,7 +62,10 @@ void CtActions::image_handle()
 {
     if (not _node_sel_and_rich_text()) return;
     if (not _is_curr_node_not_read_only_or_error()) return;
-    CtDialogs::file_select_args args = {.pParentWin=_pCtMainWin, .curr_folder=_pCtMainWin->get_ct_config()->pickDirImg};
+
+    CtDialogs::file_select_args args(_pCtMainWin);
+    args.curr_folder=_pCtMainWin->get_ct_config()->pickDirImg;
+
     std::string filename = CtDialogs::file_select_dialog(args);
     if (filename.empty()) return;
     _pCtMainWin->get_ct_config()->pickDirImg = Glib::path_get_dirname(filename);
@@ -92,13 +95,12 @@ void CtActions::table_handle()
             rows.push_back(empty_row);
     }
     if (res == 2) {
-        CtDialogs::file_select_args args = {
-            .pParentWin=_pCtMainWin,
-            .curr_folder=_pCtMainWin->get_ct_config()->pickDirCsv,
-            .curr_file_name="",
-            .filter_name=_("CSV File"),
-            .filter_pattern={"*.csv"}
-        };
+        CtDialogs::file_select_args args(_pCtMainWin);
+        args.curr_folder = _pCtMainWin->get_ct_config()->pickDirCsv;
+        args.curr_file_name = "";
+        args.filter_name = _("CSV File");
+        args.filter_pattern = {"*.csv"};
+
         Glib::ustring filename = CtDialogs::file_select_dialog(args);
         if (filename.empty()) return;
         _pCtMainWin->get_ct_config()->pickDirCsv = Glib::path_get_dirname(filename);
@@ -187,7 +189,9 @@ void CtActions::embfile_insert()
     if (!_is_curr_node_not_read_only_or_error()) return;
     auto iter_insert = _curr_buffer()->get_insert()->get_iter();
 
-    CtDialogs::file_select_args args = {.pParentWin=_pCtMainWin, .curr_folder=_pCtMainWin->get_ct_config()->pickDirFile};
+    CtDialogs::file_select_args args(_pCtMainWin);
+    args.curr_folder = _pCtMainWin->get_ct_config()->pickDirFile;
+
     std::string filepath = CtDialogs::file_select_dialog(args);
     if (filepath.empty()) return;
 

--- a/future/src/ct/ct_actions_edit.cc
+++ b/future/src/ct/ct_actions_edit.cc
@@ -424,7 +424,7 @@ void CtActions::text_row_up()
         missing_leading_newline = true;
     else
     {
-        while (destination_iter.get_char() != CtConst::CHAR_NEWLINE[0])
+        while (destination_iter.get_char() != g_utf8_get_char(CtConst::CHAR_NEWLINE))
             if (not destination_iter.backward_char())
             {
                 missing_leading_newline = true;
@@ -444,7 +444,7 @@ void CtActions::text_row_up()
     {
         text_buffer->erase(range.iter_start, range.iter_end);
         destination_iter = text_buffer->get_iter_at_offset(destination_offset);
-        if (text_to_move.empty() or text_to_move[text_to_move.length()-1] != CtConst::CHAR_NEWLINE[0])
+        if (text_to_move.empty() or text_to_move[text_to_move.length()-1] != g_utf8_get_char(CtConst::CHAR_NEWLINE))
         {
             diff_offsets += 1;
             text_to_move += CtConst::CHAR_NEWLINE;
@@ -466,7 +466,7 @@ void CtActions::text_row_up()
             text_buffer->remove_all_tags(clr_start_iter, destination_iter);
         }
         bool append_newline = false;
-        if (text_to_move.empty() or text_to_move[text_to_move.length()-1] != CtConst::CHAR_NEWLINE[0])
+        if (text_to_move.empty() or text_to_move[text_to_move.length()-1] != g_utf8_get_char(CtConst::CHAR_NEWLINE))
         {
             diff_offsets += 1;
             append_newline = true;
@@ -501,7 +501,7 @@ void CtActions::text_row_down()
     if (not range.iter_end.forward_char()) return;
     int missing_leading_newline = false;
     Gtk::TextIter destination_iter = range.iter_end;
-    while (destination_iter.get_char() != CtConst::CHAR_NEWLINE[0])
+    while (destination_iter.get_char() != g_utf8_get_char(CtConst::CHAR_NEWLINE))
         if (not destination_iter.forward_char())
         {
             missing_leading_newline = true;
@@ -521,7 +521,7 @@ void CtActions::text_row_down()
         text_buffer->erase(range.iter_start, range.iter_end);
         destination_offset -= diff_offsets;
         destination_iter = text_buffer->get_iter_at_offset(destination_offset);
-        if (text_to_move.empty() or text_to_move[text_to_move.length() - 1] != CtConst::CHAR_NEWLINE[0])
+        if (text_to_move.empty() or text_to_move[text_to_move.length() - 1] != g_utf8_get_char(CtConst::CHAR_NEWLINE))
         {
             diff_offsets += 1;
             text_to_move += CtConst::CHAR_NEWLINE;
@@ -551,7 +551,7 @@ void CtActions::text_row_down()
             text_buffer->remove_all_tags(clr_start_iter, destination_iter);
         }
         bool append_newline = false;
-        if (text_to_move.empty() or text_to_move[text_to_move.length()-1] != CtConst::CHAR_NEWLINE[0])
+        if (text_to_move.empty() or text_to_move[text_to_move.length()-1] != g_utf8_get_char(CtConst::CHAR_NEWLINE))
         {
             diff_offsets += 1;
             append_newline = true;
@@ -599,7 +599,7 @@ void CtActions::strip_trailing_spaces()
             gunichar curr_char = curr_iter.get_char();
             if (curr_state == 0)
             {
-                if (curr_char == CtConst::CHAR_SPACE[0] or curr_char ==  CtConst::CHAR_TAB[0])
+                if (curr_char == g_utf8_get_char(CtConst::CHAR_SPACE) or curr_char == g_utf8_get_char(CtConst::CHAR_TAB))
                 {
                     start_offset = curr_iter.get_offset();
                     curr_state = 1;
@@ -607,14 +607,14 @@ void CtActions::strip_trailing_spaces()
             }
             else if (curr_state == 1)
             {
-                if (curr_char == CtConst::CHAR_NEWLINE[0])
+                if (curr_char == g_utf8_get_char(CtConst::CHAR_NEWLINE))
                 {
                     text_buffer->erase(text_buffer->get_iter_at_offset(start_offset), curr_iter);
                     removed_something = true;
                     cleaned_lines += 1;
                     break;
                 }
-                else if (curr_char != CtConst::CHAR_SPACE[0] and curr_char !=  CtConst::CHAR_TAB[0])
+                else if (curr_char != g_utf8_get_char(CtConst::CHAR_SPACE) and curr_char != g_utf8_get_char(CtConst::CHAR_TAB))
                 {
                     curr_state = 0;
                 }

--- a/future/src/ct/ct_actions_export.cc
+++ b/future/src/ct/ct_actions_export.cc
@@ -258,8 +258,12 @@ void CtActions::_export_to_txt(bool is_single, Glib::ustring auto_path, bool aut
 
 Glib::ustring CtActions::_get_pdf_filepath(Glib::ustring proposed_name)
 {
-    CtDialogs::file_select_args args = {.pParentWin=_pCtMainWin, .curr_folder=_pCtMainWin->get_ct_config()->pickDirExport, .curr_file_name=proposed_name + ".pdf",
-                                       .filter_name=_("PDF File"), .filter_pattern={"*.pdf"}};
+    CtDialogs::file_select_args args(_pCtMainWin);
+    args.curr_folder = _pCtMainWin->get_ct_config()->pickDirExport;
+    args.curr_file_name = proposed_name + ".pdf";
+    args.filter_name = _("PDF File");
+    args.filter_pattern = {"*.pdf"};
+
     Glib::ustring filename = CtDialogs::file_save_as_dialog(args);
     if (filename != "")
     {
@@ -272,8 +276,12 @@ Glib::ustring CtActions::_get_pdf_filepath(Glib::ustring proposed_name)
 // Prepare for the txt file save
 Glib::ustring CtActions::_get_txt_filepath(Glib::ustring proposed_name)
 {
-    CtDialogs::file_select_args args = {.pParentWin=_pCtMainWin, .curr_folder=_pCtMainWin->get_ct_config()->pickDirExport, .curr_file_name=proposed_name + ".txt",
-                                       .filter_name=_("Plain Text Document"), .filter_pattern={"*.txt"}};
+    CtDialogs::file_select_args args(_pCtMainWin);
+    args.curr_folder = _pCtMainWin->get_ct_config()->pickDirExport;
+    args.curr_file_name = proposed_name + ".txt";
+    args.filter_name = _("Plain Text Document");
+    args.filter_pattern = {"*.txt"};
+
     Glib::ustring filename = CtDialogs::file_save_as_dialog(args);
     if (filename != "")
     {

--- a/future/src/ct/ct_actions_file.cc
+++ b/future/src/ct/ct_actions_file.cc
@@ -58,7 +58,7 @@ void CtActions::file_save_as()
     {
         return;
     }
-    CtDialogs::storage_select_args storageSelArgs{ .pParentWin = _pCtMainWin };
+    CtDialogs::storage_select_args storageSelArgs(_pCtMainWin);
     std::string currDocFilepath = _pCtMainWin->get_ct_storage()->get_file_path();
     if (not currDocFilepath.empty())
     {
@@ -69,7 +69,7 @@ void CtActions::file_save_as()
     {
         return;
     }
-    CtDialogs::file_select_args fileSelArgs{ .pParentWin = _pCtMainWin };
+    CtDialogs::file_select_args fileSelArgs(_pCtMainWin);
     if (not currDocFilepath.empty())
     {
         fileSelArgs.curr_folder = Glib::path_get_dirname(currDocFilepath);
@@ -91,11 +91,11 @@ void CtActions::file_save_as()
 
 void CtActions::file_open()
 {
-    CtDialogs::file_select_args args;
-    args.pParentWin = _pCtMainWin;
+    CtDialogs::file_select_args args(_pCtMainWin);
     args.curr_folder = _pCtMainWin->get_ct_storage()->get_file_dir();
     args.filter_name = _("CherryTree Document");
     args.filter_pattern.push_back("*.ct*");
+
     std::string filepath = CtDialogs::file_select_dialog(args);
 
     if (filepath.empty()) return;

--- a/future/src/ct/ct_actions_find.cc
+++ b/future/src/ct/ct_actions_find.cc
@@ -690,7 +690,7 @@ bool CtActions::_parse_node_content_iter(const CtTreeIter& tree_iter, Glib::RefP
     bool pattern_found;
 
     Gtk::TextIter buff_start_iter = text_buffer->begin();
-    if (buff_start_iter.get_char() != CtConst::CHAR_NEWLINE[0]) {
+    if (buff_start_iter.get_char() != g_utf8_get_char(CtConst::CHAR_NEWLINE)) {
         s_state.newline_trick = true;
         restore_modified = !text_buffer->get_modified();
         text_buffer->insert(buff_start_iter, CtConst::CHAR_NEWLINE);
@@ -946,12 +946,12 @@ std::string CtActions::_get_line_content(Glib::RefPtr<Gtk::TextBuffer> text_buff
     auto line_start = text_iter;
     auto line_end = text_iter;
     if (!line_start.backward_char()) return "";
-    while (line_start.get_char() != CtConst::CHAR_NEWLINE[0])
+    while (line_start.get_char() != g_utf8_get_char(CtConst::CHAR_NEWLINE))
         if (!line_start.backward_char())
             break;
-    if (line_start.get_char() == CtConst::CHAR_NEWLINE[0])
+    if (line_start.get_char() == g_utf8_get_char(CtConst::CHAR_NEWLINE))
         line_start.forward_char();
-    while (line_end.get_char() != CtConst::CHAR_NEWLINE[0])
+    while (line_end.get_char() != g_utf8_get_char(CtConst::CHAR_NEWLINE))
         if (!line_end.forward_char())
             break;
     return text_buffer->get_text(line_start, line_end);
@@ -961,11 +961,11 @@ std::string CtActions::_get_line_content(Glib::RefPtr<Gtk::TextBuffer> text_buff
 std::string CtActions::_get_first_line_content(Glib::RefPtr<Gtk::TextBuffer> text_buffer)
 {
     Gtk::TextIter start_iter = text_buffer->get_iter_at_offset(0);
-    while (start_iter.get_char() == CtConst::CHAR_NEWLINE[0])
+    while (start_iter.get_char() == g_utf8_get_char(CtConst::CHAR_NEWLINE))
         if (!start_iter.forward_char())
             return "";
     Gtk::TextIter end_iter = start_iter;
-    while (end_iter.get_char() != CtConst::CHAR_NEWLINE[0])
+    while (end_iter.get_char() != g_utf8_get_char(CtConst::CHAR_NEWLINE))
         if (!end_iter.forward_char())
             break;
     return text_buffer->get_text(start_iter, end_iter);

--- a/future/src/ct/ct_actions_format.cc
+++ b/future/src/ct/ct_actions_format.cc
@@ -437,7 +437,7 @@ Glib::ustring CtActions::_link_check_around_cursor()
     auto text_iter = _curr_buffer()->get_insert()->get_iter();
     Glib::ustring tag_name = link_check_around_cursor_iter(text_iter);
     if (tag_name.empty()) {
-        if (text_iter.get_char() == CtConst::CHAR_SPACE[0] and text_iter.backward_char()) {
+        if (text_iter.get_char() == g_utf8_get_char(CtConst::CHAR_SPACE) and text_iter.backward_char()) {
             tag_name = link_check_around_cursor_iter(text_iter);
             if (tag_name.empty()) return "";
         } else

--- a/future/src/ct/ct_actions_others.cc
+++ b/future/src/ct/ct_actions_others.cc
@@ -121,7 +121,10 @@ void CtActions::embfile_delete()
 // Embedded File Save Dialog
 void CtActions::embfile_save()
 {
-    CtDialogs::file_select_args args = {.pParentWin=_pCtMainWin, .curr_folder=_pCtMainWin->get_ct_config()->pickDirFile, .curr_file_name=curr_file_anchor->get_file_name()};
+    CtDialogs::file_select_args args(_pCtMainWin);
+    args.curr_folder = _pCtMainWin->get_ct_config()->pickDirFile;
+    args.curr_file_name = curr_file_anchor->get_file_name();
+
     std::string filepath = CtDialogs::file_save_as_dialog(args);
     if (filepath.empty()) return;
 
@@ -162,13 +165,12 @@ void CtActions::embfile_open()
 // Save to Disk the selected Image
 void CtActions::image_save()
 {
-    CtDialogs::file_select_args args{
-        .pParentWin=_pCtMainWin,
-        .curr_folder=_pCtMainWin->get_ct_config()->pickDirImg,
-        .curr_file_name="",
-        .filter_name=_("PNG Image"),
-        .filter_pattern={"*.png"}
-    };
+    CtDialogs::file_select_args args(_pCtMainWin);
+    args.curr_folder = _pCtMainWin->get_ct_config()->pickDirImg;
+    args.curr_file_name = "";
+    args.filter_name = _("PNG Image");
+    args.filter_pattern = {"*.png"};
+
     std::string filename = CtDialogs::file_save_as_dialog(args);
     if (filename.empty()) return;
 
@@ -457,7 +459,9 @@ void CtActions::exec_code()
 void CtActions::codebox_load_from_file()
 {
     if (not _is_curr_node_not_read_only_or_error()) return;
-    CtDialogs::file_select_args args = {.pParentWin=_pCtMainWin, .curr_folder=_pCtMainWin->get_ct_config()->pickDirCbox};
+    CtDialogs::file_select_args args(_pCtMainWin);
+    args.curr_folder = _pCtMainWin->get_ct_config()->pickDirCbox;
+
     std::string filepath = CtDialogs::file_select_dialog(args);
     if (filepath.empty()) return;
     _pCtMainWin->get_ct_config()->pickDirCbox = Glib::path_get_dirname(filepath);
@@ -472,7 +476,9 @@ void CtActions::codebox_load_from_file()
 // Save the CodeBox Content To a Text File
 void CtActions::codebox_save_to_file()
 {
-    CtDialogs::file_select_args args = {.pParentWin=_pCtMainWin, .curr_folder=_pCtMainWin->get_ct_config()->pickDirCbox};
+    CtDialogs::file_select_args args(_pCtMainWin);
+    args.curr_folder=_pCtMainWin->get_ct_config()->pickDirCbox;
+
     std::string filepath = CtDialogs::file_save_as_dialog(args);
     if (filepath.empty()) return;
     _pCtMainWin->get_ct_config()->pickDirCbox = Glib::path_get_dirname(filepath);

--- a/future/src/ct/ct_dialogs.cc
+++ b/future/src/ct/ct_dialogs.cc
@@ -925,7 +925,9 @@ bool CtDialogs::link_handle_dialog(CtMainWin& ctMainWin,
     });
     button_browse_file.signal_clicked().connect([&]()
     {
-        std::string filepath = file_select_dialog({.pParentWin=&dialog, .curr_folder=ctMainWin.get_ct_config()->pickDirFile});
+        file_select_args args(&dialog);
+        args.curr_folder=ctMainWin.get_ct_config()->pickDirFile;
+        std::string filepath = file_select_dialog(args);
         if (filepath.empty())
         {
             return;

--- a/future/src/ct/ct_dialogs.h
+++ b/future/src/ct/ct_dialogs.h
@@ -238,6 +238,8 @@ struct file_select_args
     Glib::ustring               filter_name;
     std::vector<std::string>    filter_pattern;
     std::vector<std::string>    filter_mime;
+
+    file_select_args(Gtk::Window* win) : pParentWin(win) {}
 };
 
 // The Select file dialog, Returns the retrieved filepath or None
@@ -265,6 +267,8 @@ struct storage_select_args
     CtDocType     ctDocType{CtDocType::None};
     CtDocEncrypt  ctDocEncrypt{CtDocEncrypt::None};
     std::string   password;
+
+    storage_select_args(Gtk::Window* win) : pParentWin(win) {}
 };
 
 // Choose the CherryTree data storage type (xml or db) and protection

--- a/future/src/ct/ct_export2pdf.cc
+++ b/future/src/ct/ct_export2pdf.cc
@@ -772,7 +772,7 @@ Glib::ustring CtExport2Pango::pango_get_from_code_buffer(Glib::RefPtr<Gsv::Buffe
             break;
         }
     }
-    if (pango_text.size() == 0 || pango_text[pango_text.size()-1] != CtConst::CHAR_NEWLINE[0])
+    if (pango_text.size() == 0 || pango_text[pango_text.size()-1] != g_utf8_get_char(CtConst::CHAR_NEWLINE))
         pango_text += CtConst::CHAR_NEWLINE;
     return pango_text;
 }

--- a/future/src/ct/ct_imports.cc
+++ b/future/src/ct/ct_imports.cc
@@ -43,8 +43,8 @@ std::vector<std::pair<int, int>> CtImports::get_web_links_offsets_from_plain_tex
         {
             int end_offset = start_offset + 3;
             while (end_offset < max_end_offset
-                   && plain_text[(size_t)end_offset] != CtConst::CHAR_SPACE[0]
-                   && plain_text[(size_t)end_offset] != CtConst::CHAR_NEWLINE[0])
+                   && plain_text[(size_t)end_offset] != g_utf8_get_char(CtConst::CHAR_SPACE)
+                   && plain_text[(size_t)end_offset] != g_utf8_get_char(CtConst::CHAR_NEWLINE))
                 end_offset += 1;
             web_links.push_back(std::make_pair(start_offset, end_offset));
             start_offset = end_offset + 1;

--- a/future/src/ct/ct_list.cc
+++ b/future/src/ct/ct_list.cc
@@ -168,18 +168,18 @@ CtListInfo CtList::list_get_number_n_level(Gtk::TextIter iter_first_paragraph)
     while (iter_start) {
         auto ch = iter_start.get_char();
         if (str::indexOf(_pCtMainWin->get_ct_config()->charsListbul, ch) != -1) {
-            if (iter_start.forward_char() && iter_start.get_char() == CtConst::CHAR_SPACE[0]) {
+            if (iter_start.forward_char() && iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_SPACE)) {
                 int num = str::indexOf(_pCtMainWin->get_ct_config()->charsListbul, ch);
                 return CtListInfo{CtListType::Bullet, num, level, -1, -1};
             }
             break;
         }
         if (str::indexOf(_pCtMainWin->get_ct_config()->charsTodo, ch) != -1) {
-            if (iter_start.forward_char() && iter_start.get_char() == CtConst::CHAR_SPACE[0])
+            if (iter_start.forward_char() && iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_SPACE))
                 return CtListInfo{CtListType::Todo, 0, level, -1, -1};
             break;
         }
-        if (ch == CtConst::CHAR_SPACE[0]) {
+        if (ch == g_utf8_get_char(CtConst::CHAR_SPACE)) {
             if (CtTextIterUtil::startswith(iter_start, Glib::ustring(3, CtConst::CHAR_SPACE[0]).c_str())) {
                 iter_start.forward_chars(3);
                 level += 1;
@@ -194,7 +194,7 @@ CtListInfo CtList::list_get_number_n_level(Gtk::TextIter iter_first_paragraph)
             while (iter_start.forward_char() && iter_start.get_char() >= '0' && iter_start.get_char() <= '9')
                 number_str += iter_start.get_char();
             ch = iter_start.get_char();
-            if (str::indexOf(CtConst::CHARS_LISTNUM, ch) != -1 && iter_start.forward_char() && iter_start.get_char() == CtConst::CHAR_SPACE[0]) {
+            if (str::indexOf(CtConst::CHARS_LISTNUM, ch) != -1 && iter_start.forward_char() && iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_SPACE)) {
                 int num = std::stoi(number_str);
                 auto aux = str::indexOf(CtConst::CHARS_LISTNUM, ch);
                 return CtListInfo{CtListType::Number, num, level, aux, -1};
@@ -210,7 +210,7 @@ CtListInfo CtList::list_get_number_n_level(Gtk::TextIter iter_first_paragraph)
 int CtList::get_multiline_list_element_end_offset(Gtk::TextIter curr_iter, CtListInfo list_info)
 {
     Gtk::TextIter iter_start = curr_iter;
-    if (iter_start.get_char() == CtConst::CHAR_NEWLINE[0]) {
+    if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_NEWLINE)) {
         if (!iter_start.forward_char()) {
             // the end of buffer is also the list end
             return iter_start.get_offset();
@@ -274,12 +274,12 @@ CtListInfo CtList::get_paragraph_list_info(Gtk::TextIter iter_start_orig)
     bool buffer_start = false;
     Gtk::TextIter iter_start = iter_start_orig;
     // let's search for the paragraph start
-    if (iter_start.get_char() == CtConst::CHAR_NEWLINE[0])
+    if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_NEWLINE))
         if (!iter_start.backward_char())
             buffer_start = true; // if we are exactly on the paragraph end
     if (!buffer_start) {
         while (true)
-            if (iter_start.get_char() == CtConst::CHAR_NEWLINE[0])
+            if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_NEWLINE))
                 break; // we got the previous paragraph start
             else if (!iter_start.backward_char()) {
                 buffer_start = true;
@@ -318,20 +318,20 @@ CtTextRange CtList::get_paragraph_iters(Gtk::TextIter* force_iter /*= nullptr*/)
         if (!force_iter) iter_start = _curr_buffer->get_insert()->get_iter();
         else             iter_start = *force_iter;
         iter_end = iter_start;
-        if (iter_start.get_char() == CtConst::CHAR_NEWLINE[0]) {
+        if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_NEWLINE)) {
             // we're upon a row end
             if (!iter_start.backward_char()) return CtTextRange{iter_invalid, iter_invalid};
-            if (iter_start.get_char() == CtConst::CHAR_NEWLINE[0]) return CtTextRange{iter_invalid, iter_invalid};
+            if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_NEWLINE)) return CtTextRange{iter_invalid, iter_invalid};
         }
     }
     while (iter_end) {
         auto ch = iter_end.get_char();
-        if (ch == CtConst::CHAR_NEWLINE[0]) break; // we got it
+        if (ch == g_utf8_get_char(CtConst::CHAR_NEWLINE)) break; // we got it
         else if (!iter_end.forward_char())  break; // we reached the buffer end
     }
     while (iter_start || iter_start == _curr_buffer->end()) {
         auto ch = iter_start.get_char();
-        if (ch == CtConst::CHAR_NEWLINE[0]) { // we got it
+        if (ch == g_utf8_get_char(CtConst::CHAR_NEWLINE)) { // we got it
             iter_start.forward_char();        // step forward to the beginning of the new line
             break;
         }
@@ -372,7 +372,7 @@ void CtList::todo_list_rotate_status(Gtk::TextIter todo_char_iter)
 bool CtList::char_iter_forward_to_newline(Gtk::TextIter& char_iter)
 {
     if (!char_iter.forward_char()) return false;
-    while (char_iter.get_char() != CtConst::CHAR_NEWLINE[0])
+    while (char_iter.get_char() != g_utf8_get_char(CtConst::CHAR_NEWLINE))
         if (!char_iter.forward_char())
             return false;
     return true;
@@ -382,7 +382,7 @@ bool CtList::char_iter_forward_to_newline(Gtk::TextIter& char_iter)
 bool CtList::char_iter_backward_to_newline(Gtk::TextIter& char_iter)
 {
     if (!char_iter.backward_char()) return false;
-    while (char_iter.get_char() != CtConst::CHAR_NEWLINE[0])
+    while (char_iter.get_char() != g_utf8_get_char(CtConst::CHAR_NEWLINE))
         if (!char_iter.backward_char()) return false;
     return true;
 }
@@ -395,13 +395,13 @@ void CtList::todo_lists_old_to_new_conversion()
     bool first_line = true;
     while (curr_iter) {
         bool fw_needed = true;
-        if ((first_line || curr_iter.get_char() == CtConst::CHAR_NEWLINE[0]) && curr_iter.forward_char()) {
+        if ((first_line || curr_iter.get_char() == g_utf8_get_char(CtConst::CHAR_NEWLINE)) && curr_iter.forward_char()) {
             first_line = false;
             if (keep_cleaning) {
                 Gtk::TextIter iter_bis = curr_iter;
-                if (iter_bis.get_char() == CtConst::CHAR_SPACE[0] && iter_bis.forward_char()
-                        && iter_bis.get_char() == CtConst::CHAR_SPACE[0] && iter_bis.forward_char()
-                        && iter_bis.get_char() == CtConst::CHAR_SPACE[0])
+                if (iter_bis.get_char() == g_utf8_get_char(CtConst::CHAR_SPACE) && iter_bis.forward_char()
+                        && iter_bis.get_char() == g_utf8_get_char(CtConst::CHAR_SPACE) && iter_bis.forward_char()
+                        && iter_bis.get_char() == g_utf8_get_char(CtConst::CHAR_SPACE))
                 {
                     bool no_stop = char_iter_forward_to_newline(curr_iter);
                     _curr_buffer->remove_all_tags(iter_bis, curr_iter);
@@ -411,21 +411,21 @@ void CtList::todo_lists_old_to_new_conversion()
                 else
                     keep_cleaning = false;
             }
-            if (curr_iter.get_char() == CtConst::CHAR_SQ_BR_OPEN[0] && curr_iter.forward_char()
-                    && (curr_iter.get_char() == CtConst::CHAR_SPACE[0] || curr_iter.get_char() == 'X'))
+            if (curr_iter.get_char() == g_utf8_get_char(CtConst::CHAR_SQ_BR_OPEN) && curr_iter.forward_char()
+                    && (curr_iter.get_char() == g_utf8_get_char(CtConst::CHAR_SPACE) || curr_iter.get_char() == 'X'))
             {
                 auto middle_char = curr_iter.get_char();
-                if (curr_iter.forward_char() && curr_iter.get_char() == CtConst::CHAR_SQ_BR_CLOSE[0]
+                if (curr_iter.forward_char() && curr_iter.get_char() == g_utf8_get_char(CtConst::CHAR_SQ_BR_CLOSE)
                         && curr_iter.forward_char())
                 {
                     Gtk::TextIter first_iter = curr_iter;
                     first_iter.backward_chars(3);
                     int iter_offset = first_iter.get_offset();
                     _curr_buffer->erase(first_iter, curr_iter);
-                    auto todo_char = middle_char == CtConst::CHAR_SPACE[0] ? _pCtMainWin->get_ct_config()->charsTodo[0] : _pCtMainWin->get_ct_config()->charsTodo[1];
+                    auto todo_char = middle_char == g_utf8_get_char(CtConst::CHAR_SPACE) ? _pCtMainWin->get_ct_config()->charsTodo[0] : _pCtMainWin->get_ct_config()->charsTodo[1];
                     _curr_buffer->insert(_curr_buffer->get_iter_at_offset(iter_offset), Glib::ustring(1, todo_char));
                     Gtk::TextIter curr_iter = _curr_buffer->get_iter_at_offset(iter_offset);
-                    if (middle_char != CtConst::CHAR_SPACE[0]) {
+                    if (middle_char != g_utf8_get_char(CtConst::CHAR_SPACE)) {
                         first_iter = curr_iter;
                         bool no_stop = char_iter_forward_to_newline(curr_iter);
                         // print "%s(%s),%s(%s)" % (first_iter.get_char(), first_iter.get_offset(), curr_iter.get_char(), curr_iter.get_offset())

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -1194,16 +1194,13 @@ void CtMainWin::switch_buffer_text_source(Glib::RefPtr<Gsv::Buffer> text_buffer,
     bool user_active_restore = user_active();
     user_active() = false;
 
-    bool rich_to_non_rich = false;
     Glib::ustring node_text;
     if (old_syntax == CtConst::RICH_TEXT_ID)
     {
-        rich_to_non_rich = true;
         node_text = CtExport2Txt(this).node_export_to_txt(tree_iter, "", {0}, -1, -1);
     }
     else
     {
-        rich_to_non_rich = false;
         node_text = text_buffer->get_text();
     }
 

--- a/future/src/ct/ct_storage_xml.cc
+++ b/future/src/ct/ct_storage_xml.cc
@@ -209,7 +209,7 @@ xmlpp::Element* CtStorageXmlHelper::node_to_xml(CtTreeIter* ct_tree_iter, xmlpp:
     return p_node_node;
 }
 
-Glib::RefPtr<Gsv::Buffer> CtStorageXmlHelper::create_buffer_and_widgets_from_xml(xmlpp::Element* parent_xml_element, const Glib::ustring& syntax,
+Glib::RefPtr<Gsv::Buffer> CtStorageXmlHelper::create_buffer_and_widgets_from_xml(xmlpp::Element* parent_xml_element, const Glib::ustring& /*syntax*/,
                                                                     std::list<CtAnchoredWidget*>& widgets, Gtk::TextIter* text_insert_pos, int force_offset)
 {
     Glib::RefPtr<Gsv::Buffer> buffer = _pCtMainWin->get_new_text_buffer();

--- a/future/src/ct/ct_treestore.cc
+++ b/future/src/ct/ct_treestore.cc
@@ -278,7 +278,7 @@ bool CtDragStore::drag_data_get_vfunc(const Gtk::TreeModel::Path& path, Gtk::Sel
 }
 
 
-bool CtDragStore::drag_data_received_vfunc(const Gtk::TreeModel::Path& dest, const Gtk::SelectionData& selection_data)
+bool CtDragStore::drag_data_received_vfunc(const Gtk::TreeModel::Path& dest, const Gtk::SelectionData& /*selection_data*/)
 {
     Gtk::TreeModel::Path src(_drag_src);
     return _pCtMainWin->get_ct_actions()->node_move(src, dest);

--- a/future/src/ct/ct_widgets.cc
+++ b/future/src/ct/ct_widgets.cc
@@ -388,13 +388,13 @@ void CtTextView::for_event_after_key_press(GdkEvent* event, const Glib::ustring&
                 {
                     int candidate_offset = iter_start.get_offset();
                     if (not iter_start.backward_char()
-                            or iter_start.get_char() == CtConst::CHAR_NEWLINE[0]
-                            or iter_start.get_char() == CtConst::CHAR_SPACE[0]
-                            or iter_start.get_char() == CtConst::CHAR_TAB[0])
+                            or iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_NEWLINE)
+                            or iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_SPACE)
+                            or iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_TAB))
                         offset_0 = candidate_offset;
                     break;
                 }
-                if (curr_char == CtConst::CHAR_NEWLINE[0]) break;
+                if (curr_char == g_utf8_get_char(CtConst::CHAR_NEWLINE)) break;
                 if (not iter_start.backward_char()) break;
             }
             if (offset_0 >= 0)
@@ -437,8 +437,8 @@ void CtTextView::for_event_after_key_press(GdkEvent* event, const Glib::ustring&
                 return;
             }
             if (not iter_start.backward_char()) return;
-            if (iter_start.get_char() != CtConst::CHAR_NEWLINE[0]) return;
-            if (iter_start.backward_char() and iter_start.get_char() == CtConst::CHAR_NEWLINE[0])
+            if (iter_start.get_char() != g_utf8_get_char(CtConst::CHAR_NEWLINE)) return;
+            if (iter_start.backward_char() and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_NEWLINE))
                 return; // former was an empty row
             CtListInfo list_info = CtList(_pCtMainWin, text_buffer).get_paragraph_list_info(iter_start);
             if (not list_info)
@@ -507,78 +507,78 @@ void CtTextView::for_event_after_key_press(GdkEvent* event, const Glib::ustring&
         {
             if (not is_code and config->enableSymbolAutoreplace and iter_start.backward_chars(2))
             {
-                if (iter_start.get_char() == CtConst::CHAR_GREATER[0] and iter_start.backward_char())
+                if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_GREATER) and iter_start.backward_char())
                 {
                     if (iter_start.get_line_offset() == 0)
                     {
                         // at line start
-                        if (iter_start.get_char() == CtConst::CHAR_LESSER[0])
+                        if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_LESSER))
                             // "<> " becoming "◇ "
                             _special_char_replace(CtConst::CHARS_LISTBUL_DEFAULT[1], iter_start, iter_insert);
-                        else if (iter_start.get_char() == CtConst::CHAR_MINUS[0])
+                        else if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_MINUS))
                             // "-> " becoming "→ "
                             _special_char_replace(CtConst::CHARS_LISTBUL_DEFAULT[4], iter_start, iter_insert);
-                        else if (iter_start.get_char() == CtConst::CHAR_EQUAL[0])
+                        else if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_EQUAL))
                             // "=> " becoming "⇒ "
                             _special_char_replace(CtConst::CHARS_LISTBUL_DEFAULT[5], iter_start, iter_insert);
                     }
-                    else if (iter_start.get_char() == CtConst::CHAR_MINUS[0] and iter_start.backward_char())
+                    else if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_MINUS) and iter_start.backward_char())
                     {
-                        if (iter_start.get_char() == CtConst::CHAR_LESSER[0])
+                        if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_LESSER))
                             // "<-> " becoming "↔ "
                             _special_char_replace(CtConst::SPECIAL_CHAR_ARROW_DOUBLE[0], iter_start, iter_insert);
-                        else if (iter_start.get_char() == CtConst::CHAR_MINUS[0])
+                        else if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_MINUS))
                             // "--> " becoming "→ "
                             _special_char_replace(CtConst::SPECIAL_CHAR_ARROW_RIGHT[0], iter_start, iter_insert);
                     }
-                    else if (iter_start.get_char() == CtConst::CHAR_EQUAL[0] and iter_start.backward_char())
+                    else if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_EQUAL) and iter_start.backward_char())
                     {
-                        if (iter_start.get_char() == CtConst::CHAR_LESSER[0])
+                        if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_LESSER))
                             // "<=> " becoming "⇔ "
                             _special_char_replace(CtConst::SPECIAL_CHAR_ARROW_DOUBLE2[0], iter_start, iter_insert);
-                        else if (iter_start.get_char() == CtConst::CHAR_EQUAL[0])
+                        else if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_EQUAL))
                             // "==> " becoming "⇒ "
                             _special_char_replace(CtConst::SPECIAL_CHAR_ARROW_RIGHT2[0], iter_start, iter_insert);
                     }
                 }
-                else if (iter_start.get_char() == CtConst::CHAR_MINUS[0] and iter_start.backward_char()
-                        and iter_start.get_char() == CtConst::CHAR_MINUS[0] and iter_start.backward_char()
-                        and iter_start.get_char() == CtConst::CHAR_LESSER[0])
+                else if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_MINUS) and iter_start.backward_char()
+                        and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_MINUS) and iter_start.backward_char()
+                        and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_LESSER))
                         // "<-- " becoming "← "
                         _special_char_replace(CtConst::SPECIAL_CHAR_ARROW_LEFT[0], iter_start, iter_insert);
-                else if (iter_start.get_char() == CtConst::CHAR_EQUAL[0] and iter_start.backward_char()
-                        and iter_start.get_char() == CtConst::CHAR_EQUAL[0] and iter_start.backward_char()
-                        and iter_start.get_char() == CtConst::CHAR_LESSER[0])
+                else if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_EQUAL) and iter_start.backward_char()
+                        and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_EQUAL) and iter_start.backward_char()
+                        and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_LESSER))
                         // "<== " becoming "⇐ "
                         _special_char_replace(CtConst::SPECIAL_CHAR_ARROW_LEFT2[0], iter_start, iter_insert);
-                else if (iter_start.get_char() == CtConst::CHAR_PARENTH_CLOSE[0] and iter_start.backward_char())
+                else if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_PARENTH_CLOSE) and iter_start.backward_char())
                 {
                     if (g_unichar_tolower(iter_start.get_char()) == 'c' and iter_start.backward_char()
-                       and iter_start.get_char() == CtConst::CHAR_PARENTH_OPEN[0])
+                       and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_PARENTH_OPEN))
                         // "(c) " becoming "© "
                         _special_char_replace(CtConst::SPECIAL_CHAR_COPYRIGHT[0], iter_start, iter_insert);
                     else if (g_unichar_tolower(iter_start.get_char()) == 'r' and iter_start.backward_char()
-                            and iter_start.get_char() == CtConst::CHAR_PARENTH_OPEN[0])
+                            and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_PARENTH_OPEN))
                             // "(r) " becoming "® "
                             _special_char_replace(CtConst::SPECIAL_CHAR_REGISTERED_TRADEMARK[0], iter_start, iter_insert);
                     else if (g_unichar_tolower(iter_start.get_char()) == 'm' and iter_start.backward_char()
                             and g_unichar_tolower(iter_start.get_char()) == 't' and iter_start.backward_char()
-                            and iter_start.get_char() == CtConst::CHAR_PARENTH_OPEN[0])
+                            and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_PARENTH_OPEN))
                             // "(tm) " becoming "™ "
                             _special_char_replace(CtConst::SPECIAL_CHAR_UNREGISTERED_TRADEMARK[0], iter_start, iter_insert);
                 }
-                else if (iter_start.get_char() == CtConst::CHAR_STAR[0] and iter_start.get_line_offset() == 0)
+                else if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_STAR) and iter_start.get_line_offset() == 0)
                     // "* " becoming "• " at line start
                     _special_char_replace(CtConst::CHARS_LISTBUL_DEFAULT[0], iter_start, iter_insert);
-                else if (iter_start.get_char() == CtConst::CHAR_SQ_BR_CLOSE[0] and iter_start.backward_char())
+                else if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_SQ_BR_CLOSE) and iter_start.backward_char())
                 {
-                    if (iter_start.get_line_offset() == 0 and iter_start.get_char() == CtConst::CHAR_SQ_BR_OPEN[0])
+                    if (iter_start.get_line_offset() == 0 and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_SQ_BR_OPEN))
                         // "[] " becoming "☐ " at line start
                         _special_char_replace(config->charsTodo[0], iter_start, iter_insert);
                 }
-                else if (iter_start.get_char() == CtConst::CHAR_COLON[0] and iter_start.backward_char())
+                else if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_COLON) and iter_start.backward_char())
                 {
-                    if (iter_start.get_line_offset() == 0 and iter_start.get_char() == CtConst::CHAR_COLON[0])
+                    if (iter_start.get_line_offset() == 0 and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_COLON))
                         // ":: " becoming "▪ " at line start
                         _special_char_replace(CtConst::CHARS_LISTBUL_DEFAULT[2], iter_start, iter_insert);
                 }
@@ -698,16 +698,16 @@ bool CtTextView::_apply_tag_try_link(Gtk::TextIter iter_end, int offset_cursor)
 
     bool tag_applied = false;
     Gtk::TextIter iter_start = iter_end;
-    if (iter_start.backward_char() and iter_start.get_char() == CtConst::CHAR_SQ_BR_CLOSE[0]
-        and iter_start.backward_char() and iter_start.get_char() == CtConst::CHAR_SQ_BR_CLOSE[0])
+    if (iter_start.backward_char() and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_SQ_BR_CLOSE)
+        and iter_start.backward_char() and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_SQ_BR_CLOSE))
     {
         int curr_state = 0;
         while (iter_start.backward_char())
         {
             auto curr_char = iter_start.get_char();
-            if (curr_char == CtConst::CHAR_NEWLINE[0])
+            if (curr_char == g_utf8_get_char(CtConst::CHAR_NEWLINE))
                 break;
-            if (curr_char == CtConst::CHAR_SQ_BR_OPEN[0])
+            if (curr_char == g_utf8_get_char(CtConst::CHAR_SQ_BR_OPEN))
             {
                 if (curr_state == 0)
                     curr_state = 1;
@@ -738,7 +738,8 @@ bool CtTextView::_apply_tag_try_link(Gtk::TextIter iter_end, int offset_cursor)
         while (iter_start.backward_char())
         {
             auto curr_char = iter_start.get_char();
-            if (curr_char == CtConst::CHAR_SPACE[0] or curr_char == CtConst::CHAR_NEWLINE[0] or curr_char == CtConst::CHAR_CR[0] or curr_char == CtConst::CHAR_TAB[0])
+            if (curr_char == g_utf8_get_char(CtConst::CHAR_SPACE) or curr_char == g_utf8_get_char(CtConst::CHAR_NEWLINE)
+                    or curr_char == g_utf8_get_char(CtConst::CHAR_CR) or curr_char == g_utf8_get_char(CtConst::CHAR_TAB))
             {
                 iter_start.forward_char();
                 break;
@@ -766,11 +767,11 @@ bool CtTextView::_apply_tag_try_link(Gtk::TextIter iter_end, int offset_cursor)
 // Returns the indentation of the former paragraph or empty string
 Glib::ustring CtTextView::_get_former_line_indentation(Gtk::TextIter iter_start)
 {
-    if (not iter_start.backward_chars(2) or iter_start.get_char() == CtConst::CHAR_NEWLINE[0]) return "";
+    if (not iter_start.backward_chars(2) or iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_NEWLINE)) return "";
     bool buffer_start = false;
     while (true)
     {
-        if (iter_start.get_char() == CtConst::CHAR_NEWLINE[0]) break; // we got the previous paragraph start
+        if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_NEWLINE)) break; // we got the previous paragraph start
         else if (not iter_start.backward_char())
         {
             buffer_start = true;
@@ -778,17 +779,17 @@ Glib::ustring CtTextView::_get_former_line_indentation(Gtk::TextIter iter_start)
         }
     }
     if (not buffer_start) iter_start.forward_char();
-    if (iter_start.get_char() == CtConst::CHAR_SPACE[0])
+    if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_SPACE))
     {
         size_t num_spaces = 1;
-        while (iter_start.forward_char() and iter_start.get_char() == CtConst::CHAR_SPACE[0])
+        while (iter_start.forward_char() and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_SPACE))
             num_spaces += 1;
         return Glib::ustring(num_spaces, CtConst::CHAR_SPACE[0]);
     }
-    if (iter_start.get_char() == CtConst::CHAR_TAB[0])
+    if (iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_TAB))
     {
         size_t num_tabs = 1;
-        while (iter_start.forward_char() and iter_start.get_char() == CtConst::CHAR_TAB[0])
+        while (iter_start.forward_char() and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_TAB))
             num_tabs += 1;
         return Glib::ustring(num_tabs, CtConst::CHAR_TAB[0]);
     }


### PR DESCRIPTION
comparing gunichar with char gives a lot of warnings, so I use  g_utf8_get_char to get gunichar from char string. It's ugly, but I don't think it will impact performance. Maybe later I will come up with better solution.