### PR TITLE
Implement markdown formatting of entered text

### DIFF
--- a/future/src/ct/ct_config.cc
+++ b/future/src/ct/ct_config.cc
@@ -223,6 +223,7 @@ void CtConfig::_populate_keyfile_from_data()
     _uKeyFile->set_boolean(_currentGroup, "auto_smart_quotes", autoSmartQuotes);
     _uKeyFile->set_boolean(_currentGroup, "triple_click_paragraph", tripleClickParagraph);
     _uKeyFile->set_boolean(_currentGroup, "enable_symbol_autoreplace", enableSymbolAutoreplace);
+    _uKeyFile->set_boolean(_currentGroup, "enable_md_formatting", enableMdFormatting);
     _uKeyFile->set_integer(_currentGroup, "wrapping_indent", wrappingIndent);
     _uKeyFile->set_boolean(_currentGroup, "auto_indent", autoIndent);
     _uKeyFile->set_boolean(_currentGroup, "rt_show_white_spaces", rtShowWhiteSpaces);
@@ -469,6 +470,7 @@ void CtConfig::_populate_data_from_keyfile()
     _populate_bool_from_keyfile("auto_smart_quotes", &autoSmartQuotes);
     _populate_bool_from_keyfile("triple_click_paragraph", &tripleClickParagraph);
     _populate_bool_from_keyfile("enable_symbol_autoreplace", &enableSymbolAutoreplace);
+    _populate_bool_from_keyfile("enable_md_formatting", &enableMdFormatting);
     _populate_int_from_keyfile("wrapping_indent", &wrappingIndent);
     _populate_bool_from_keyfile("auto_indent", &autoIndent);
     _populate_bool_from_keyfile("rt_show_white_spaces", &rtShowWhiteSpaces);

--- a/future/src/ct/ct_config.h
+++ b/future/src/ct/ct_config.h
@@ -88,6 +88,7 @@ public:
     bool                                        autoSmartQuotes{true};
     bool                                        tripleClickParagraph{true};
     bool                                        enableSymbolAutoreplace{true};
+    bool                                        enableMdFormatting{false};
     int                                         wrappingIndent{-14};
     bool                                        autoIndent{true};
     bool                                        rtShowWhiteSpaces{false};

