### PR TITLE
replace some gchar* with ustring in ct_const.h

### DIFF
--- a/future/src/ct/ct_const.h
+++ b/future/src/ct/ct_const.h
@@ -29,165 +29,165 @@
 #include <array>
 #include "config.h"
 
-namespace CtConst {
+struct CtConst {
 
-const constexpr gchar* CT_VERSION  {PACKAGE_VERSION};
-const constexpr gchar* APP_NAME    {PACKAGE_NAME};
+const inline static gchar* CT_VERSION  {PACKAGE_VERSION};
+const inline static gchar* APP_NAME    {PACKAGE_NAME};
 
-const constexpr gchar* CTDOC_XML_NOENC          {".ctd"};
-const constexpr gchar* CTDOC_XML_ENC            {".ctz"};
-const constexpr gchar* CTDOC_SQLITE_NOENC       {".ctb"};
-const constexpr gchar* CTDOC_SQLITE_ENC         {".ctx"};
-const constexpr gchar* LINK_TYPE_WEBS           {"webs"};
-const constexpr gchar* LINK_TYPE_FILE           {"file"};
-const constexpr gchar* LINK_TYPE_FOLD           {"fold"};
-const constexpr gchar* LINK_TYPE_NODE           {"node"};
-const constexpr gchar* NODE_ICON_TYPE_CHERRY    {"c"};
-const constexpr gchar* NODE_ICON_TYPE_CUSTOM    {"b"};
-const constexpr gchar* NODE_ICON_TYPE_NONE      {"n"};
-const constexpr gchar* CHERRY_RED               {"cherry_red"};
-const constexpr gchar* CHERRY_BLUE              {"cherry_blue"};
-const constexpr gchar* CHERRY_ORANGE            {"cherry_orange"};
-const constexpr gchar* CHERRY_CYAN              {"cherry_cyan"};
-const constexpr gchar* CHERRY_ORANGE_DARK       {"cherry_orange_dark"};
-const constexpr gchar* CHERRY_SHERBERT          {"cherry_sherbert"};
-const constexpr gchar* CHERRY_YELLOW            {"cherry_yellow"};
-const constexpr gchar* CHERRY_GREEN             {"cherry_green"};
-const constexpr gchar* CHERRY_PURPLE            {"cherry_purple"};
-const constexpr gchar* CHERRY_BLACK             {"cherry_black"};
-const constexpr gchar* CHERRY_GRAY              {"cherry_grey"};
-const constexpr gchar* RICH_TEXT_ID             {"custom-colors"};
-const constexpr gchar* TABLE_CELL_TEXT_ID       {"table-cell-text"};
-const constexpr gchar* PLAIN_TEXT_ID            {"plain-text"};
-const constexpr gchar* STYLE_APPLIED_ID          {"<style-applied>"};
-const constexpr gchar* SYN_HIGHL_BASH           {"sh"};
-const constexpr gchar* STYLE_SCHEME_LIGHT       {"classic"};
-const constexpr gchar* STYLE_SCHEME_DARK        {"cobalt"};
-const constexpr gchar* STYLE_SCHEME_GRAY        {"oblivion"};
-const constexpr gchar* TIMESTAMP_FORMAT_DEFAULT {"%Y/%m/%d - %H:%M"};
+const inline static gchar* CTDOC_XML_NOENC          {".ctd"};
+const inline static gchar* CTDOC_XML_ENC            {".ctz"};
+const inline static gchar* CTDOC_SQLITE_NOENC       {".ctb"};
+const inline static gchar* CTDOC_SQLITE_ENC         {".ctx"};
+const inline static gchar* LINK_TYPE_WEBS           {"webs"};
+const inline static gchar* LINK_TYPE_FILE           {"file"};
+const inline static gchar* LINK_TYPE_FOLD           {"fold"};
+const inline static gchar* LINK_TYPE_NODE           {"node"};
+const inline static gchar* NODE_ICON_TYPE_CHERRY    {"c"};
+const inline static gchar* NODE_ICON_TYPE_CUSTOM    {"b"};
+const inline static gchar* NODE_ICON_TYPE_NONE      {"n"};
+const inline static gchar* CHERRY_RED               {"cherry_red"};
+const inline static gchar* CHERRY_BLUE              {"cherry_blue"};
+const inline static gchar* CHERRY_ORANGE            {"cherry_orange"};
+const inline static gchar* CHERRY_CYAN              {"cherry_cyan"};
+const inline static gchar* CHERRY_ORANGE_DARK       {"cherry_orange_dark"};
+const inline static gchar* CHERRY_SHERBERT          {"cherry_sherbert"};
+const inline static gchar* CHERRY_YELLOW            {"cherry_yellow"};
+const inline static gchar* CHERRY_GREEN             {"cherry_green"};
+const inline static gchar* CHERRY_PURPLE            {"cherry_purple"};
+const inline static gchar* CHERRY_BLACK             {"cherry_black"};
+const inline static gchar* CHERRY_GRAY              {"cherry_grey"};
+const inline static gchar* RICH_TEXT_ID             {"custom-colors"};
+const inline static gchar* TABLE_CELL_TEXT_ID       {"table-cell-text"};
+const inline static gchar* PLAIN_TEXT_ID            {"plain-text"};
+const inline static gchar* STYLE_APPLIED_ID         {"<style-applied>"};
+const inline static gchar* SYN_HIGHL_BASH           {"sh"};
+const inline static gchar* STYLE_SCHEME_LIGHT       {"classic"};
+const inline static gchar* STYLE_SCHEME_DARK        {"cobalt"};
+const inline static gchar* STYLE_SCHEME_GRAY        {"oblivion"};
+const inline static gchar* TIMESTAMP_FORMAT_DEFAULT {"%Y/%m/%d - %H:%M"};
 
-const constexpr gchar* SPECIAL_CHARS_DEFAULT     {"“”„‘’•◇▪▸☐☑☒★…‰€©®™°↓↑→←↔↵⇓⇑⇒⇐⇔»«▼▲►◄≤≥≠≈±¹²³½¼⅛×÷∞ø∑σ√∫ΔδΠπΣΦΩωαβγεηλμ☺☻☼♥♣♦✔♀♂♪♫✝"};
-const constexpr gchar* SPECIAL_CHAR_ARROW_RIGHT   {"→"};
-const constexpr gchar* SPECIAL_CHAR_ARROW_RIGHT2  {"⇒"};
-const constexpr gchar* SPECIAL_CHAR_ARROW_LEFT    {"←"};
-const constexpr gchar* SPECIAL_CHAR_ARROW_LEFT2   {"⇐"};
-const constexpr gchar* SPECIAL_CHAR_ARROW_DOUBLE  {"↔"};
-const constexpr gchar* SPECIAL_CHAR_ARROW_DOUBLE2 {"⇔"};
-const constexpr gchar* SPECIAL_CHAR_COPYRIGHT     {"©"};
-const constexpr gchar* SPECIAL_CHAR_UNREGISTERED_TRADEMARK {"™"};
-const constexpr gchar* SPECIAL_CHAR_REGISTERED_TRADEMARK   {"®"};
-const constexpr gchar* SELWORD_CHARS_DEFAULT {".-@"};
-const constexpr gchar* CHARS_LISTBUL_DEFAULT {"•◇▪-→⇒"};
-const constexpr gchar* CHARS_TOC_DEFAULT     {"▸•◇▪"};
-const constexpr gchar* CHARS_TODO_DEFAULT    {"☐☑☒"};
-const constexpr gchar* CHARS_SMART_DQUOTE_DEFAULT    {"“”"};
-const constexpr gchar* CHARS_SMART_SQUOTE_DEFAULT    {"‘’"};
+const inline static Glib::ustring SPECIAL_CHARS_DEFAULT      {"“”„‘’•◇▪▸☐☑☒★…‰€©®™°↓↑→←↔↵⇓⇑⇒⇐⇔»«▼▲►◄≤≥≠≈±¹²³½¼⅛×÷∞ø∑σ√∫ΔδΠπΣΦΩωαβγεηλμ☺☻☼♥♣♦✔♀♂♪♫✝"};
+const inline static Glib::ustring SPECIAL_CHAR_ARROW_RIGHT   {"→"};
+const inline static Glib::ustring SPECIAL_CHAR_ARROW_RIGHT2  {"⇒"};
+const inline static Glib::ustring SPECIAL_CHAR_ARROW_LEFT    {"←"};
+const inline static Glib::ustring SPECIAL_CHAR_ARROW_LEFT2   {"⇐"};
+const inline static Glib::ustring SPECIAL_CHAR_ARROW_DOUBLE  {"↔"};
+const inline static Glib::ustring SPECIAL_CHAR_ARROW_DOUBLE2 {"⇔"};
+const inline static Glib::ustring SPECIAL_CHAR_COPYRIGHT     {"©"};
+const inline static Glib::ustring SPECIAL_CHAR_UNREGISTERED_TRADEMARK {"™"};
+const inline static Glib::ustring SPECIAL_CHAR_REGISTERED_TRADEMARK   {"®"};
+const inline static Glib::ustring SELWORD_CHARS_DEFAULT      {".-@"};
+const inline static Glib::ustring CHARS_LISTBUL_DEFAULT      {"•◇▪-→⇒"};
+const inline static Glib::ustring CHARS_TOC_DEFAULT          {"▸•◇▪"};
+const inline static Glib::ustring CHARS_TODO_DEFAULT         {"☐☑☒"};
+const inline static Glib::ustring CHARS_SMART_DQUOTE_DEFAULT {"“”"};
+const inline static Glib::ustring CHARS_SMART_SQUOTE_DEFAULT {"‘’"};
 
-const constexpr gchar* COLOR_48_LINK_WEBS   {"#00008989ffff"};
-const constexpr gchar* COLOR_48_LINK_NODE   {"#071c838e071c"};
-const constexpr gchar* COLOR_48_LINK_FILE   {"#8b8b69691414"};
-const constexpr gchar* COLOR_48_LINK_FOLD   {"#7f7f7f7f7f7f"};
-const constexpr gchar* COLOR_48_YELLOW      {"#bbbbbbbb0000"};
-const constexpr gchar* COLOR_48_WHITE       {"#ffffffffffff"};
-const constexpr gchar* COLOR_48_BLACK       {"#000000000000"};
-const constexpr gchar* COLOR_24_BLACK       {"#000000"};
-const constexpr gchar* COLOR_24_WHITE       {"#ffffff"};
-const constexpr gchar* COLOR_24_BLUEBG      {"#001b33"};
-const constexpr gchar* COLOR_24_LBLACK      {"#0b0c0c"};
-const constexpr gchar* COLOR_24_GRAY        {"#e0e0e0"};
-const constexpr gchar* DEFAULT_MONOSPACE_BG {"#7f7f7f"};
-const constexpr gchar* RICH_TEXT_DARK_FG      {COLOR_24_WHITE};
-const constexpr gchar* RICH_TEXT_DARK_BG      {COLOR_24_BLUEBG};
-const constexpr gchar* RICH_TEXT_LIGHT_FG     {COLOR_24_BLACK};
-const constexpr gchar* RICH_TEXT_LIGHT_BG     {COLOR_24_WHITE};
-const constexpr gchar* TREE_TEXT_DARK_FG      {COLOR_24_WHITE};
-const constexpr gchar* TREE_TEXT_DARK_BG      {COLOR_24_BLUEBG};
-const constexpr gchar* TREE_TEXT_LIGHT_FG     {COLOR_24_LBLACK};
-const constexpr gchar* TREE_TEXT_LIGHT_BG     {COLOR_24_GRAY};
+const inline static gchar* COLOR_48_LINK_WEBS   {"#00008989ffff"};
+const inline static gchar* COLOR_48_LINK_NODE   {"#071c838e071c"};
+const inline static gchar* COLOR_48_LINK_FILE   {"#8b8b69691414"};
+const inline static gchar* COLOR_48_LINK_FOLD   {"#7f7f7f7f7f7f"};
+const inline static gchar* COLOR_48_YELLOW      {"#bbbbbbbb0000"};
+const inline static gchar* COLOR_48_WHITE       {"#ffffffffffff"};
+const inline static gchar* COLOR_48_BLACK       {"#000000000000"};
+const inline static gchar* COLOR_24_BLACK       {"#000000"};
+const inline static gchar* COLOR_24_WHITE       {"#ffffff"};
+const inline static gchar* COLOR_24_BLUEBG      {"#001b33"};
+const inline static gchar* COLOR_24_LBLACK      {"#0b0c0c"};
+const inline static gchar* COLOR_24_GRAY        {"#e0e0e0"};
+const inline static gchar* DEFAULT_MONOSPACE_BG {"#7f7f7f"};
+const inline static gchar* RICH_TEXT_DARK_FG      {COLOR_24_WHITE};
+const inline static gchar* RICH_TEXT_DARK_BG      {COLOR_24_BLUEBG};
+const inline static gchar* RICH_TEXT_LIGHT_FG     {COLOR_24_BLACK};
+const inline static gchar* RICH_TEXT_LIGHT_BG     {COLOR_24_WHITE};
+const inline static gchar* TREE_TEXT_DARK_FG      {COLOR_24_WHITE};
+const inline static gchar* TREE_TEXT_DARK_BG      {COLOR_24_BLUEBG};
+const inline static gchar* TREE_TEXT_LIGHT_FG     {COLOR_24_LBLACK};
+const inline static gchar* TREE_TEXT_LIGHT_BG     {COLOR_24_GRAY};
 
-const constexpr gchar* GTKSPELLCHECK_TAG_NAME {"gtkspellchecker-misspelled"};
-const constexpr gchar* TAG_WEIGHT           {"weight"};
-const constexpr gchar* TAG_FOREGROUND       {"foreground"};
-const constexpr gchar* TAG_BACKGROUND       {"background"};
-const constexpr gchar* TAG_STYLE            {"style"};
-const constexpr gchar* TAG_UNDERLINE        {"underline"};
-const constexpr gchar* TAG_STRIKETHROUGH    {"strikethrough"};
-const constexpr gchar* TAG_SCALE            {"scale"};
-const constexpr gchar* TAG_FAMILY           {"family"};
-const constexpr gchar* TAG_JUSTIFICATION    {"justification"};
-const constexpr gchar* TAG_LINK             {"link"};
-const constexpr gchar* TAG_SEPARATOR        {"separator"};
-const constexpr gchar* TAG_SEPARATOR_ANSI_REPR {"---------"};
+const inline static gchar* GTKSPELLCHECK_TAG_NAME  {"gtkspellchecker-misspelled"};
+const inline static gchar* TAG_WEIGHT              {"weight"};
+const inline static gchar* TAG_FOREGROUND          {"foreground"};
+const inline static gchar* TAG_BACKGROUND          {"background"};
+const inline static gchar* TAG_STYLE               {"style"};
+const inline static gchar* TAG_UNDERLINE           {"underline"};
+const inline static gchar* TAG_STRIKETHROUGH       {"strikethrough"};
+const inline static gchar* TAG_SCALE               {"scale"};
+const inline static gchar* TAG_FAMILY              {"family"};
+const inline static gchar* TAG_JUSTIFICATION       {"justification"};
+const inline static gchar* TAG_LINK                {"link"};
+const inline static gchar* TAG_SEPARATOR           {"separator"};
+const inline static gchar* TAG_SEPARATOR_ANSI_REPR {"---------"};
 
-const constexpr gchar* TAG_PROP_VAL_HEAVY        {"heavy"};
-const constexpr gchar* TAG_PROP_VAL_ITALIC       {"italic"};
-const constexpr gchar* TAG_PROP_VAL_MONOSPACE    {"monospace"};
-const constexpr gchar* TAG_PROP_VAL_SINGLE       {"single"};
-const constexpr gchar* TAG_PROP_VAL_SMALL        {"small"};
-const constexpr gchar* TAG_PROP_VAL_TRUE         {"true"};
-const constexpr gchar* TAG_PROP_VAL_H1           {"h1"};
-const constexpr gchar* TAG_PROP_VAL_H2           {"h2"};
-const constexpr gchar* TAG_PROP_VAL_H3           {"h3"};
-const constexpr gchar* TAG_PROP_VAL_H4           {"h4"};
-const constexpr gchar* TAG_PROP_VAL_H5           {"h5"};
-const constexpr gchar* TAG_PROP_VAL_H6           {"h6"};
-const constexpr gchar* TAG_PROP_VAL_SUP          {"sup"};
-const constexpr gchar* TAG_PROP_VAL_SUB          {"sub"};
-const constexpr gchar* TAG_PROP_VAL_LEFT         {"left"};
-const constexpr gchar* TAG_PROP_VAL_CENTER       {"center"};
-const constexpr gchar* TAG_PROP_VAL_RIGHT        {"right"};
-const constexpr gchar* TAG_PROP_VAL_FILL         {"fill"};
+const inline static gchar* TAG_PROP_VAL_HEAVY        {"heavy"};
+const inline static gchar* TAG_PROP_VAL_ITALIC       {"italic"};
+const inline static gchar* TAG_PROP_VAL_MONOSPACE    {"monospace"};
+const inline static gchar* TAG_PROP_VAL_SINGLE       {"single"};
+const inline static gchar* TAG_PROP_VAL_SMALL        {"small"};
+const inline static gchar* TAG_PROP_VAL_TRUE         {"true"};
+const inline static gchar* TAG_PROP_VAL_H1           {"h1"};
+const inline static gchar* TAG_PROP_VAL_H2           {"h2"};
+const inline static gchar* TAG_PROP_VAL_H3           {"h3"};
+const inline static gchar* TAG_PROP_VAL_H4           {"h4"};
+const inline static gchar* TAG_PROP_VAL_H5           {"h5"};
+const inline static gchar* TAG_PROP_VAL_H6           {"h6"};
+const inline static gchar* TAG_PROP_VAL_SUP          {"sup"};
+const inline static gchar* TAG_PROP_VAL_SUB          {"sub"};
+const inline static gchar* TAG_PROP_VAL_LEFT         {"left"};
+const inline static gchar* TAG_PROP_VAL_CENTER       {"center"};
+const inline static gchar* TAG_PROP_VAL_RIGHT        {"right"};
+const inline static gchar* TAG_PROP_VAL_FILL         {"fill"};
 
-const constexpr gchar* STR_KEY_UP                {"Up"};
-const constexpr gchar* STR_KEY_DOWN              {"Down"};
-const constexpr gchar* STR_KEY_LEFT              {"Left"};
-const constexpr gchar* STR_KEY_RIGHT             {"Right"};
-const constexpr gchar* STR_STOCK_CT_IMP          {"import_in_cherrytree"};
+const inline static gchar* STR_KEY_UP                {"Up"};
+const inline static gchar* STR_KEY_DOWN              {"Down"};
+const inline static gchar* STR_KEY_LEFT              {"Left"};
+const inline static gchar* STR_KEY_RIGHT             {"Right"};
+const inline static gchar* STR_STOCK_CT_IMP          {"import_in_cherrytree"};
 
-const constexpr int MAX_FILE_NAME_LEN              {142};
-const constexpr int WHITE_SPACE_BETW_PIXB_AND_TEXT {3};
-const constexpr int GRID_SLIP_OFFSET               {3};
+const inline static int MAX_FILE_NAME_LEN              {142};
+const inline static int WHITE_SPACE_BETW_PIXB_AND_TEXT {3};
+const inline static int GRID_SLIP_OFFSET               {3};
 
-const constexpr gchar* CHAR_SPACE             {" "};
-const constexpr gchar* CHAR_NEWLINE           {"\n"};
-const constexpr gchar* CHAR_NEWPAGE           {"\x0c"};
-const constexpr gchar* CHAR_CR                {"\r"};
-const constexpr gchar* CHAR_TAB               {"\t"};
-const constexpr std::array<gunichar, 4> CHARS_LISTNUM {'.', ')', '-', '>'};
-const constexpr gchar* CHAR_TILDE             {"~"};
-const constexpr gchar* CHAR_MINUS             {"-"};
-const constexpr gchar* CHAR_DQUOTE            {"\""};
-const constexpr gchar* CHAR_SQUOTE            {"'"};
-const constexpr gchar* CHAR_GRAVE             {"`"};
-const constexpr gchar* CHAR_SLASH             {"/"};
-const constexpr gchar* CHAR_BSLASH            {"\\"};
-const constexpr gchar* CHAR_SQ_BR_OPEN        {"["};
-const constexpr gchar* CHAR_SQ_BR_CLOSE       {"]"};
-const constexpr gchar* CHAR_PARENTH_OPEN      {"("};
-const constexpr gchar* CHAR_PARENTH_CLOSE     {")"};
-const constexpr gchar* CHAR_LESSER            {"<"};
-const constexpr gchar* CHAR_GREATER           {">"};
-const constexpr gchar* CHAR_STAR              {"*"};
-const constexpr gchar* CHAR_QUESTION          {"?"};
-const constexpr gchar* CHAR_COMMA             {","};
-const constexpr gchar* CHAR_COLON             {":"};
-const constexpr gchar* CHAR_SEMICOLON         {";"};
-const constexpr gchar* CHAR_USCORE            {"_"};
-const constexpr gchar* CHAR_EQUAL             {"="};
-const constexpr gchar* CHAR_BR_OPEN           {"{"};
-const constexpr gchar* CHAR_BR_CLOSE          {"}"};
-const constexpr gchar* CHAR_CARET             {"^"};
-const constexpr gchar* CHAR_PIPE              {"|"};
-const constexpr gchar* CHAR_AMPERSAND         {"&"};
+const inline static gchar* CHAR_SPACE             {" "};
+const inline static gchar* CHAR_NEWLINE           {"\n"};
+const inline static gchar* CHAR_NEWPAGE           {"\x0c"};
+const inline static gchar* CHAR_CR                {"\r"};
+const inline static gchar* CHAR_TAB               {"\t"};
+const inline static std::array<gunichar, 4> CHARS_LISTNUM {'.', ')', '-', '>'};
+const inline static gchar* CHAR_TILDE             {"~"};
+const inline static gchar* CHAR_MINUS             {"-"};
+const inline static gchar* CHAR_DQUOTE            {"\""};
+const inline static gchar* CHAR_SQUOTE            {"'"};
+const inline static gchar* CHAR_GRAVE             {"`"};
+const inline static gchar* CHAR_SLASH             {"/"};
+const inline static gchar* CHAR_BSLASH            {"\\"};
+const inline static gchar* CHAR_SQ_BR_OPEN        {"["};
+const inline static gchar* CHAR_SQ_BR_CLOSE       {"]"};
+const inline static gchar* CHAR_PARENTH_OPEN      {"("};
+const inline static gchar* CHAR_PARENTH_CLOSE     {")"};
+const inline static gchar* CHAR_LESSER            {"<"};
+const inline static gchar* CHAR_GREATER           {">"};
+const inline static gchar* CHAR_STAR              {"*"};
+const inline static gchar* CHAR_QUESTION          {"?"};
+const inline static gchar* CHAR_COMMA             {","};
+const inline static gchar* CHAR_COLON             {":"};
+const inline static gchar* CHAR_SEMICOLON         {";"};
+const inline static gchar* CHAR_USCORE            {"_"};
+const inline static gchar* CHAR_EQUAL             {"="};
+const inline static gchar* CHAR_BR_OPEN           {"{"};
+const inline static gchar* CHAR_BR_CLOSE          {"}"};
+const inline static gchar* CHAR_CARET             {"^"};
+const inline static gchar* CHAR_PIPE              {"|"};
+const inline static gchar* CHAR_AMPERSAND         {"&"};
 
-const constexpr std::array<std::string_view, 4> WEB_LINK_STARTERS {
+const inline static std::array<std::string_view, 4> WEB_LINK_STARTERS {
     "http://",
     "https://",
     "www.",
     "ftp://"
 };
 
-const constexpr std::array<std::string_view, 10> TAG_PROPERTIES {
+const inline static std::array<std::string_view, 10> TAG_PROPERTIES {
     TAG_WEIGHT,
     TAG_FOREGROUND,
     TAG_BACKGROUND,
@@ -200,7 +200,7 @@ const constexpr std::array<std::string_view, 10> TAG_PROPERTIES {
     TAG_LINK
 };
 
-const constexpr gchar* TOOLBAR_VEC_DEFAULT {
+const inline static gchar* TOOLBAR_VEC_DEFAULT {
     "tree_add_node,tree_add_subnode,separator,go_node_prev,go_node_next,"
     "separator,*,ct_save,export_pdf,separator,"
     "find_in_allnodes,separator,handle_bull_list,handle_num_list,handle_todo_list,"
@@ -210,28 +210,28 @@ const constexpr gchar* TOOLBAR_VEC_DEFAULT {
     "fmt_h1,fmt_h2,fmt_h3,fmt_small,fmt_superscript,fmt_subscript,fmt_monospace"
 };
 
-const constexpr std::array<const gchar*, 17>  TOOLBAR_VEC_BLACKLIST {
+const inline static std::array<const gchar*, 17>  TOOLBAR_VEC_BLACKLIST {
     "anch_cut", "anch_copy", "anch_del", "anch_edit", "emb_file_cut",
     "emb_file_copy", "emb_file_del", "emb_file_save", "emb_file_open",
     "img_save", "img_edit", "img_cut", "img_copy", "img_del",
     "img_link_edit", "img_link_dismiss", "toggle_show_mainwin"
 };
 
-const constexpr gchar* LANG_DEFAULT{"default"};
+const inline static gchar* LANG_DEFAULT{"default"};
 
-const constexpr std::array<const gchar*, 21> AVAILABLE_LANGS {
+const inline static std::array<const gchar*, 21> AVAILABLE_LANGS {
     LANG_DEFAULT, "cs", "de", "el", "en", "es", "fi", "fr", "hy", "it",
     "ja", "lt", "nl", "pl", "pt_BR", "ru", "sl", "sv", "tr", "uk", "zh_CN"
 };
 
-const constexpr int NODE_ICON_CODE_ID          {38};
-const constexpr int NODE_ICON_BULLET_ID        {25};
-const constexpr int NODE_ICON_NO_ICON_ID       {26};
-const constexpr int NODE_ICON_SIZE             {16};
-const constexpr int MAX_TOOLTIP_LINK_CHARS     {150};
+const inline static int NODE_ICON_CODE_ID          {38};
+const inline static int NODE_ICON_BULLET_ID        {25};
+const inline static int NODE_ICON_NO_ICON_ID       {26};
+const inline static int NODE_ICON_SIZE             {16};
+const inline static int MAX_TOOLTIP_LINK_CHARS     {150};
 
 // former NODES_STOCK
-const constexpr std::array<const gchar*, 49> NODE_CUSTOM_ICONS {
+const inline static std::array<const gchar*, 49> NODE_CUSTOM_ICONS {
     nullptr,           // NEVER USED
     "circle-green",    //  1
     "circle-yellow",   //  2
@@ -284,7 +284,7 @@ const constexpr std::array<const gchar*, 49> NODE_CUSTOM_ICONS {
 };
 
 // former NODES_ICONS
-const constexpr std::array<const gchar*, 11> NODE_CHERRY_ICONS {
+const inline static std::array<const gchar*, 11> NODE_CHERRY_ICONS {
     CHERRY_RED,         //  0
     CHERRY_BLUE,        //  1
     CHERRY_ORANGE,      //  2
@@ -298,7 +298,7 @@ const constexpr std::array<const gchar*, 11> NODE_CHERRY_ICONS {
     CHERRY_GRAY         // 10
 };
 
-const constexpr std::array<std::pair<const gchar*, const gchar*>, 11> CODE_ICONS {
+const inline static std::array<std::pair<const gchar*, const gchar*>, 11> CODE_ICONS {
     std::make_pair("python", "python"),
     std::make_pair("python3", "python"),
     std::make_pair("perl", "perl"),
@@ -313,11 +313,11 @@ const constexpr std::array<std::pair<const gchar*, const gchar*>, 11> CODE_ICONS
 };
 
 
-const constexpr gchar* CODE_EXEC_TMP_SRC  {"<tmp_src_path>"};
-const constexpr gchar* CODE_EXEC_TMP_BIN  {"<tmp_bin_path>"};
-const constexpr gchar* CODE_EXEC_COMMAND  {"<command>"};
+const inline static gchar* CODE_EXEC_TMP_SRC  {"<tmp_src_path>"};
+const inline static gchar* CODE_EXEC_TMP_BIN  {"<tmp_bin_path>"};
+const inline static gchar* CODE_EXEC_COMMAND  {"<command>"};
 
-const std::array<std::pair<const std::string, const std::string>, 8> CODE_EXEC_TYPE_CMD_DEFAULT {
+const inline static std::array<std::pair<const std::string, const std::string>, 8> CODE_EXEC_TYPE_CMD_DEFAULT {
     std::make_pair("c",          std::string("gcc -o ") + CODE_EXEC_TMP_BIN + " " + CODE_EXEC_TMP_SRC + " && " + CODE_EXEC_TMP_BIN),
     std::make_pair("cpp",        std::string("g++ -o ") + CODE_EXEC_TMP_BIN + " " + CODE_EXEC_TMP_SRC + " && " + CODE_EXEC_TMP_BIN),
     std::make_pair("dosbatch",   std::string("call ") + CODE_EXEC_TMP_SRC),
@@ -328,7 +328,7 @@ const std::array<std::pair<const std::string, const std::string>, 8> CODE_EXEC_T
     std::make_pair("sh",         std::string("sh ") + CODE_EXEC_TMP_SRC)
 };
 
-const constexpr std::array<std::pair<const gchar*, const gchar*>, 11> CODE_EXEC_TYPE_EXT_DEFAULT {
+const inline static std::array<std::pair<const gchar*, const gchar*>, 11> CODE_EXEC_TYPE_EXT_DEFAULT {
     std::make_pair("c",          "c"),
     std::make_pair("cpp",        "cpp"),
     std::make_pair("dosbatch",   "bat"),
@@ -339,17 +339,18 @@ const constexpr std::array<std::pair<const gchar*, const gchar*>, 11> CODE_EXEC_
     std::make_pair("sh",         "sh")
 };
 
-const std::unordered_map<std::string, std::string> CODE_EXEC_TERM_RUN_DEFAULT {
+const inline static std::unordered_map<std::string, std::string> CODE_EXEC_TERM_RUN_DEFAULT {
     {"linux", std::string("xterm -hold -geometry 180x45 -e \"") + CODE_EXEC_COMMAND + "\""},
     {"win",   std::string("start cmd /k \"") + CODE_EXEC_COMMAND + "\""}
 };
 
-const constexpr std::array<std::string_view, 4>  INVALID_HTML_TAGS = {
+const inline static std::array<std::string_view, 4>  INVALID_HTML_TAGS = {
     "script", "title", "head", "html"
 };
+
 // List of extensions for cherrytree save files, for use with gtk FileFilter
-const std::vector<std::string> CT_FILE_EXTENSIONS_FILTER = {
+const inline static std::vector<std::string> CT_FILE_EXTENSIONS_FILTER = {
         "*.ctb", "*.ctx", "*.ctd", "*.ctz"
 };
 
-} // namespace CtConst
+}; // struct CtConst


### PR DESCRIPTION
`gchar*` still causes issues, so I replaced it with `Glib::ustring` in some places as it was in the older ct_const.h.

`constexpr` doesn't work with `Glib::ustring`, but I like to have single `ct_const.h` without `ct_const.cc`, so changed `namespace` to `struct` to keep such behavior.