### PR TITLE
Add markdown parsing and importing

### DIFF
--- a/future/src/ct/CMakeLists.txt
+++ b/future/src/ct/CMakeLists.txt
@@ -56,7 +56,9 @@ set(CT_SHARED_FILES
     ct_widgets.cc
     ct_import_zim_handler.cc
     ct_import_handler.cc
-    )
+        ct_text_parser.cc
+    ct_md_handler.cc
+        ct_parser.cc)
 
 add_library(cherrytree_shared STATIC ${CT_SHARED_FILES})
 target_link_libraries(cherrytree_shared

--- a/future/src/ct/CMakeLists.txt
+++ b/future/src/ct/CMakeLists.txt
@@ -56,9 +56,10 @@ set(CT_SHARED_FILES
     ct_widgets.cc
     ct_import_zim_handler.cc
     ct_import_handler.cc
-        ct_text_parser.cc
-    ct_md_handler.cc
-        ct_parser.cc)
+    ct_text_parser.cc
+    ct_md_parser.cc
+    ct_parser.cc
+    )
 
 add_library(cherrytree_shared STATIC ${CT_SHARED_FILES})
 target_link_libraries(cherrytree_shared

--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -427,6 +427,7 @@ private:
     void _import_node_from_html(const std::filesystem::path& filepath);
     void _import_node_from_plaintext(const std::filesystem::path& filepath);
     void _import_nodes_from_zim_directory(const std::filesystem::path& filepath);
+    void _import_node_from_md_file(const std::filesystem::path& filepath);
 public:
     // import actions
     void import_node_from_html_file() noexcept;
@@ -435,4 +436,5 @@ public:
     void import_nodes_from_plaintext_directory() noexcept;
     void import_nodes_from_ct_file() noexcept;
     void import_nodes_from_zim_directory() noexcept;
+    void import_node_from_md_file() /*noexcept*/;
 };

--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -436,5 +436,6 @@ public:
     void import_nodes_from_plaintext_directory() noexcept;
     void import_nodes_from_ct_file() noexcept;
     void import_nodes_from_zim_directory() noexcept;
-    void import_node_from_md_file() /*noexcept*/;
+    void import_node_from_md_file() noexcept;
+    void import_nodes_from_md_directory() noexcept;
 };

