### PR TITLE
Fix searching map based on pointer key when exporting to pdf

### DIFF
--- a/future/src/ct/ct_export2pdf.cc
+++ b/future/src/ct/ct_export2pdf.cc
@@ -808,13 +808,18 @@ Glib::ustring CtExport2Pango::_pango_process_slot(int start_offset, int end_offs
     Glib::ustring curr_pango_text = "";
     CtTextIterUtil::generic_process_slot(start_offset, end_offset, curr_buffer,
                                          [&](Gtk::TextIter& start_iter, Gtk::TextIter& curr_iter, std::map<const gchar*, std::string>& curr_attributes) {
-        curr_pango_text += _pango_text_serialize(start_iter, curr_iter, curr_attributes);
+        std::map<std::string, std::string> curr_attributes_str;
+        for (const auto& keypair : curr_attributes) {
+            curr_attributes_str.emplace(keypair.first, keypair.second);
+        }
+        
+        curr_pango_text += _pango_text_serialize(start_iter, curr_iter, curr_attributes_str);
     });
     return curr_pango_text;
 }
 
 // Adds a slice to the Pango Text
-Glib::ustring CtExport2Pango::_pango_text_serialize(Gtk::TextIter start_iter, Gtk::TextIter end_iter, const std::map<const gchar*, std::string>& curr_attributes)
+Glib::ustring CtExport2Pango::_pango_text_serialize(Gtk::TextIter start_iter, Gtk::TextIter end_iter, const std::map<std::string, std::string> &curr_attributes)
 {
     Glib::ustring pango_attrs;
     bool superscript_active = false;

--- a/future/src/ct/ct_export2pdf.cc
+++ b/future/src/ct/ct_export2pdf.cc
@@ -150,8 +150,8 @@ void CtPrint::print_text(CtMainWin* pCtMainWin, const Glib::ustring& pdf_filepat
     {
         if (auto* image = dynamic_cast<CtImage*>(widget))            _widgets.push_back(std::shared_ptr<CtPrintImageProxy>(new CtPrintImageProxy(image)));
         else if (auto* table = dynamic_cast<CtTable*>(widget))       _widgets.push_back(std::shared_ptr<CtPrintTableProxy>(new CtPrintTableProxy(table, 1, table->get_table_matrix().size())));
-        else if (auto* codebox = dynamic_cast<CtCodebox*>(widget)) _widgets.push_back(std::shared_ptr<CtPrintCodeboxProxy>(new CtPrintCodeboxProxy(codebox)));
-        else                                                            _widgets.push_back(std::shared_ptr<CtPrintSomeProxy>(new CtPrintSomeProxy(widget)));
+        else if (auto* codebox = dynamic_cast<CtCodebox*>(widget))   _widgets.push_back(std::shared_ptr<CtPrintCodeboxProxy>(new CtPrintCodeboxProxy(codebox)));
+        else                                                         _widgets.push_back(std::shared_ptr<CtPrintSomeProxy>(new CtPrintSomeProxy(widget)));
     }
 
     CtPrintData print_data;

--- a/future/src/ct/ct_export2pdf.h
+++ b/future/src/ct/ct_export2pdf.h
@@ -205,5 +205,5 @@ public:
                                        bool excude_anchors, std::list<CtAnchoredWidget*>& out_widgets);
 private:
     Glib::ustring _pango_process_slot(int start_offset, int end_offset, Glib::RefPtr<Gtk::TextBuffer> curr_buffer);
-    Glib::ustring _pango_text_serialize(Gtk::TextIter start_iter, Gtk::TextIter end_iter, const std::map<const gchar*, std::string>& curr_attributes);
+    Glib::ustring _pango_text_serialize(Gtk::TextIter start_iter, Gtk::TextIter end_iter, const std::map<std::string, std::string> &curr_attributes);
 };


### PR DESCRIPTION
This fixes a bug I encountered on my future-text-formatting branch, where exporting to pdf fails because the key lookup for `curr_attributes` fails (since it is comparing pointers). Weirdly this does not seem to be an issue upstream, possibly something to do with the changes to tags in my branch?

I am not sure why this ends up not working since it _should_ be comparing identical pointers (both read from `CtConst::TAG_PROPERTIES`). Regardless, comparing strings is a more robust option here.

It also includes formatting changes to improve the readability (e.g `static_cast` instead of C style casts, `auto` when casting, etc) and one or two optimisations (e.g move instead of copy)

