### PR TITLE
show/hide aux icon in TreeView

### DIFF
--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -467,7 +467,9 @@ void CtMainWin::_reset_CtTreestore_CtTreeview()
 
     _uCtTreestore.reset(new CtTreeStore(this));
     _uCtTreestore->tree_view_connect(_uCtTreeview.get());
+    _uCtTreeview->set_title_wrap_mode(get_ct_config()->cherryWrapWidth);
     _uCtTreeview->get_column(CtTreeView::AUX_ICON_COL_NUM)->set_visible(!get_ct_config()->auxIconHide);
+
 
     _uCtTreeview->signal_cursor_changed().connect(sigc::mem_fun(*this, &CtMainWin::_on_treeview_cursor_changed));
     _uCtTreeview->signal_button_release_event().connect(sigc::mem_fun(*this, &CtMainWin::_on_treeview_button_release_event));

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -467,6 +467,7 @@ void CtMainWin::_reset_CtTreestore_CtTreeview()
 
     _uCtTreestore.reset(new CtTreeStore(this));
     _uCtTreestore->tree_view_connect(_uCtTreeview.get());
+    _uCtTreeview->get_column(CtTreeView::AUX_ICON_COL_NUM)->set_visible(!get_ct_config()->auxIconHide);
 
     _uCtTreeview->signal_cursor_changed().connect(sigc::mem_fun(*this, &CtMainWin::_on_treeview_cursor_changed));
     _uCtTreeview->signal_button_release_event().connect(sigc::mem_fun(*this, &CtMainWin::_on_treeview_button_release_event));

--- a/future/src/ct/ct_pref_dlg.cc
+++ b/future/src/ct/ct_pref_dlg.cc
@@ -896,10 +896,9 @@ Gtk::Widget* CtPrefDlg::build_tab_tree_1()
     checkbutton_nodes_bookm_exp->signal_toggled().connect([pConfig, checkbutton_nodes_bookm_exp](){
         pConfig->nodesBookmExp = checkbutton_nodes_bookm_exp->get_active();
     });
-    checkbutton_aux_icon_hide->signal_toggled().connect([pConfig, checkbutton_aux_icon_hide](){
+    checkbutton_aux_icon_hide->signal_toggled().connect([this, pConfig, checkbutton_aux_icon_hide](){
         pConfig->auxIconHide = checkbutton_aux_icon_hide->get_active();
-        //dad.aux_renderer_pixbuf.set_property("visible", not dad.aux_icon_hide)
-        //dad.treeview_refresh()
+        apply_for_each_window([pConfig](CtMainWin* win) { win->get_tree_view().get_column(CtTreeView::AUX_ICON_COL_NUM)->set_visible(!pConfig->auxIconHide); });
     });
 
     return pMainBox;

--- a/future/src/ct/ct_pref_dlg.cc
+++ b/future/src/ct/ct_pref_dlg.cc
@@ -951,10 +951,9 @@ Gtk::Widget* CtPrefDlg::build_tab_tree_2()
     pMainBox->set_margin_top(6);
     pMainBox->pack_start(*frame_misc_tree, false, false);
 
-    spinbutton_tree_nodes_names_width->signal_value_changed().connect([pConfig, spinbutton_tree_nodes_names_width](){
+    spinbutton_tree_nodes_names_width->signal_value_changed().connect([this, pConfig, spinbutton_tree_nodes_names_width](){
         pConfig->cherryWrapWidth = spinbutton_tree_nodes_names_width->get_value_as_int();
-        //dad.renderer_text.set_property('wrap-width', dad.cherry_wrap_width)
-        //dad.treeview_refresh()
+        apply_for_each_window([pConfig](CtMainWin* win) { win->get_tree_view().set_title_wrap_mode(pConfig->cherryWrapWidth); });
     });
     checkbutton_tree_right_side->signal_toggled().connect([this, pConfig, checkbutton_tree_right_side](){
         pConfig->treeRightSide = checkbutton_tree_right_side->get_active();

--- a/future/src/ct/ct_treestore.cc
+++ b/future/src/ct/ct_treestore.cc
@@ -427,13 +427,15 @@ void CtTreeStore::tree_view_connect(Gtk::TreeView* pTreeView)
 {
     pTreeView->set_model(_rTreeStore);
 
+    // if change column num, then change CtTreeView::TITLE_COL_NUM
     Gtk::TreeView::Column* pColumns = Gtk::manage(new Gtk::TreeView::Column(""));
     pColumns->pack_start(_columns.rColPixbuf, /*expand=*/false);
     pColumns->pack_start(_columns.colNodeName);
     pColumns->set_expand(true);
     pTreeView->append_column(*pColumns);
     pTreeView->append_column("", _columns.rColPixbufAux);
-    Gtk::TreeViewColumn* pTVCol0 = pTreeView->get_column(0);
+
+    Gtk::TreeViewColumn* pTVCol0 = pTreeView->get_column(CtTreeView::TITLE_COL_NUM);
     std::vector<Gtk::CellRenderer*> cellRenderers0 = pTVCol0->get_cells();
     if (cellRenderers0.size() > 1)
     {

--- a/future/src/ct/ct_widgets.cc
+++ b/future/src/ct/ct_widgets.cc
@@ -138,6 +138,19 @@ void CtTreeView::set_cursor_safe(const Gtk::TreeIter& iter)
     set_cursor(get_model()->get_path(iter));
 }
 
+void CtTreeView::set_title_wrap_mode(int wrap_width)
+{
+    Gtk::TreeViewColumn* pTVCol0 = get_column(CtTreeView::TITLE_COL_NUM);
+    std::vector<Gtk::CellRenderer*> cellRenderers0 = pTVCol0->get_cells();
+    if (cellRenderers0.size() > 1)
+        if (Gtk::CellRendererText *pCellRendererText = dynamic_cast<Gtk::CellRendererText*>(cellRenderers0[1]))
+        {
+            // todo: Gtk3 has broken wrap for TreeView
+            //pCellRendererText->property_wrap_mode().set_value(Pango::WRAP_CHAR);
+            //pCellRendererText->property_wrap_width().set_value(wrap_width);
+        }
+}
+
 
 CtTextView::CtTextView(CtMainWin* pCtMainWin)
  : _pCtMainWin(pCtMainWin)

--- a/future/src/ct/ct_widgets.h
+++ b/future/src/ct/ct_widgets.h
@@ -86,6 +86,10 @@ protected:
 class CtTreeView : public Gtk::TreeView
 {
 public:
+    const inline static int TITLE_COL_NUM = 0;
+    const inline static int AUX_ICON_COL_NUM = 1;
+
+public:
     CtTreeView();
     virtual ~CtTreeView();
     void set_cursor_safe(const Gtk::TreeIter& iter);

--- a/future/src/ct/ct_widgets.h
+++ b/future/src/ct/ct_widgets.h
@@ -93,6 +93,7 @@ public:
     CtTreeView();
     virtual ~CtTreeView();
     void set_cursor_safe(const Gtk::TreeIter& iter);
+    void set_title_wrap_mode(int wrap_width);
 };
 
 class CtTextView : public Gsv::View


### PR DESCRIPTION
Also, I tried to fix wrapping titles in TreeView, but it's broken and the bug in [bugzilla ](https://bugzilla.gnome.org/show_bug.cgi?id=653108) is not going to be fixed.
Gnome may introduce a new control in Gtk4 to fix the issue.

Closes #834