### PR TITLE
copy\paste codebox in yaml format

### DIFF
--- a/future/src/ct/ct_clipboard.h
+++ b/future/src/ct/ct_clipboard.h
@@ -82,6 +82,11 @@ private:
     void _on_received_to_uri_list(const Gtk::SelectionData& selection_data, Gtk::TextView* pTextView, bool);
 
 private:
+    Glib::ustring _codebox_to_yaml(CtCodebox* codebox);
+    void          _yaml_to_codebox(const Glib::ustring& yaml_text, Gtk::TextView* pTextView);
+    void          _xml_to_codebox(const Glib::ustring& xml_text, Gtk::TextView* pTextView);
+
+private:
     static bool _static_force_plain_text;
     CtMainWin*  _pCtMainWin;
 };


### PR DESCRIPTION
Resolves #892, copy\paste codebox in yaml format instead of plain text.
User can copy only one codebox (without additional text or by 'Copy codebox' comand) and paste only one too.

Example
```yaml
- codebox:
    syntax: python3
    width: 600
    height: 200
    width_in_pixels: true
    highlight_brackets: false
    source: |-
      def compound_interest(principle, rate, time): 
        
          # Calculates compound interest  
          CI = principle * (pow((1 + rate / 100), time)) 
          print("Compound interest is", CI) 
        
      # Driver Code  
      compound_interest(10000, 10.25, 5)
```
Don't change block indent (6 spaces)
User can add additional fields between `codebox` and `source`, e.g. 
```yaml
- codebox:
    title: some example
``` 

For now, I use a custom yaml parser. If it caused issues, it would be replaced by a normal library.