--- a/future/src/ct/ct_actions_import.cc
+++ b/future/src/ct/ct_actions_import.cc
@@ -183,22 +183,30 @@ void CtActions::import_nodes_from_plaintext_directory() noexcept
 
 void CtActions::_import_node_from_md_file(const std::filesystem::path& filepath) {
 
-    //std::ifstream infile;
-    //infile.exceptions(std::ios_base::failbit);
-    //infile.open(filepath);
+    std::ifstream infile(filepath);
+    if (!infile) throw std::runtime_error(fmt::format("Failure while opening input file: {}: {}", filepath.string(), strerror(errno)));
 
-    std::stringstream ss;
-    ss << "__italic__ Normal **bold** **__italic and bold__**";
+    //std::stringstream ss;
+    //ss << "__italic__ Normal **bold** **__italic and bold__** [Link Txt](https://google.com)";
     
     CtMDParser handler(_pCtMainWin->get_ct_config());
-    handler.feed(ss);
+    handler.feed(infile);
 
     std::cout << "--XML OUT--\n" << handler.to_string() << std::endl;
 }
 
 void CtActions::import_node_from_md_file() /*noexcept*/ {
    // try {
-        _import_node_from_md_file("");
+        CtDialogs::file_select_args args(_pCtMainWin);
+        args.filter_mime = {"text/plain"};
+        args.filter_pattern = "*.md";
+        
+        auto path = CtDialogs::file_select_dialog(args);
+        
+        // Cancelled
+        if (path.empty()) return;
+        
+        _import_node_from_md_file(path);
 
 
     /*} catch(std::exception& e) {

--- a/future/src/ct/ct_actions_import.cc
+++ b/future/src/ct/ct_actions_import.cc
@@ -180,6 +180,33 @@ void CtActions::import_nodes_from_plaintext_directory() noexcept
     }
 }
 
+
+void CtActions::_import_node_from_md_file(const std::filesystem::path& filepath) {
+
+    std::ifstream infile;
+    infile.exceptions(std::ios_base::failbit);
+    infile.open(filepath);
+
+    std::stringstream ss;
+    ss << "__italic__ Normal **bold** **__italic and bold__**";
+    
+    CtMDParser handler(_pCtMainWin->get_ct_config());
+    handler.feed(ss);
+
+    std::cout << "--XML OUT--\n" << handler.to_string() << std::endl;
+}
+
+void CtActions::import_node_from_md_file() /*noexcept*/ {
+   // try {
+        _import_node_from_md_file("");
+
+
+    /*} catch(std::exception& e) {
+        std::cerr << "Exception caught while importing node from md file: " << e.what() << "\n";
+    }*/
+
+}
+
 void CtActions::_import_nodes_from_zim_directory(const std::filesystem::path& filepath)
 {
     CtZimImportHandler handler(_pCtMainWin->get_ct_config());

--- a/future/src/ct/ct_actions_import.cc
+++ b/future/src/ct/ct_actions_import.cc
@@ -183,9 +183,9 @@ void CtActions::import_nodes_from_plaintext_directory() noexcept
 
 void CtActions::_import_node_from_md_file(const std::filesystem::path& filepath) {
 
-    std::ifstream infile;
-    infile.exceptions(std::ios_base::failbit);
-    infile.open(filepath);
+    //std::ifstream infile;
+    //infile.exceptions(std::ios_base::failbit);
+    //infile.open(filepath);
 
     std::stringstream ss;
     ss << "__italic__ Normal **bold** **__italic and bold__**";

--- a/future/src/ct/ct_import_handler.cc
+++ b/future/src/ct/ct_import_handler.cc
@@ -39,103 +39,17 @@ void CtImportFile::fix_internal_links(const std::string &node_name, uint64_t nod
     
 }
 
-void CtImportHandler::_add_superscript_tag(std::optional<std::string> text) 
-{
-    _current_element->set_attribute(CtConst::TAG_SCALE, CtConst::TAG_PROP_VAL_SUP);
-    
-    if (text) _add_text(*text);
-}
 
-void CtImportHandler::_add_subscript_tag(std::optional<std::string> text) 
-{
-    _current_element->set_attribute(CtConst::TAG_SCALE, CtConst::TAG_PROP_VAL_SUB);
-    
-    if (text) _add_text(*text);
-}
-
-void CtImportHandler::_add_ordered_list(unsigned int level, const std::string &data) 
-{
-    _add_text(fmt::format("{}. {}", level, data));
-}
-
-void CtImportHandler::_add_internal_link(const std::string& text) 
+void CtImportHandler::_add_internal_link(const std::string& text)
 {
     _add_internal_link_to_curr_file(text, _current_element);
     _add_text(text);
 }
 
-void CtImportHandler::_add_todo_list(CHECKBOX_STATE state, const std::string& text) 
-{
-    auto todo_index = static_cast<int>(state);
-    _add_text(_pCtConfig->charsTodo[todo_index] + CtConst::CHAR_SPACE + text);
+void CtImportHandler::_init_new_doc() {
+    _docs.emplace_back(std::make_shared<xmlpp::Document>());
+    _current_import_file()->doc = _xml_doc();
+    _current_element = _xml_doc()->create_root_node("root")->add_child("slot");
+    _current_element = _current_element->add_child("rich_text");
 }
 
-void CtImportHandler::_add_list(uint8_t level, const std::string& data) 
-{
-    if (level >= _pCtConfig->charsListbul.size()) {
-        if (_pCtConfig->charsListbul.size() == 0) {
-            throw std::runtime_error("No bullet-list characters set");
-        }
-        level = _pCtConfig->charsListbul.size() - 1;
-    }
-    std::string indent;
-    auto i_lvl = 0;
-    while(i_lvl < level) {
-        ++i_lvl;
-        indent += CtConst::CHAR_TAB;
-    }
-    
-    _add_text(indent + _pCtConfig->charsListbul[level] + CtConst::CHAR_SPACE + data);
-}
-void CtImportHandler::_add_weight_tag(const Glib::ustring& level, std::optional<std::string> data) 
-{
-    _current_element->set_attribute("weight", level);
-    if (data) {
-        _add_text(*data);
-    }
-}
-
-void CtImportHandler::_add_link(const std::string& text) 
-{
-    auto val = CtImports::get_internal_link_from_http_url(text);
-    _current_element->set_attribute(CtConst::TAG_LINK, val);
-    _add_text(text);
-}
-
-void CtImportHandler::_add_strikethrough_tag(std::optional<std::string> data) 
-{
-    _current_element->set_attribute(CtConst::TAG_STRIKETHROUGH, CtConst::TAG_PROP_VAL_TRUE);
-    if (data) _add_text(*data);
-}
-
-void CtImportHandler::_add_text(std::string text) 
-{
-    auto curr_text = _current_element->get_child_text();
-    if (!curr_text) _current_element->set_child_text(std::move(text));
-    else            curr_text->set_content(curr_text->get_content() + std::move(text));
-}
-
-void CtImportHandler::_close_current_tag() 
-{
-    if (!_tag_empty()) _current_element = _current_element->get_parent()->add_child("rich_text");
-}
-
-void CtImportHandler::_add_newline() {
-    _add_text(CtConst::CHAR_NEWLINE);
-}
-
-void CtImportHandler::_add_italic_tag(std::optional<std::string> data) 
-{
-    _current_element->set_attribute(CtConst::TAG_STYLE, CtConst::TAG_PROP_VAL_ITALIC);
-    if (data) {
-        _add_text(*data);
-    }
-}
-
-void CtImportHandler::_add_scale_tag(int level, std::optional<std::string> data) 
-{
-    _current_element->set_attribute("scale", fmt::format("h{}", level));
-    if (data) {
-        _add_text(*data);
-    }
-}

--- a/future/src/ct/ct_import_zim_handler.cc
+++ b/future/src/ct/ct_import_zim_handler.cc
@@ -186,11 +186,13 @@ const std::vector<CtImportHandler::token_schema>& CtZimImportHandler::_get_token
         {"https://", false, false, [this](const std::string& data) {
             _close_current_tag();
             _add_link("https://"+data);
+            _add_text("https://"+data);
             _close_current_tag();
         }},
         {"http://", false, false, [this](const std::string& data) {
             _close_current_tag();
             _add_link("http://"+data);
+            _add_text("http://"+data);
             _close_current_tag();
         }},
         // Bullet list

--- a/future/src/ct/ct_import_zim_handler.cc
+++ b/future/src/ct/ct_import_zim_handler.cc
@@ -78,90 +78,6 @@ bool CtZimImportHandler::_has_notebook_file() {
     return false;
 }
 
-std::vector<std::pair<const CtImportHandler::token_schema *, std::string>> CtZimImportHandler::_tokenize(const std::string& stream) 
-{
-    
-    auto& tokens = _get_tokens();
-    std::vector<std::pair<const CtImportHandler::token_schema *, std::string>> token_stream;
-    std::unordered_map<std::string_view, bool> open_tags;
-    std::string buff;
-    std::size_t pos = 0;
-    bool keep_parsing = true;
-    const token_schema* curr_token;
-    for (const auto& ch : stream) {
-        buff += ch;
-        pos++;
-        for (const auto &token : tokens) {
-            auto tag_open = open_tags[token.open_tag];
-            
-            
-            auto buff_pos = buff.find(token.open_tag);
-            auto has_opentag = buff_pos != std::string::npos;
-            
-            
-            
-            if (keep_parsing) {
-                if (has_opentag && !tag_open) {
-                    
-                    // First token
-                    curr_token = &token;
-
-                    keep_parsing = !curr_token->capture_all;
-
-                    if (!token.has_closetag) {
-                        // Token will go till end of stream
-                        token_stream.emplace_back(curr_token, std::string(stream.begin() + pos, stream.end()));
-                        
-                        if (keep_parsing) {
-                            // Parse the other data in the stream 
-                            auto tokonised_stream = _tokenize(token_stream.back().second);
-                            for (const auto& token : tokonised_stream) {
-                                if (token.first) {
-                                    token_stream.emplace_back(token);
-                                }
-                             } 
-                        }
-                        return token_stream;
-                    }
-                    open_tags[token.open_tag] = true;
-                    if (pos - buff_pos != pos - buff.length()) {
-                        // Characters may be chopped
-                        token_stream.emplace_back(nullptr, std::string(buff.begin(), buff.begin() + buff_pos));
-                    }
-                    
-                    buff.resize(0);
-
-                    break;
-                }
-                
-            }
-            auto has_closetag = has_opentag && token.is_symmetrical;
-            if (!token.is_symmetrical && token.has_closetag) {
-                if (token.close_tag.empty()) throw CtImportException("Token has no close tag");
-                has_closetag = buff.find(token.close_tag) != std::string::npos;
-            }
-
-            if (has_closetag && tag_open) {
-                auto tag = token.is_symmetrical ? token.open_tag : token.close_tag;
-                token_stream.emplace_back(curr_token, std::string(stream.begin() + pos - buff.length(), stream.begin() + pos - tag.length()));
-                open_tags[token.open_tag] = false;
-                
-                keep_parsing = true;
-                
-                buff.resize(0);
-                break;
-            }
-            
-        }
-        
-    }
-    if (!buff.empty()) {
-        // No token
-        token_stream.emplace_back(nullptr, buff);
-    }
-    
-    return token_stream;
-}
 
 void CtZimImportHandler::add_directory(const fs::path& path) 
 {
@@ -180,12 +96,7 @@ void CtZimImportHandler::add_directory(const fs::path& path)
 void CtZimImportHandler::feed(std::istream& data) 
 {
     
-   
-    _docs.emplace_back(std::make_shared<xmlpp::Document>());
-    _current_import_file()->doc = _xml_doc();
-    _current_element = _xml_doc()->create_root_node("root")->add_child("slot");
-    _current_element = _current_element->add_child("rich_text");
-    
+   _init_new_doc();
     
     std::string line;
     while(std::getline(data, line, '\n')) {

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -265,6 +265,7 @@ protected:
     void _add_text(std::string text, bool close_tag = true);
     void _close_current_tag();
     void _add_newline();
+    void _add_tag_data(std::string_view, std::string data);
     
     [[nodiscard]] constexpr bool _tag_empty() const
     {

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -205,61 +205,50 @@ private:
     
 };
 
-/**
- * @brief Base class/interface for import handlers
- * @class CtImportHandler
- */
-class CtImportHandler
+class CtParser
 {
-public:
-    using token_map_t = std::unordered_map<std::string_view, std::function<void(const std::string&)>>;
-    
-    
+protected:
     struct token_schema {
         
         std::string open_tag;
         
         bool has_closetag   = true;
         bool is_symmetrical = true;
-    
+        
         std::function<void(const std::string&)> action;
         
         std::string close_tag = "";
         
         /// Whether to capture all the tokens inside it without formatting
         bool capture_all = false;
-
-
+        
+        
         std::string data = "";
         
-        bool operator==(const token_schema& other) const 
+        bool operator==(const token_schema& other) const
         {
             if (is_symmetrical || !has_closetag) return open_tag == other.open_tag;
             else                                 return (open_tag == other.open_tag) && (close_tag == other.close_tag);
         }
     };
-protected:
     
-    enum class PARSING_STATE 
+    enum class PARSING_STATE
     {
         HEAD,
         BODY
     } _parse_state = PARSING_STATE::HEAD;
     
-    enum class CHECKBOX_STATE 
+    enum class CHECKBOX_STATE
     {
         UNCHECKED = 0,
         TICKED = 1,
         MARKED = 2
     };
-
-protected:
+    
     // XML generation
-    std::vector<std::shared_ptr<xmlpp::Document>> _docs;
     xmlpp::Element* _current_element = nullptr;
-    std::vector<std::shared_ptr<CtImportFile>> _import_files;
-    bool                      _processed_files = false;
-   
+    xmlpp::Document _document;
+    
     void _add_scale_tag(int level, std::optional<std::string> data);
     void _add_weight_tag(const Glib::ustring& level, std::optional<std::string> data);
     void _add_italic_tag(std::optional<std::string> data);
@@ -269,13 +258,56 @@ protected:
     void _add_todo_list(CHECKBOX_STATE state, const std::string& data);
     /// Add a link, text should contain the full qualified name (e.g https://example.com)
     void _add_link(const std::string& text);
-    void _add_internal_link(const std::string& text);
     void _add_superscript_tag(std::optional<std::string> text);
     void _add_subscript_tag(std::optional<std::string> text);
-    void _add_text(std::string text);
+    void _add_text(std::string text, bool close_tag = true);
     void _close_current_tag();
     void _add_newline();
     
+    [[nodiscard]] constexpr bool _tag_empty() const
+    {
+        if (!_current_element) return true;
+        else                   return !_current_element->get_child_text();
+    }
+    
+    virtual std::vector<std::pair<const token_schema *, std::string>> _tokenize(const std::string& stream) = 0;
+    
+    virtual const std::vector<token_schema>& _get_tokens() = 0;
+    
+    const CtConfig* _pCtConfig = nullptr;
+public:
+    explicit CtParser(const CtConfig* pCtConfig) : _pCtConfig(pCtConfig) {}
+    
+    virtual void feed(std::istream& data) = 0;
+    
+    std::string to_string() { return _document.write_to_string(); }
+};
+
+/**
+ * @brief Base class/interface for import handlers
+ * @class CtImportHandler
+ */
+class CtImportHandler: public virtual CtParser
+{
+public:
+    using token_map_t = std::unordered_map<std::string_view, std::function<void(const std::string&)>>;
+    
+
+protected:
+    // XML generation
+    std::vector<std::shared_ptr<xmlpp::Document>> _docs;
+    std::vector<std::shared_ptr<CtImportFile>> _import_files;
+    bool                      _processed_files = false;
+    
+    
+    void _add_internal_link(const std::string& text);
+    /**
+     * @brief Create and setup a new document to be fed into
+     * 
+     */
+    void _init_new_doc();
+
+
     [[nodiscard]] const std::shared_ptr<xmlpp::Document>& _xml_doc() const { return _docs.back(); }
     
     [[nodiscard]] std::shared_ptr<CtImportFile>& _current_import_file() { return _import_files.at(_docs.size() - 1); }
@@ -285,35 +317,38 @@ protected:
     static void _add_internal_link_to_file(CtImportFile& file, std::string link_name, xmlpp::Element* element) { file._internal_links[link_name].emplace_back(element); }
     void _add_internal_link_to_curr_file(std::string link_name, xmlpp::Element* element) { _add_internal_link_to_file(*_current_import_file(), std::move(link_name), element); }
     
-    [[nodiscard]] constexpr bool _tag_empty() const 
-    {
-        if (!_current_element) return true;
-        else                   return !_current_element->get_child_text();
-    }
     
-    virtual std::vector<std::pair<const CtImportHandler::token_schema *, std::string>> _tokenize(const std::string& stream) = 0;
     /**
      * @brief Get a list of file extensions supported by the import handler
      * @return
      */
     [[nodiscard]] virtual const std::unordered_set<std::string>& _get_accepted_file_extensions() const = 0;
-    virtual const std::vector<token_schema>& _get_tokens() = 0;
-    
+
 public:
-    explicit CtImportHandler(const CtConfig* pCtConfig) : _pCtConfig(pCtConfig) {}
-    virtual void feed(std::istream& data) = 0;
+    using CtParser::CtParser;
     
     std::vector<std::shared_ptr<CtImportFile>>& imported_files() { return _import_files; }
 
     virtual void add_directory(const std::filesystem::path& path) = 0;
-protected:
-    const CtConfig* _pCtConfig = nullptr;
 };
 
+class CtTextParser: public virtual CtParser
+{
+protected:
+    /**
+     * @brief Transform an input string into a token stream
+     * @param stream
+     * @return
+     */
+    std::vector<std::pair<const token_schema *, std::string>> _tokenize(const std::string& stream) override;
+    uint8_t _list_level = 0;
+    
+public:
+    using CtParser::CtParser;
+    
+};
 
-
-
-class CtZimImportHandler: public CtImportHandler 
+class CtZimImportHandler: public CtImportHandler, public CtTextParser
 {
 private:
     bool _has_notebook_file();
@@ -329,24 +364,36 @@ protected:
     */
     void _process_files(const std::filesystem::path& path);
     
-    /**
-     * @brief Transform an input string into a token stream
-     * @param stream
-     * @return
-     */
-    std::vector<std::pair<const CtImportHandler::token_schema *, std::string>> _tokenize(const std::string& stream) override;
-    
     
     std::vector<std::shared_ptr<CtImportFile>> _get_files(const std::filesystem::path& path, uint32_t current_depth, CtImportFile* parent);
 public:
     using CtImportHandler::CtImportHandler;
-    
+
     void feed(std::istream& data) override;
     
     void add_directory(const std::filesystem::path& path) override;
 
+};
+
+
+class CtMDParser: public CtTextParser {
 protected:
-    uint8_t _list_level = 0;
+
+    const std::vector<token_schema>& _get_tokens() override;
+    
+public:
+    using CtTextParser::CtTextParser;
+
+    void feed(std::istream& stream) override;
+
+};
+
+class CtMDImportHandler: public CtMDParser, public CtImportHandler {
+protected:
+    [[nodiscard]] const std::unordered_set<std::string>& _get_accepted_file_extensions() const override;
+public:
+    virtual void add_directory(const std::filesystem::path &path) override;
+    
 };
 
 

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -248,6 +248,8 @@ protected:
     // XML generation
     xmlpp::Element* _current_element = nullptr;
     xmlpp::Document _document;
+    std::unordered_map<std::string_view, bool> _open_tags;
+    
     
     void _add_scale_tag(int level, std::optional<std::string> data);
     void _add_weight_tag(const Glib::ustring& level, std::optional<std::string> data);
@@ -273,6 +275,7 @@ protected:
     virtual std::vector<std::pair<const token_schema *, std::string>> _tokenize(const std::string& stream) = 0;
     
     virtual const std::vector<token_schema>& _get_tokens() = 0;
+    
     
     const CtConfig* _pCtConfig = nullptr;
 public:

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -401,6 +401,7 @@ protected:
 
     const std::vector<token_schema>& _get_tokens() override;
     
+    bool _in_link = false;
 public:
     using CtTextParser::CtTextParser;
 

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -205,6 +205,10 @@ private:
     
 };
 
+/**
+ * @brief Base class for parsers
+ * @class CtParser
+ */
 class CtParser
 {
 protected:
@@ -336,6 +340,10 @@ public:
     virtual void add_directory(const std::filesystem::path& path) = 0;
 };
 
+/**
+ * @brief Base class for parsing text data
+ * @class CtTextParser
+ */
 class CtTextParser: public virtual CtParser
 {
 protected:
@@ -352,6 +360,10 @@ public:
     
 };
 
+/**
+ * @brief Import handler for Zim Wiki directories
+ * @class CtZimImportHandler
+ */
 class CtZimImportHandler: public CtImportHandler, public CtTextParser
 {
 private:
@@ -379,8 +391,12 @@ public:
 
 };
 
-
-class CtMDParser: public CtTextParser {
+/**
+ * @brief Markdown parser
+ * @class CtMDParser
+ */
+class CtMDParser: public CtTextParser
+{
 protected:
 
     const std::vector<token_schema>& _get_tokens() override;
@@ -392,12 +408,5 @@ public:
 
 };
 
-class CtMDImportHandler: public CtMDParser, public CtImportHandler {
-protected:
-    [[nodiscard]] const std::unordered_set<std::string>& _get_accepted_file_extensions() const override;
-public:
-    virtual void add_directory(const std::filesystem::path &path) override;
-    
-};
 
 

--- a/future/src/ct/ct_md_handler.cc
+++ b/future/src/ct/ct_md_handler.cc
@@ -21,7 +21,7 @@
 
 #include "ct_imports.h"
 #include "ct_const.h"
-
+#include "ct_misc_utils.h"
 
 
 const std::vector<CtImportHandler::token_schema>& CtMDParser::_get_tokens() {
@@ -41,7 +41,37 @@ const std::vector<CtImportHandler::token_schema>& CtMDParser::_get_tokens() {
         // Second half of a link
         {"(", true, false, [this](const std::string& data){
             _add_link(data);
-        }, ")"}
+        }, ")"},
+        // List
+        {"* ", false, false, [this](const std::string& data){
+            _add_list(0, data);
+        }},
+        // Strikethrough
+        {"~~", true, true, [this](const std::string& data){
+            _add_strikethrough_tag(data);
+        }},
+        // Headers (h1, h2, etc)
+        {"#", false, false, [this](const std::string& data){
+            auto tag_num = 1;
+            auto iter = data.begin();
+            while(*iter == '#') {
+                ++tag_num;
+                ++iter;
+            }
+            
+            
+            if (tag_num > 3) tag_num = 3; // Reset to 3 if too large
+    
+            auto str = str::replace(data, "# ", "");
+            str = str::replace(str, "#", "");
+        
+            // Remove the extra space if single front
+            if (tag_num == 1 && str.front() == ' ') {
+                str.replace(str.begin(), str.begin() + 1, "");
+            }
+            
+            _add_scale_tag(tag_num, str);
+        }, "#", true}
 
     };
 

--- a/future/src/ct/ct_md_handler.cc
+++ b/future/src/ct/ct_md_handler.cc
@@ -21,7 +21,6 @@
 
 #include "ct_imports.h"
 #include "ct_const.h"
-#include <iostream>
 
 
 
@@ -34,7 +33,15 @@ const std::vector<CtImportHandler::token_schema>& CtMDParser::_get_tokens() {
         // Bold
         {"**", true, true, [this](const std::string& data){
             _add_weight_tag(CtConst::TAG_PROP_VAL_HEAVY, data);
-        }}
+        }},
+        // First part of a link
+        {"[", true, false, [this](const std::string& data) mutable {
+            _add_text(data, false);
+        }, "]"},
+        // Second half of a link
+        {"(", true, false, [this](const std::string& data){
+            _add_link(data);
+        }, ")"}
 
     };
 
@@ -56,11 +63,10 @@ void CtMDParser::feed(std::istream& stream) {
             if (token.first) {
                 token.first->action(token.second);
             } else {
-                _add_text(token.second);
+                if (!token.second.empty()) _add_text(token.second);
             }
         }
-
-
+        _add_newline();
     }
 
 }

--- a/future/src/ct/ct_md_handler.cc
+++ b/future/src/ct/ct_md_handler.cc
@@ -1,0 +1,77 @@
+/*
+ * ct_md_handler.cc
+ *
+ * Copyright 2017-2020 Giuseppe Penone <giuspen@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "ct_imports.h"
+#include "ct_const.h"
+#include <iostream>
+
+
+
+const std::vector<CtImportHandler::token_schema>& CtMDParser::_get_tokens() {
+    static const std::vector<token_schema> tokens = {
+        // Italic
+        {"__", true, true, [this](const std::string& data){
+            _add_italic_tag(data);
+        }},
+        // Bold
+        {"**", true, true, [this](const std::string& data){
+            _add_weight_tag(CtConst::TAG_PROP_VAL_HEAVY, data);
+        }}
+
+    };
+
+    return tokens;
+}
+
+
+
+void CtMDParser::feed(std::istream& stream) {
+    if (!_current_element) _current_element = _document.create_root_node("root")->add_child("slot")->add_child("rich_text");
+    
+    
+    std::string line;
+    while(std::getline(stream, line, '\n')) {
+        // Feed the line
+        auto tokens = _tokenize(line);
+
+        for (const auto& token : tokens) {
+            if (token.first) {
+                token.first->action(token.second);
+            } else {
+                _add_text(token.second);
+            }
+        }
+
+
+    }
+
+}
+
+const std::unordered_set<std::string>& CtMDImportHandler::_get_accepted_file_extensions() const {
+    static std::unordered_set<std::string> extens = {
+            ".md"
+    };
+    return extens;
+}
+
+void CtMDImportHandler::add_directory(const std::filesystem::path &path) {
+
+}

--- a/future/src/ct/ct_md_parser.cc
+++ b/future/src/ct/ct_md_parser.cc
@@ -36,12 +36,20 @@ const std::vector<CtImportHandler::token_schema>& CtMDParser::_get_tokens()
             _add_weight_tag(CtConst::TAG_PROP_VAL_HEAVY, data);
         }},
         // First part of a link
-        {"[", true, false, [this](const std::string& data) mutable {
+        {"[", true, false, [this](const std::string& data) {
             _add_text(data, false);
+            _in_link = true;
         }, "]"},
         // Second half of a link
-        {"(", true, false, [this](const std::string& data){
-            _add_link(data);
+        {"(", true, false, [this](const std::string& data) {
+            if (_in_link) {
+                _add_link(data);
+                _in_link = false;
+            }
+            else {
+                // Just text in brackets
+                _add_text("(" + data + ")");
+            }
         }, ")"},
         // List
         {"* ", false, false, [this](const std::string& data){

--- a/future/src/ct/ct_md_parser.cc
+++ b/future/src/ct/ct_md_parser.cc
@@ -24,7 +24,8 @@
 #include "ct_misc_utils.h"
 
 
-const std::vector<CtImportHandler::token_schema>& CtMDParser::_get_tokens() {
+const std::vector<CtImportHandler::token_schema>& CtMDParser::_get_tokens()
+{
     static const std::vector<token_schema> tokens = {
         // Italic
         {"__", true, true, [this](const std::string& data){
@@ -80,7 +81,8 @@ const std::vector<CtImportHandler::token_schema>& CtMDParser::_get_tokens() {
 
 
 
-void CtMDParser::feed(std::istream& stream) {
+void CtMDParser::feed(std::istream& stream)
+{
     if (!_current_element) _current_element = _document.create_root_node("root")->add_child("slot")->add_child("rich_text");
     
     
@@ -101,13 +103,4 @@ void CtMDParser::feed(std::istream& stream) {
 
 }
 
-const std::unordered_set<std::string>& CtMDImportHandler::_get_accepted_file_extensions() const {
-    static std::unordered_set<std::string> extens = {
-            ".md"
-    };
-    return extens;
-}
 
-void CtMDImportHandler::add_directory(const std::filesystem::path &path) {
-
-}

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -222,6 +222,7 @@ void CtMenu::init_actions(CtActions* pActions)
     _actions.push_back(CtMenuAction{import_cat, "import_txt_folder", "from_txt", _("From _Folder of Plain Text Files"), None, _("Add Nodes from a Folder of Plain Text Files to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_plaintext_directory) /* dad.nodes_add_from_plain_text_folder */});
     _actions.push_back(CtMenuAction{import_cat, "import_html_file", "from_html", _("From _HTML File"), None, _("Add Node from an HTML File to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_node_from_html_file) /* dad.nodes_add_from_html_file */});
     _actions.push_back(CtMenuAction{import_cat, "import_html_folder", "from_html", _("From _Folder of HTML Files"), None, _("Add Nodes from a Folder of HTML Files to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_node_from_html_directory) /* dad.nodes_add_from_html_folder */});
+    _actions.push_back(CtMenuAction{import_cat, "import_md_file",  CtConst::STR_STOCK_CT_IMP, _("From _Markdown file"), None, _("Add a node from a Markdown file to the current tree"), sigc::mem_fun(*pActions, &CtActions::import_node_from_md_file) /* dad.nodes_add_from_html_folder */});
     _actions.push_back(CtMenuAction{import_cat, "import_basket", CtConst::STR_STOCK_CT_IMP, _("From _Basket Folder"), None, _("Add Nodes of a Basket Folder to the Current Tree"), sigc::signal<void>() /* dad.nodes_add_from_basket_folder */});
     _actions.push_back(CtMenuAction{import_cat, "import_epim_html", CtConst::STR_STOCK_CT_IMP, _("From _EssentialPIM HTML File"), None, _("Add Node from an EssentialPIM HTML File to the Current Tree"), sigc::signal<void>() /* dad.nodes_add_from_epim_html_file */});
     _actions.push_back(CtMenuAction{import_cat, "import_gnote", CtConst::STR_STOCK_CT_IMP, _("From _Gnote Folder"), None, _("Add Nodes of a Gnote Folder to the Current Tree"), sigc::signal<void>() /* dad.nodes_add_from_gnote_folder */});
@@ -866,6 +867,7 @@ const char* CtMenu::_get_ui_str_menu()
       <menuitem action='import_txt_folder'/>
       <menuitem action='import_html_file'/>
       <menuitem action='import_html_folder'/>
+      <menuitem action='import_md_file'/>
       <menuitem action='import_basket'/>
       <menuitem action='import_epim_html'/>
       <menuitem action='import_gnote'/>
@@ -939,6 +941,7 @@ const char* CtMenu::_get_ui_str_menu()
     <menuitem action='import_txt_folder'/>
     <menuitem action='import_html_file'/>
     <menuitem action='import_html_folder'/>
+    <menuitem action='import_md_file'/>
     <menuitem action='import_basket'/>
     <menuitem action='import_epim_html'/>
     <menuitem action='import_gnote'/>

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -222,7 +222,8 @@ void CtMenu::init_actions(CtActions* pActions)
     _actions.push_back(CtMenuAction{import_cat, "import_txt_folder", "from_txt", _("From _Folder of Plain Text Files"), None, _("Add Nodes from a Folder of Plain Text Files to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_plaintext_directory) /* dad.nodes_add_from_plain_text_folder */});
     _actions.push_back(CtMenuAction{import_cat, "import_html_file", "from_html", _("From _HTML File"), None, _("Add Node from an HTML File to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_node_from_html_file) /* dad.nodes_add_from_html_file */});
     _actions.push_back(CtMenuAction{import_cat, "import_html_folder", "from_html", _("From _Folder of HTML Files"), None, _("Add Nodes from a Folder of HTML Files to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_node_from_html_directory) /* dad.nodes_add_from_html_folder */});
-    _actions.push_back(CtMenuAction{import_cat, "import_md_file",  CtConst::STR_STOCK_CT_IMP, _("From _Markdown file"), None, _("Add a node from a Markdown file to the current tree"), sigc::mem_fun(*pActions, &CtActions::import_node_from_md_file) /* dad.nodes_add_from_html_folder */});
+    _actions.push_back(CtMenuAction{import_cat, "import_md_file",  CtConst::STR_STOCK_CT_IMP, _("From _Markdown File"), None, _("Add a node from a Markdown File to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_node_from_md_file)});
+    _actions.push_back(CtMenuAction{import_cat, "import_md_folder",  CtConst::STR_STOCK_CT_IMP, _("From _Folder Markdown of Files"), None, _("Add Nodes from a Folder of Markdown Files to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_md_directory)});
     _actions.push_back(CtMenuAction{import_cat, "import_basket", CtConst::STR_STOCK_CT_IMP, _("From _Basket Folder"), None, _("Add Nodes of a Basket Folder to the Current Tree"), sigc::signal<void>() /* dad.nodes_add_from_basket_folder */});
     _actions.push_back(CtMenuAction{import_cat, "import_epim_html", CtConst::STR_STOCK_CT_IMP, _("From _EssentialPIM HTML File"), None, _("Add Node from an EssentialPIM HTML File to the Current Tree"), sigc::signal<void>() /* dad.nodes_add_from_epim_html_file */});
     _actions.push_back(CtMenuAction{import_cat, "import_gnote", CtConst::STR_STOCK_CT_IMP, _("From _Gnote Folder"), None, _("Add Nodes of a Gnote Folder to the Current Tree"), sigc::signal<void>() /* dad.nodes_add_from_gnote_folder */});
@@ -868,6 +869,7 @@ const char* CtMenu::_get_ui_str_menu()
       <menuitem action='import_html_file'/>
       <menuitem action='import_html_folder'/>
       <menuitem action='import_md_file'/>
+      <menuitem action='import_md_folder'/>
       <menuitem action='import_basket'/>
       <menuitem action='import_epim_html'/>
       <menuitem action='import_gnote'/>
@@ -942,6 +944,7 @@ const char* CtMenu::_get_ui_str_menu()
     <menuitem action='import_html_file'/>
     <menuitem action='import_html_folder'/>
     <menuitem action='import_md_file'/>
+    <menuitem action='import_md_folder'/>
     <menuitem action='import_basket'/>
     <menuitem action='import_epim_html'/>
     <menuitem action='import_gnote'/>

--- a/future/src/ct/ct_parser.cc
+++ b/future/src/ct/ct_parser.cc
@@ -1,0 +1,127 @@
+/*
+ * ct_parser.cc
+ *
+ * Copyright 2017-2020 Giuseppe Penone <giuspen@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "ct_imports.h"
+#include "ct_const.h"
+#include "ct_config.h"
+#include <src/fmt/format.h>
+
+
+void CtParser::_add_superscript_tag(std::optional<std::string> text)
+{
+    _current_element->set_attribute(CtConst::TAG_SCALE, CtConst::TAG_PROP_VAL_SUP);
+    
+    if (text) _add_text(*text);
+}
+
+void CtParser::_add_subscript_tag(std::optional<std::string> text)
+{
+    _current_element->set_attribute(CtConst::TAG_SCALE, CtConst::TAG_PROP_VAL_SUB);
+    
+    if (text) _add_text(*text);
+}
+
+void CtParser::_add_ordered_list(unsigned int level, const std::string &data)
+{
+    _add_text(fmt::format("{}. {}", level, data));
+}
+
+
+void CtParser::_add_todo_list(CHECKBOX_STATE state, const std::string& text)
+{
+    auto todo_index = static_cast<int>(state);
+    _add_text(_pCtConfig->charsTodo[todo_index] + CtConst::CHAR_SPACE + text);
+}
+
+void CtParser::_add_list(uint8_t level, const std::string& data)
+{
+    if (level >= _pCtConfig->charsListbul.size()) {
+    if (_pCtConfig->charsListbul.size() == 0) {
+        throw std::runtime_error("No bullet-list characters set");
+    }
+        level = _pCtConfig->charsListbul.size() - 1;
+    }
+    std::string indent;
+    auto i_lvl = 0;
+    while(i_lvl < level) {
+    ++i_lvl;
+    indent += CtConst::CHAR_TAB;
+}
+
+_add_text(indent + _pCtConfig->charsListbul[level] + CtConst::CHAR_SPACE + data);
+}
+void CtParser::_add_weight_tag(const Glib::ustring& level, std::optional<std::string> data)
+{
+    _current_element->set_attribute("weight", level);
+    if (data) {
+    _add_text(*data, false);
+}
+}
+
+void CtParser::_add_link(const std::string& text)
+{
+    auto val = CtImports::get_internal_link_from_http_url(text);
+    _current_element->set_attribute(CtConst::TAG_LINK, val);
+    _add_text(text, false);
+}
+
+void CtParser::_add_strikethrough_tag(std::optional<std::string> data)
+{
+    _current_element->set_attribute(CtConst::TAG_STRIKETHROUGH, CtConst::TAG_PROP_VAL_TRUE);
+    if (data) _add_text(*data, false);
+}
+
+void CtParser::_add_text(std::string text, bool close_tag /* = true */)
+{
+    if (close_tag) _close_current_tag();
+    
+    auto curr_text = _current_element->get_child_text();
+    if (!curr_text) _current_element->set_child_text(std::move(text));
+    else            curr_text->set_content(curr_text->get_content() + std::move(text));
+    
+    if (close_tag) _close_current_tag();
+}
+
+void CtParser::_close_current_tag()
+{
+    if (!_tag_empty()) _current_element = _current_element->get_parent()->add_child("rich_text");
+}
+
+void CtParser::_add_newline() {
+    _add_text(CtConst::CHAR_NEWLINE);
+}
+
+void CtParser::_add_italic_tag(std::optional<std::string> data)
+{
+    _current_element->set_attribute(CtConst::TAG_STYLE, CtConst::TAG_PROP_VAL_ITALIC);
+    if (data) {
+        _add_text(*data, false);
+    }
+}
+
+void CtParser::_add_scale_tag(int level, std::optional<std::string> data)
+{
+    _current_element->set_attribute("scale", fmt::format("h{}", level));
+    if (data) {
+        _add_text(*data, false);
+    }
+}
+

--- a/future/src/ct/ct_parser.cc
+++ b/future/src/ct/ct_parser.cc
@@ -72,8 +72,8 @@ void CtParser::_add_weight_tag(const Glib::ustring& level, std::optional<std::st
 {
     _current_element->set_attribute("weight", level);
     if (data) {
-    _add_text(*data, false);
-}
+        _add_text(*data, false);
+    }
 }
 
 void CtParser::_add_link(const std::string& text)

--- a/future/src/ct/ct_parser.cc
+++ b/future/src/ct/ct_parser.cc
@@ -86,7 +86,7 @@ void CtParser::_add_link(const std::string& text)
 void CtParser::_add_strikethrough_tag(std::optional<std::string> data)
 {
     _current_element->set_attribute(CtConst::TAG_STRIKETHROUGH, CtConst::TAG_PROP_VAL_TRUE);
-    if (data) _add_text(*data, false);
+    if (data) _add_tag_data(CtConst::TAG_STRIKETHROUGH, *data);
 }
 
 void CtParser::_add_text(std::string text, bool close_tag /* = true */)

--- a/future/src/ct/ct_text_parser.cc
+++ b/future/src/ct/ct_text_parser.cc
@@ -1,0 +1,107 @@
+/*
+ * ct_text_parser.cc
+ *
+ * Copyright 2017-2020 Giuseppe Penone <giuspen@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "ct_imports.h"
+
+std::vector<std::pair<const CtImportHandler::token_schema *, std::string>> CtTextParser::_tokenize(const std::string& stream)
+{
+    
+    auto& tokens = _get_tokens();
+    std::vector<std::pair<const CtImportHandler::token_schema *, std::string>> token_stream;
+    std::unordered_map<std::string_view, bool> open_tags;
+    std::string buff;
+    std::size_t pos = 0;
+    bool keep_parsing = true;
+    const token_schema* curr_token;
+    for (const auto& ch : stream) {
+        buff += ch;
+        pos++;
+        for (const auto &token : tokens) {
+            auto tag_open = open_tags[token.open_tag];
+            
+            
+            auto buff_pos = buff.find(token.open_tag);
+            auto has_opentag = buff_pos != std::string::npos;
+            
+            
+            
+            if (keep_parsing) {
+                if (has_opentag && !tag_open) {
+                    
+                    // First token
+                    curr_token = &token;
+
+                    keep_parsing = !curr_token->capture_all;
+
+                    if (!token.has_closetag) {
+                        // Token will go till end of stream
+                        token_stream.emplace_back(curr_token, std::string(stream.begin() + pos, stream.end()));
+                        
+                        if (keep_parsing) {
+                            // Parse the other data in the stream 
+                            auto tokonised_stream = _tokenize(token_stream.back().second);
+                            for (const auto& token : tokonised_stream) {
+                                if (token.first) {
+                                    token_stream.emplace_back(token);
+                                }
+                             } 
+                        }
+                        return token_stream;
+                    }
+                    open_tags[token.open_tag] = true;
+                    if (pos - buff_pos != pos - buff.length()) {
+                        // Characters may be chopped
+                        token_stream.emplace_back(nullptr, std::string(buff.begin(), buff.begin() + buff_pos));
+                    }
+                    
+                    buff.resize(0);
+
+                    break;
+                }
+                
+            }
+            auto has_closetag = has_opentag && token.is_symmetrical;
+            if (!token.is_symmetrical && token.has_closetag) {
+                if (token.close_tag.empty()) throw CtImportException("Token has no close tag");
+                has_closetag = buff.find(token.close_tag) != std::string::npos;
+            }
+
+            if (has_closetag && tag_open) {
+                auto tag = token.is_symmetrical ? token.open_tag : token.close_tag;
+                token_stream.emplace_back(curr_token, std::string(stream.begin() + pos - buff.length(), stream.begin() + pos - tag.length()));
+                open_tags[token.open_tag] = false;
+                
+                keep_parsing = true;
+                
+                buff.resize(0);
+                break;
+            }
+            
+        }
+        
+    }
+    if (!buff.empty()) {
+        // No token
+        token_stream.emplace_back(nullptr, buff);
+    }
+    
+    return token_stream;
+}

--- a/future/src/ct/ct_text_parser.cc
+++ b/future/src/ct/ct_text_parser.cc
@@ -73,7 +73,7 @@ std::vector<std::pair<const CtParser::token_schema *, std::string>> CtTextParser
                         token_stream.emplace_back(nullptr, std::string(buff.begin(), buff.begin() + buff_pos));
                     }
                     
-                    buff.resize(0);
+                    buff.clear();
 
                     break;
                 }
@@ -97,12 +97,10 @@ std::vector<std::pair<const CtParser::token_schema *, std::string>> CtTextParser
                     }
                 }
                 open_tags[token.open_tag] = false;
-                
-                
                 keep_parsing = true;
                 
-                curr_open_tags.resize(0);
-                buff.resize(0);
+                curr_open_tags.clear();
+                buff.clear();
                 break;
             }
             

--- a/future/tests/data/md_testfile.md
+++ b/future/tests/data/md_testfile.md
@@ -19,3 +19,5 @@ __Italic__ and then **bold** and then **__bold and italic__**
 
 And I am a [link to google](https://google.com)
 
+(I a some text in brackets)
+

--- a/future/tests/data/md_testfile.md
+++ b/future/tests/data/md_testfile.md
@@ -1,0 +1,21 @@
+# H1
+## H2
+### H3
+#### H4
+
+* List item 1
+* List item 2
+* List item 3
+
+
+~~StrikedOuted~~
+
+__Italic__
+
+**Bold** **__Italic AND Bold__**
+
+__Italic__ and then **bold** and then **__bold and italic__**
+
+
+And I am a [link to google](https://google.com)
+


### PR DESCRIPTION
This adds a basic markdown parser and an option to import from a markdown file/directory

The parser can currently handle:
- Lists (but only on one level)
- Headers (h1, h2, etc)
- Links 
- Italic text
- Bold text
- Strikethrough 

It can also apply multiple styles at once.

This does not include either pasting markdown or real-time formatting.