--- a/future/src/ct/ct_import_zim_handler.cc
+++ b/future/src/ct/ct_import_zim_handler.cc
@@ -96,8 +96,9 @@ void CtZimImportHandler::add_directory(const fs::path& path)
 void CtZimImportHandler::feed(std::istream& data) 
 {
     
-   _init_new_doc();
-   _init_tokens();
+    _init_new_doc();
+    _init_tokens();
+    _build_token_maps();
     
     std::string line;
     while(std::getline(data, line, '\n')) {
@@ -127,7 +128,6 @@ const std::unordered_set<std::string>& CtZimImportHandler::_get_accepted_file_ex
 
 void CtZimImportHandler::_parse_body_line(const std::string& line) 
 {
-    
     auto tokens = _tokenize(line);
     
     for (const auto& token : tokens) {

--- a/future/src/ct/ct_import_zim_handler.cc
+++ b/future/src/ct/ct_import_zim_handler.cc
@@ -128,7 +128,8 @@ const std::unordered_set<std::string>& CtZimImportHandler::_get_accepted_file_ex
 
 void CtZimImportHandler::_parse_body_line(const std::string& line) 
 {
-    auto tokens = _tokenize(line);
+    auto tokens_raw = _tokenize(line);
+    auto tokens = _parse_tokens(tokens_raw);
     
     for (const auto& token : tokens) {
         if (token.first) {

--- a/future/src/ct/ct_import_zim_handler.cc
+++ b/future/src/ct/ct_import_zim_handler.cc
@@ -150,29 +150,6 @@ void CtZimImportHandler::_parse_body_line(const std::string& line)
 void CtZimImportHandler::_init_tokens()
 {
     if (_token_schemas.empty()) {
-        auto links_match_func = [this](const std::string& data){
-            auto target_char = *data.begin();
-            if (target_char == '>' || target_char == '*' || target_char == 'x' || target_char == ' ') {
-                // Captured a TODO list
-    
-                CHECKBOX_STATE state;
-                switch(target_char) {
-                    case 'x': state = CHECKBOX_STATE::MARKED; break;
-                    case '*': state = CHECKBOX_STATE::TICKED; break;
-                    case ' ': state = CHECKBOX_STATE::UNCHECKED; break;
-                    case '>': state = CHECKBOX_STATE::MARKED; break; // No version exists for cherrytree
-                }
-    
-                _add_todo_list(state, "");
-            } else {
-                std::string txt(data.begin() + 1, data.end());
-                // Capured a [[LINK]]
-                _close_current_tag();
-                _add_internal_link(txt);
-                _close_current_tag();
-            }
-        };
-    
         _token_schemas = {
             // Bold
             {"**", true, true, [this](const std::string& data){
@@ -246,9 +223,25 @@ void CtZimImportHandler::_init_tokens()
                 // Todo: Implement this (needs image importing)
             },"}}"},
             // Todo list
-            {"[", true, false, links_match_func, "] "},
+           // {"[", true, false, links_match_func, "] "},
+            {"[*", true, false, [this](const std::string& data) {
+                _add_todo_list(CHECKBOX_STATE::TICKED, data);
+            }, "]"},
+            {"[x", true, false, [this](const std::string& data) {
+                _add_todo_list(CHECKBOX_STATE::MARKED, data);
+            }, "]"},
+            {"[>", true, false, [this](const std::string& data) {
+                _add_todo_list(CHECKBOX_STATE::MARKED, data);
+            }, "]"},
+            {"[ ", true, false, [this](const std::string& data) {
+                _add_todo_list(CHECKBOX_STATE::UNCHECKED, data);
+            }, "]"},
             // Internal link (e.g MyPage) - This is just for removing the leftover ']'
-            {"[", true, false, links_match_func, "]]"},
+            {"[[", true, false, [this](const std::string& data){
+                _close_current_tag();
+                _add_internal_link(data);
+                _close_current_tag();
+            }, "]]"},
             // Verbatum - captures all the tokens inside it and print without formatting
             {"''", true, true, [this](const std::string& data){
                 _add_text(data);

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -211,8 +211,7 @@ private:
  */
 class CtParser
 {
-public:
-    using tags_map_t = std::unordered_map<std::string_view, std::vector<const token_schema *>>;
+
 protected:
     struct token_schema {
         
@@ -289,15 +288,19 @@ protected:
     
     
     const CtConfig* _pCtConfig = nullptr;
-    
-    /// Tokens to be cached by the parser
-    std::vector<token_schema> _token_schemas;
-    
+
+
 private:
+    using tags_map_t = std::unordered_map<std::string_view, const token_schema *>;
     tags_map_t _open_tokens_map;
     tags_map_t _close_tokens_map;
     
+protected:
+    /// Tokens to be cached by the parser
+    std::vector<token_schema> _token_schemas;
+    
     void _build_token_maps();
+    
 public:
     explicit CtParser(const CtConfig* pCtConfig) : _pCtConfig(pCtConfig) {}
     
@@ -317,6 +320,8 @@ public:
         _build_token_maps();
         return _close_tokens_map;
     }
+    const tags_map_t& open_tokens_map() const { return _open_tokens_map; }
+    const tags_map_t& close_tokens_map() const { return _close_tokens_map; }
     
 };
 

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -154,10 +154,18 @@ private:
  * @brief Thrown when an exception occures during importing
  */
 class CtImportException: public std::runtime_error {
-    static constexpr std::string_view signature = "[Import Exception]: ";
 public:
     explicit CtImportException(const std::string& msg) : std::runtime_error("[Import Exception]: " + msg) {}
 };
+/**
+ * @class CtParseError
+ * @brief Thrown when an exception occures during parsing
+ */
+class CtParseError: public std::runtime_error {
+public:
+    explicit CtParseError(const std::string& msg) : std::runtime_error("[Parse Exception]: " + msg) {}
+};
+
 class CtConfig;
 class CtImportHandler;
 

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -279,7 +279,7 @@ protected:
         else                   return !_current_element->get_child_text();
     }
     
-    virtual std::vector<std::pair<const token_schema *, std::string>> _tokenize(const std::string& stream) const = 0;
+    virtual std::vector<std::pair<const token_schema *, std::string>> _parse_tokens(const std::vector<std::string>& tokens) const = 0;
     
     /**
      * @brief Initalise _tokens_schemas with the tokens map
@@ -391,11 +391,16 @@ class CtTextParser: public virtual CtParser
 protected:
     /**
      * @brief Transform an input string into a token stream
-     * @param stream
+     * @param tokens
      * @return
      */
-    std::vector<std::pair<const token_schema *, std::string>> _tokenize(const std::string& stream) const override;
+    std::vector<std::pair<const token_schema *, std::string>> _parse_tokens(const std::vector<std::string>& tokens) const override;
     uint8_t _list_level = 0;
+    
+    std::vector<std::string> _tokenize(const std::string& text);
+    
+private:
+    std::unordered_set<char> _possible_tokens;
     
 public:
     using CtParser::CtParser;

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -28,6 +28,7 @@
 #include <glibmm/ustring.h>
 #include <libxml2/libxml/HTMLparser.h>
 #include <libxml++/libxml++.h>
+#include <gtkmm.h>
 #include <filesystem>
 #include <unordered_set>
 #include <fstream>
@@ -322,6 +323,13 @@ public:
     }
     const tags_map_t& open_tokens_map() const { return _open_tokens_map; }
     const tags_map_t& close_tokens_map() const { return _close_tokens_map; }
+    
+    /**
+     * @brief Find the formatting boundries for a word based on stored tags
+     * @param word_end
+     * @return
+     */
+    std::pair<Gtk::TextIter, Gtk::TextIter> find_formatting_boundaries(const Gtk::TextIter& start_bounds, const Gtk::TextIter& word_end);
     
 };
 

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -324,13 +324,6 @@ public:
     const tags_map_t& open_tokens_map() const { return _open_tokens_map; }
     const tags_map_t& close_tokens_map() const { return _close_tokens_map; }
     
-    /**
-     * @brief Find the formatting boundries for a word based on stored tags
-     * @param word_end
-     * @return
-     */
-    std::pair<Gtk::TextIter, Gtk::TextIter> find_formatting_boundaries(const Gtk::TextIter& start_bounds, const Gtk::TextIter& word_end);
-    
 };
 
 /**
@@ -404,6 +397,14 @@ private:
     
 public:
     using CtParser::CtParser;
+    
+    /**
+     * @brief Find the formatting boundries for a word based on stored tags
+     * @param word_end
+     * @return
+     */
+    std::pair<Gtk::TextIter, Gtk::TextIter> find_formatting_boundaries(Gtk::TextIter start_bounds, Gtk::TextIter word_end);
+    
     
 };
 

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -211,6 +211,8 @@ private:
  */
 class CtParser
 {
+public:
+    using tags_map_t = std::unordered_map<std::string_view, std::vector<const token_schema *>>;
 protected:
     struct token_schema {
         
@@ -251,7 +253,7 @@ protected:
     
     // XML generation
     xmlpp::Element* _current_element = nullptr;
-    xmlpp::Document _document;
+    std::unique_ptr<xmlpp::Document> _document{std::make_unique<xmlpp::Document>()};
     std::unordered_map<std::string_view, bool> _open_tags;
     
     
@@ -290,12 +292,32 @@ protected:
     
     /// Tokens to be cached by the parser
     std::vector<token_schema> _token_schemas;
+    
+private:
+    tags_map_t _open_tokens_map;
+    tags_map_t _close_tokens_map;
+    
+    void _build_token_maps();
 public:
     explicit CtParser(const CtConfig* pCtConfig) : _pCtConfig(pCtConfig) {}
     
     virtual void feed(std::istream& data) = 0;
     
-    std::string to_string() { return _document.write_to_string(); }
+    std::string to_string() { return _document->write_to_string(); }
+
+    void wipe();
+    
+    const tags_map_t& open_tokens_map()
+    {
+        _build_token_maps();
+        return _open_tokens_map;
+    };
+    const tags_map_t& close_tokens_map()
+    {
+        _build_token_maps();
+        return _close_tokens_map;
+    }
+    
 };
 
 /**

--- a/future/src/ct/ct_md_parser.cc
+++ b/future/src/ct/ct_md_parser.cc
@@ -123,14 +123,14 @@ void CtMDParser::feed(std::istream& stream)
                         continue;
                     }
                 }
-
+                
 
                 iter->first->action(iter->second);
             } else {
                 if (!iter->second.empty()) _add_text(iter->second);
             }
         }
-        _add_newline();
+        if (!stream.eof()) _add_newline();
     }
 
 }

--- a/future/src/ct/ct_md_parser.cc
+++ b/future/src/ct/ct_md_parser.cc
@@ -100,7 +100,7 @@ void CtMDParser::_init_tokens()
 
 void CtMDParser::feed(std::istream& stream)
 {
-    if (!_current_element) _current_element = _document.create_root_node("root")->add_child("slot")->add_child("rich_text");
+    if (!_current_element) _current_element = _document->create_root_node("root")->add_child("slot")->add_child("rich_text");
     _init_tokens();
     
     std::string line;

--- a/future/src/ct/ct_md_parser.cc
+++ b/future/src/ct/ct_md_parser.cc
@@ -29,25 +29,21 @@ void CtMDParser::_init_tokens()
     if (_token_schemas.empty()) {
         _token_schemas = {
                 // Italic
-                {
-                        "__", true,  true,  [this](const std::string &data) {
+                {"__", true,  true,  [this](const std::string &data) {
                     _add_italic_tag(data);
                 }},
                 // Bold
-                {
-                        "**", true,  true,  [this](const std::string &data) {
+                {"**", true,  true,  [this](const std::string &data) {
                     _add_weight_tag(CtConst::TAG_PROP_VAL_HEAVY, data);
                 }},
                 // First part of a link
-                {
-                        "[",  true,  false, [this](const std::string &data) {
+                {"[",  true,  false, [this](const std::string &data) {
                     _add_text(data, false);
                     _in_link = true;
                 }, "]", true
                 },
                 // Second half of a link
-                {
-                        "(",  true,  false, [this](const std::string &data) {
+                {"(",  true,  false, [this](const std::string &data) {
                     if (_in_link) {
                         _add_link(data);
                         _in_link = false;
@@ -55,21 +51,21 @@ void CtMDParser::_init_tokens()
                         // Just text in brackets
                         _add_text("(" + data + ")");
                     }
-                }, ")", true
-                },
+                }, ")", true},
                 // List
-                {
-                        "* ", false, false, [this](const std::string &data) {
+                {"* ", false, false, [this](const std::string &data) {
+                    _add_list(0, data);
+                }},
+                // Also list
+                {"- ", false, false, [this](const std::string& data){
                     _add_list(0, data);
                 }},
                 // Strikethrough
-                {
-                        "~~", true,  true,  [this](const std::string &data) {
+                {"~~", true,  true,  [this](const std::string &data) {
                     _add_strikethrough_tag(data);
                 }},
                 // Headers (h1, h2, etc)
-                {
-                        "#",  false, false, [this](const std::string &data) {
+                {"#",  false, false, [this](const std::string &data) {
                     auto tag_num = 1;
                     auto iter    = data.begin();
                     while (*iter == '#') {
@@ -87,10 +83,9 @@ void CtMDParser::_init_tokens()
                     if (tag_num == 1 && str.front() == ' ') {
                         str.replace(str.begin(), str.begin() + 1, "");
                     }
-                
+                    _close_current_tag();
                     _add_scale_tag(tag_num, str);
-                }, "#", true
-                }
+                }, "#", true}
         
         };
     }

--- a/future/src/ct/ct_md_parser.cc
+++ b/future/src/ct/ct_md_parser.cc
@@ -102,6 +102,7 @@ void CtMDParser::feed(std::istream& stream)
 {
     if (!_current_element) _current_element = _document->create_root_node("root")->add_child("slot")->add_child("rich_text");
     _init_tokens();
+    _build_token_maps();
     
     std::string line;
     while(std::getline(stream, line, '\n')) {

--- a/future/src/ct/ct_md_parser.cc
+++ b/future/src/ct/ct_md_parser.cc
@@ -107,7 +107,8 @@ void CtMDParser::feed(std::istream& stream)
     std::string line;
     while(std::getline(stream, line, '\n')) {
         // Feed the line
-        auto tokens = _tokenize(line);
+        auto tokens_raw = _tokenize(line);
+        auto tokens = _parse_tokens(tokens_raw);
 
         for (auto iter = tokens.begin(); iter != tokens.end(); ++iter) {
             if (iter->first) {

--- a/future/src/ct/ct_parser.cc
+++ b/future/src/ct/ct_parser.cc
@@ -152,15 +152,15 @@ void CtParser::_build_token_maps() {
         // Build open tokens
         if (_open_tokens_map.empty()) {
             for (const auto& token : _token_schemas) {
-                _open_tokens_map[token.open_tag].emplace_back(&token);
+                _open_tokens_map[token.open_tag] = &token;
             }
         }
         // Build close tokens
         if (_close_tokens_map.empty()) {
             for (const auto& token : _token_schemas) {
                 if (token.has_closetag) {
-                    if (token.is_symmetrical) _close_tokens_map[token.open_tag].emplace_back(&token);
-                    else                      _close_tokens_map[token.close_tag].emplace_back(&token);
+                    if (token.is_symmetrical) _close_tokens_map[token.open_tag] = &token;
+                    else                      _close_tokens_map[token.close_tag] = &token;
                 }
             }
         }

--- a/future/src/ct/ct_parser.cc
+++ b/future/src/ct/ct_parser.cc
@@ -159,8 +159,8 @@ void CtParser::_build_token_maps() {
         if (_close_tokens_map.empty()) {
             for (const auto& token : _token_schemas) {
                 if (token.has_closetag) {
-                    if (token.is_symmetrical) _close_tokens_map[token.open_tag] = &token;
-                    else                      _close_tokens_map[token.close_tag] = &token;
+                    if (token.is_symmetrical || !token.has_closetag) _close_tokens_map[token.open_tag]  = &token;
+                    else                                             _close_tokens_map[token.close_tag] = &token;
                 }
             }
         }

--- a/future/src/ct/ct_parser.cc
+++ b/future/src/ct/ct_parser.cc
@@ -167,48 +167,4 @@ void CtParser::_build_token_maps() {
     }
 }
 
-std::pair<Gtk::TextIter, Gtk::TextIter> CtParser::find_formatting_boundaries(const Gtk::TextIter& start_bounds, const Gtk::TextIter& word_end) {
-    _build_token_maps();
-    
-    auto word_start = word_end;
-    
-    int tokens_open = 0;
-    std::string buff;
-    bool found_open_token = false;
-    while (word_start != start_bounds) {
-        if (word_start.inside_word()) {
-            --word_start;
-            continue;
-        } else if (word_start.ends_word()) {
-            buff.clear();
-            --word_start;
-            continue;
-        }
-        if (word_start.get_char() == ' ' && !found_open_token) {
-            --word_start;
-            continue;
-        }
-        buff += std::string(1, word_start.get_char());
-        
-        
-        
-        if (_close_tokens_map.find(buff) != _close_tokens_map.end()) {
-            ++tokens_open;
-            found_open_token = true;
-        } else {
-            auto open_iter = _open_tokens_map.find(buff);
-            if (open_iter != _open_tokens_map.end()) {
-                --tokens_open;
-            }
-        }
-    
-        if (word_start.get_char() == ' ' && (tokens_open == 0)) {
-            break;
-        }
-        
-        --word_start;
-    }
-    
-    return {word_start, word_end};
-}
 

--- a/future/src/ct/ct_parser.cc
+++ b/future/src/ct/ct_parser.cc
@@ -167,3 +167,48 @@ void CtParser::_build_token_maps() {
     }
 }
 
+std::pair<Gtk::TextIter, Gtk::TextIter> CtParser::find_formatting_boundaries(const Gtk::TextIter& start_bounds, const Gtk::TextIter& word_end) {
+    _build_token_maps();
+    
+    auto word_start = word_end;
+    
+    int tokens_open = 0;
+    std::string buff;
+    bool found_open_token = false;
+    while (word_start != start_bounds) {
+        if (word_start.inside_word()) {
+            --word_start;
+            continue;
+        } else if (word_start.ends_word()) {
+            buff.clear();
+            --word_start;
+            continue;
+        }
+        if (word_start.get_char() == ' ' && !found_open_token) {
+            --word_start;
+            continue;
+        }
+        buff += std::string(1, word_start.get_char());
+        
+        
+        
+        if (_close_tokens_map.find(buff) != _close_tokens_map.end()) {
+            ++tokens_open;
+            found_open_token = true;
+        } else {
+            auto open_iter = _open_tokens_map.find(buff);
+            if (open_iter != _open_tokens_map.end()) {
+                --tokens_open;
+            }
+        }
+    
+        if (word_start.get_char() == ' ' && (tokens_open == 0)) {
+            break;
+        }
+        
+        --word_start;
+    }
+    
+    return {word_start, word_end};
+}
+

--- a/future/src/ct/ct_pref_dlg.cc
+++ b/future/src/ct/ct_pref_dlg.cc
@@ -296,11 +296,14 @@ Gtk::Widget* CtPrefDlg::build_tab_text()
     Gtk::VBox* vbox_editor = Gtk::manage(new Gtk::VBox());
     Gtk::CheckButton* checkbutton_auto_smart_quotes = Gtk::manage(new Gtk::CheckButton(_("Enable Smart Quotes Auto Replacement")));
     Gtk::CheckButton* checkbutton_enable_symbol_autoreplace = Gtk::manage(new Gtk::CheckButton(_("Enable Symbol Auto Replacement")));
+    Gtk::CheckButton* checkbutton_md_formatting = Gtk::manage(new Gtk::CheckButton(_("Enable Markdown formatting (Experimental)")));
     checkbutton_auto_smart_quotes->set_active(pConfig->autoSmartQuotes);
     checkbutton_enable_symbol_autoreplace->set_active(pConfig->enableSymbolAutoreplace);
-
+    checkbutton_md_formatting->set_active(pConfig->enableMdFormatting);
+    
     vbox_editor->pack_start(*checkbutton_auto_smart_quotes, false, false);
     vbox_editor->pack_start(*checkbutton_enable_symbol_autoreplace, false, false);
+    vbox_editor->pack_start(*checkbutton_md_formatting, false, false, 0);
 
     Gtk::Frame* frame_editor = Gtk::manage(new Gtk::Frame(std::string("<b>")+_("Text Editor")+"</b>"));
     ((Gtk::Label*)frame_editor->get_label_widget())->set_use_markup(true);
@@ -322,6 +325,10 @@ Gtk::Widget* CtPrefDlg::build_tab_text()
     checkbutton_enable_symbol_autoreplace->signal_toggled().connect([pConfig, checkbutton_enable_symbol_autoreplace](){
         pConfig->enableSymbolAutoreplace = checkbutton_enable_symbol_autoreplace->get_active();
     });
+    checkbutton_md_formatting->signal_toggled().connect([pConfig, checkbutton_md_formatting]{
+        pConfig->enableMdFormatting = checkbutton_md_formatting->get_active();
+    });
+    
     return pMainBox;
 }
 

--- a/future/src/ct/ct_text_parser.cc
+++ b/future/src/ct/ct_text_parser.cc
@@ -33,6 +33,31 @@ std::vector<std::pair<const CtParser::token_schema *, std::string>> CtTextParser
     const token_schema* curr_token;
     auto& token_map_open = open_tokens_map();
     auto& token_map_close = close_tokens_map();
+    std::vector<std::string> tokens;
+    std::string::const_iterator last_pos = stream.begin();
+    for (auto ch = stream.begin(); ch != stream.end(); ++ch) {
+        //buff += ch;
+        pos++;
+    
+        
+        if (std::isspace(*ch)) {
+            tokens.emplace_back(last_pos, ch);
+            last_pos = ch;
+        } else {
+            auto forward_pos = last_pos;
+            while (forward_pos != ch && std::isalnum(*forward_pos)) {
+                ++forward_pos;
+            }
+            std::string key(last_pos, ch);
+            if (token_map_open.find(key) != token_map_open.end() || token_map_close.find(key) != token_map_close.end()) {
+                tokens.emplace_back(last_pos, ch);
+                last_pos = ch;
+            }
+        }
+    }
+    //buff.clear();
+    pos = 0;
+    
     for (const auto& ch : stream) {
         buff += ch;
         pos++;

--- a/future/src/ct/ct_widgets.cc
+++ b/future/src/ct/ct_widgets.cc
@@ -589,6 +589,7 @@ void CtTextView::for_event_after_key_press(GdkEvent* event, const Glib::ustring&
                     auto word_start = iter_insert;
                     word_start.backward_char();
                     if (!word_start.inside_word()) {
+                        word_start.backward_sentence_start();
                         _markdown_check_and_replace(text_buffer, word_start, iter_insert);
                     }
                 }
@@ -601,7 +602,7 @@ void CtTextView::_markdown_check_and_replace(Glib::RefPtr<Gtk::TextBuffer> text_
 {
     if (!_md_parser) _md_parser = std::make_unique<CtMDParser>(_pCtMainWin->get_ct_config());
     else _md_parser->wipe();
-    auto& open_tags = _md_parser->open_tokens_map();
+    /*auto& open_tags = _md_parser->open_tokens_map();
     
     while (start_iter.backward_word_start()) {
         if (!start_iter.backward_char()) break;
@@ -615,10 +616,15 @@ void CtTextView::_markdown_check_and_replace(Glib::RefPtr<Gtk::TextBuffer> text_
             start_iter = next_wrd;
             break;
         }
-    }
+    }*/
     
+    end_iter.backward_char();
     Glib::ustring text(start_iter, end_iter);
+    auto iter_pair = _md_parser->find_formatting_boundaries(start_iter, end_iter);
     std::cout << "TXT: " << text << std::endl;
+    
+    text = Glib::ustring(iter_pair.first, iter_pair.second);
+    std::cout << "TXT2: " << text << std::endl;
     
     std::stringstream txt(text);
 

--- a/future/src/ct/ct_widgets.cc
+++ b/future/src/ct/ct_widgets.cc
@@ -609,8 +609,9 @@ void CtTextView::_markdown_check_and_replace(Glib::RefPtr<Gtk::TextBuffer> text_
         next_wrd.backward_word_start();
         
         Glib::ustring wrd(next_wrd, start_iter);
-        wrd = str::replace(wrd, " ", "");
-        if (open_tags.find(wrd) != open_tags.end()) {
+        std::string str = wrd;
+        //wrd = str::replace(wrd, " ", "");
+        if (open_tags.find(str) != open_tags.end()) {
             start_iter = next_wrd;
             break;
         }

--- a/future/src/ct/ct_widgets.cc
+++ b/future/src/ct/ct_widgets.cc
@@ -433,7 +433,7 @@ void CtTextView::for_event_after_key_press(GdkEvent* event, const Glib::ustring&
         Gtk::TextIter iter_start = iter_insert;
         if (event->key.keyval == GDK_KEY_Return)
         {
-            if (_pCtMainWin->get_ct_config()->enableMdFormatting) {
+            if (_pCtMainWin->get_ct_config()->enableMdFormatting && syntaxHighlighting == CtConst::RICH_TEXT_ID) {
                 // Format the last line
                 auto start_iter = iter_start;
                 start_iter.backward_line();
@@ -597,7 +597,7 @@ void CtTextView::for_event_after_key_press(GdkEvent* event, const Glib::ustring&
                     if (iter_start.get_line_offset() == 0 and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_COLON))
                         // ":: " becoming "▪ " at line start
                         _special_char_replace(CtConst::CHARS_LISTBUL_DEFAULT[2], iter_start, iter_insert);
-                } else if (_pCtMainWin->get_ct_config()->enableMdFormatting) {
+                } else if (_pCtMainWin->get_ct_config()->enableMdFormatting && syntaxHighlighting == CtConst::RICH_TEXT_ID) {
                     auto word_start = iter_insert;
                     if (word_start.backward_chars(2)) {
                         if (!word_start.inside_word() && !word_start.ends_word() && !word_start.starts_line()) {

--- a/future/src/ct/ct_widgets.h
+++ b/future/src/ct/ct_widgets.h
@@ -27,8 +27,13 @@
 #include <sqlite3.h>
 #include <iostream>
 #include <unordered_map>
+#include <memory>
+
 #include "ct_types.h"
 
+
+class CtMDParser;
+class CtClipboard;
 class CtTmp
 {
 public:
@@ -113,10 +118,12 @@ private:
     void          _special_char_replace(gunichar special_char, Gtk::TextIter iter_start, Gtk::TextIter iter_insert);
     /// Replace the char between iter_start and iter_end with another one
     void          _special_char_replace(Glib::ustring special_char, Gtk::TextIter iter_start, Gtk::TextIter iter_end);
-
+    void          _markdown_check_and_replace(Glib::RefPtr<Gtk::TextBuffer> text_buffer, Gtk::TextIter iter_start, Gtk::TextIter iter_end);
 public:
     static const double TEXT_SCROLL_MARGIN;
 
 private:
     CtMainWin* _pCtMainWin;
+    std::unique_ptr<CtClipboard> _clipboard;
+    std::unique_ptr<CtMDParser> _md_parser;
 };


### PR DESCRIPTION
This adds the ability to use markdown when formatting text. It is disabled by default and can be enabled by going to `preferences -> text -> Enable Markdown formatting (Experimental)`.

The formatting is checked when hitting space after a word or when pressing enter (enter checks the whole line, space checks the sentence), escaping characters is currently not supported but ctrl-z can be used to undo.

This also includes a rewrite of how the parser tokenizes the input and separates the tokenization from the parsing (which was necessary for parsing formatting). There are also general misc improvements to the parser and a fix for #869.

fixes #869 