### PR TITLE
Added check for ts_* fields when populating and saving the treestore

### DIFF
--- a/future/src/ct/ct_storage_sqlite.h
+++ b/future/src/ct/ct_storage_sqlite.h
@@ -26,6 +26,7 @@
 #include <glibmm/refptr.h>
 #include <gtksourceviewmm/buffer.h>
 #include <gtkmm/treeiter.h>
+#include <unordered_set>
 
 class CtMainWin;
 class CtAnchoredWidget;
@@ -62,14 +63,14 @@ private:
      * 
      * @param db 
      */
-    void                _check_db_tables(sqlite3* db);
+    void                _check_db_tables();
     /**
      * @brief Get a list of field names for a table
      * @warning Only hardcoded table names should be passed to this method
      * @param table_name 
      * @return std::unordered_set<std::string> 
      */
-    std::unordered_set<std::string> _get_table_field_names(std::string_view table_name) {
+    std::unordered_set<std::string> _get_table_field_names(std::string_view table_name);
 
     void                _image_from_db(const gint64& nodeId, std::list<CtAnchoredWidget*>& anchoredWidgets) const;
     void                _codebox_from_db(const gint64& nodeId, std::list<CtAnchoredWidget*>& anchoredWidgets) const;

--- a/future/src/ct/ct_storage_sqlite.h
+++ b/future/src/ct/ct_storage_sqlite.h
@@ -63,6 +63,14 @@ private:
      * @param db 
      */
     void                _check_db_tables(sqlite3* db);
+    /**
+     * @brief Get a list of field names for a table
+     * @warning Only hardcoded table names should be passed to this method
+     * @param table_name 
+     * @return std::unordered_set<std::string> 
+     */
+    std::unordered_set<std::string> _get_table_field_names(std::string_view table_name) {
+
     void                _image_from_db(const gint64& nodeId, std::list<CtAnchoredWidget*>& anchoredWidgets) const;
     void                _codebox_from_db(const gint64& nodeId, std::list<CtAnchoredWidget*>& anchoredWidgets) const;
     void                _table_from_db(const gint64& nodeId, std::list<CtAnchoredWidget*>& anchoredWidgets) const;

--- a/future/src/ct/ct_storage_sqlite.h
+++ b/future/src/ct/ct_storage_sqlite.h
@@ -57,6 +57,12 @@ private:
     Gtk::TreeIter       _node_from_db(guint node_id, Gtk::TreeIter parent_iter);
     CtTreeIter          _node_from_imported_db(gint64 node_id, CtTreeIter* parent_iter);
     
+    /**
+     * @brief Check that the database contains the required tables
+     * 
+     * @param db 
+     */
+    void                _check_db_tables(sqlite3* db);
     void                _image_from_db(const gint64& nodeId, std::list<CtAnchoredWidget*>& anchoredWidgets) const;
     void                _codebox_from_db(const gint64& nodeId, std::list<CtAnchoredWidget*>& anchoredWidgets) const;
     void                _table_from_db(const gint64& nodeId, std::list<CtAnchoredWidget*>& anchoredWidgets) const;


### PR DESCRIPTION
This fixes the schema mismatch error when importing CT SQLite files created before 49e7f9b for the C++ port