### PR TITLE
Implement importing through pandoc

### DIFF
--- a/future/src/ct/CMakeLists.txt
+++ b/future/src/ct/CMakeLists.txt
@@ -60,6 +60,8 @@ set(CT_SHARED_FILES
     ct_text_parser.cc
     ct_md_parser.cc
     ct_parser.cc
+    ct_pandoc.cc
+    ct_process.cc
     )
 
 add_library(cherrytree_shared STATIC ${CT_SHARED_FILES})

--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -402,6 +402,7 @@ private:
     void _import_node_from_plaintext(const std::filesystem::path& filepath);
     void _import_nodes_from_zim_directory(const std::filesystem::path& filepath);
     void _import_node_from_md_file(const std::filesystem::path& filepath);
+    void _import_through_pandoc(const std::filesystem::path& filepath);
 public:
     // import actions
     void import_node_from_html_file() noexcept;
@@ -412,6 +413,7 @@ public:
     void import_nodes_from_zim_directory() noexcept;
     void import_node_from_md_file() noexcept;
     void import_nodes_from_md_directory() noexcept;
+    void import_node_from_pandoc() noexcept;
 
 private:
     // helper for export actions

--- a/future/src/ct/ct_actions_import.cc
+++ b/future/src/ct/ct_actions_import.cc
@@ -327,7 +327,8 @@ void CtActions::import_nodes_from_md_directory() noexcept
     }
 }
 
-bool pandoc_in_path(CtMainWin& main_win) {
+bool pandoc_in_path(CtMainWin& main_win) 
+{
     if (!CtPandoc::has_pandoc()) {
         CtDialogs::warning_dialog(_("Pandoc executable could not be found, please ensure it is in your path"), main_win);
         return false;
@@ -335,7 +336,8 @@ bool pandoc_in_path(CtMainWin& main_win) {
     return true;
 }
 
-void CtActions::_import_through_pandoc(const std::filesystem::path& filepath) {
+void CtActions::_import_through_pandoc(const std::filesystem::path& filepath) 
+{
     if (!std::filesystem::exists(filepath)) throw std::runtime_error(fmt::format("Path does not exist: {}", filepath.string()));
     
     try {
@@ -358,8 +360,11 @@ void CtActions::_import_through_pandoc(const std::filesystem::path& filepath) {
     }
 }
 
-void CtActions::import_node_from_pandoc() noexcept {
+void CtActions::import_node_from_pandoc() noexcept 
+{
     try {
+        if (!pandoc_in_path(*_pCtMainWin)) return;
+
         CtDialogs::file_select_args args(_pCtMainWin);
         auto path = CtDialogs::file_select_dialog(args);
         if (path.empty()) return;
@@ -367,7 +372,9 @@ void CtActions::import_node_from_pandoc() noexcept {
         _import_through_pandoc(path);
         
     } catch(std::exception& e) {
-        spdlog::error("Exception caught in CtActions::import_node_from_pandoc: {}", e.what());
+        auto err_msg = fmt::format("Exception caught in CtActions::import_node_from_pandoc: {}", e.what());
+        spdlog::error(err_msg);
+        CtDialogs::error_dialog(err_msg, *_pCtMainWin);
     }
     
     

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -241,6 +241,7 @@ void CtMenu::init_actions(CtActions* pActions)
     _actions.push_back(CtMenuAction{import_cat, "import_treepad", CtConst::STR_STOCK_CT_IMP, _("From T_reepad Lite File"), None, _("Add Nodes of a Treepad Lite File to the Current Tree"), sigc::signal<void>() /* dad.nodes_add_from_treepad_file */});
     _actions.push_back(CtMenuAction{import_cat, "import_tuxcards", CtConst::STR_STOCK_CT_IMP, _("From _TuxCards File"), None, _("Add Nodes of a TuxCards File to the Current Tree"), sigc::signal<void>() /* dad.nodes_add_from_tuxcards_file */});
     _actions.push_back(CtMenuAction{import_cat, "import_zim", CtConst::STR_STOCK_CT_IMP, _("From _Zim Folder"), None, _("Add Nodes of a Zim Folder to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_zim_directory) /* dad.nodes_add_from_zim_folder */});
+    _actions.push_back(CtMenuAction{import_cat, "import_pandoc_file", CtConst::STR_STOCK_CT_IMP, _("From File using _Pandoc"), None, _("Add a node to the current tree using Pandoc"), sigc::mem_fun(*pActions, &CtActions::import_node_from_pandoc) /* dad.nodes_add_from_zim_folder */});
     const char* others_cat = "";
     _actions.push_back(CtMenuAction{others_cat, "anch_cut", "edit_cut", _("C_ut Anchor"), None, _("Cut the Selected Anchor"), sigc::mem_fun(*pActions, &CtActions::anchor_cut)});
     _actions.push_back(CtMenuAction{others_cat, "anch_copy", "edit_copy", _("_Copy Anchor"), None, _("Copy the Selected Anchor"), sigc::mem_fun(*pActions, &CtActions::anchor_copy)});
@@ -886,6 +887,7 @@ const char* CtMenu::_get_ui_str_menu()
       <menuitem action='import_treepad'/>
       <menuitem action='import_tuxcards'/>
       <menuitem action='import_zim'/>
+      <menuitem action='import_pandoc_file'/>
     </menu>
     <separator/>
     <menu action='TreeExportMenu'>
@@ -961,6 +963,7 @@ const char* CtMenu::_get_ui_str_menu()
     <menuitem action='import_treepad'/>
     <menuitem action='import_tuxcards'/>
     <menuitem action='import_zim'/>
+    <menuitem action='import_pandoc_file'/>
   </menu>
 
   <menu action='ExportMenu'>

--- a/future/src/ct/ct_pandoc.cc
+++ b/future/src/ct/ct_pandoc.cc
@@ -43,7 +43,8 @@ std::unique_ptr<CtProcess> pandoc_process() {
 
 namespace CtPandoc {
 
-bool dir_contains_file(const std::filesystem::path& path, std::string_view file) {
+bool dir_contains_file(const std::filesystem::path& path, std::string_view file) 
+{
     for (auto& dir_entry : fs::directory_iterator(path)) {
         auto p = dir_entry.path().stem();
         if (p == file) {
@@ -54,10 +55,11 @@ bool dir_contains_file(const std::filesystem::path& path, std::string_view file)
 }
 
 // Checks if the specified file is in the PATH environment variable
-bool in_path(std::string_view file) {
-    std::stringstream env_path(getenv("path"));
+bool in_path(std::string_view file) 
+{
+    std::stringstream env_path(getenv("PATH"));
     std::vector<fs::path> path_dirs;
-    
+
     // Split into search paths
     std::string str;
     while(std::getline(env_path, str, path_delim)) {
@@ -66,8 +68,10 @@ bool in_path(std::string_view file) {
     
     // Search for the file
     for (const auto& path : path_dirs) {
-        if (dir_contains_file(path, file)) {
-            return true;
+        if (fs::exists(path)) { // Sanity check
+            if (dir_contains_file(path, file)) {
+                return true;
+            }
         }
     }
     
@@ -75,12 +79,14 @@ bool in_path(std::string_view file) {
 }
 
 
-bool has_pandoc() {
+bool has_pandoc() 
+{
     return in_path("pandoc");
 }
 
 
-void to_html(std::istream& input, std::ostream& output) {
+void to_html(std::istream& input, std::ostream& output) 
+{
     auto process = pandoc_process();
     try {
         process->input(&input);

--- a/future/src/ct/ct_pandoc.cc
+++ b/future/src/ct/ct_pandoc.cc
@@ -1,9 +1,7 @@
 /*
- * ct_logging.h
+ * ct_pandoc.cc
  *
- * Copyright 2009-2020
- * Giuseppe Penone <giuspen@gmail.com>
- * Evgenii Gurianov <https://github.com/txe>
+ * Copyright 2017-2020 Giuseppe Penone <giuspen@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,16 +19,34 @@
  * MA 02110-1301, USA.
  */
 
-#pragma once
+#include <sstream>
+#include "ct_pandoc.h"
+#include "ct_process.h"
+#include "ct_logging.h"
+
+std::unique_ptr<CtProcess> pandoc_process() {
+    auto p = std::make_unique<CtProcess>("pandoc");
+    p->append_arg("-t");
+    p->append_arg("html");
+    return p;
+}
+
+namespace CtPandoc {
+
+bool has_pandoc() {
+    return true;
+}
 
 
-#define SPDLOG_FMT_EXTERNAL 
-#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
-#include <spdlog/spdlog.h>
-#include <spdlog/fmt/ostr.h>
+void to_html(std::istream& input, std::ostream& output) {
+    auto process = pandoc_process();
+    try {
+        process->input(&input);
+        process->run(output);
+    } catch(std::exception& e) {
+        spdlog::error("Exception in to_html: {}", e.what());
+        throw;
+    }
+}
 
-
-
-
-
-
+}

--- a/future/src/ct/ct_pandoc.h
+++ b/future/src/ct/ct_pandoc.h
@@ -1,9 +1,7 @@
 /*
- * ct_logging.h
+ * ct_pandoc.h
  *
- * Copyright 2009-2020
- * Giuseppe Penone <giuspen@gmail.com>
- * Evgenii Gurianov <https://github.com/txe>
+ * Copyright 2017-2020 Giuseppe Penone <giuspen@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,15 +20,17 @@
  */
 
 #pragma once
+#include <istream>
+#include <ostream>
 
+/**
+ * @brief Contains functions which provide an interface between a pandoc binary and cherrytree
+ */
+namespace CtPandoc {
 
-#define SPDLOG_FMT_EXTERNAL 
-#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
-#include <spdlog/spdlog.h>
-#include <spdlog/fmt/ostr.h>
+bool has_pandoc();
 
+void to_html(std::istream& input, std::ostream& output);
 
-
-
-
+} // CtPandoc
 

--- a/future/src/ct/ct_process.cc
+++ b/future/src/ct/ct_process.cc
@@ -1,0 +1,121 @@
+/*
+ * ct_process.cc
+ *
+ * Copyright 2017-2020 Giuseppe Penone <giuspen@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "ct_process.h"
+#include "ct_logging.h"
+#include <fmt/format.h>
+#include <unistd.h>
+
+
+pid_t io_fork(int fds[2], const std::function<void(int, int)>& func) {
+    int pipes[4];
+    
+    if (pipe(&pipes[0]) != 0 || pipe(&pipes[2]) != 0) {
+        throw CtProcess::CtProcessError("Failed to open pipes");
+    }
+    
+    auto pid = fork();
+    if (pid > 0) {
+        // Parent
+        fds[0] = pipes[0];
+        fds[1] = pipes[3];
+        
+        close(pipes[1]);
+        close(pipes[2]);
+        return pid;
+    } else if (pid == 0) {
+        // Child
+        close(pipes[3]);
+        close(pipes[0]);
+        
+        func(pipes[2], pipes[1]);
+        _exit(0);
+    }
+    throw CtProcess::CtProcessError("fork() returned error code");
+}
+
+
+void CtProcess::run(const std::vector<std::string>& args, std::ostream &output) {
+    
+    // The casts here are safe because the exec family do not modify their args, its just for compatibility
+    std::vector<char*> process_args;
+    process_args.emplace_back(const_cast<char*>(_process_name.c_str()));
+    for (const auto& arg : args) {
+        process_args.emplace_back(const_cast<char*>(arg.c_str()));
+    }
+    process_args.emplace_back(nullptr);
+    
+   
+   auto func = [process_args, this](int read_fs, int write_fs){
+    
+       dup2(write_fs, STDOUT_FILENO);
+       dup2(write_fs, STDERR_FILENO);
+       dup2(read_fs, STDIN_FILENO);
+       
+       close(write_fs);
+       close(read_fs);
+       
+       execvp(_process_name.c_str(), process_args.data());
+       spdlog::error("execlp() failed");
+       _exit(1);
+   };
+   
+   int fds[2];
+    io_fork(fds, func);
+    
+   if (_input_data) {
+       std::streamsize       pos;
+       std::array<char, 256> buffer{};
+       _input_data->read(buffer.data(), buffer.size());
+       while (*_input_data || (pos = _input_data->gcount()) != 0) {
+           if (write(fds[1], buffer.data(), buffer.size()) < 0) throw CtProcessError("Error while writing to output pipe");
+        
+           if (pos != 0) _input_data->read(buffer.data(), buffer.size());
+       }
+   }
+    close(fds[1]);
+    
+    std::array<char, 257> buff{};
+    while(true) {
+        auto read_retr = read(fds[0], buff.data(), buff.size() - 1);
+        if (read_retr > 0) {
+            output << buff.data();
+        } else if (read_retr == 0) {
+            // EOF
+            break;
+        } else {
+            throw CtProcessError(fmt::format("Error while reading from process; CODE: {}", errno));
+        }
+    }
+}
+
+
+
+void operator>>(CtProcess &process, std::ostream &output) {
+    process.run(output);
+}
+
+void CtProcess::run(std::ostream &output) {
+    run(_args, output);
+}
+
+
+

--- a/future/src/ct/ct_process.cc
+++ b/future/src/ct/ct_process.cc
@@ -22,6 +22,55 @@
 #include "ct_process.h"
 #include "ct_logging.h"
 #include <fmt/format.h>
+
+#if defined(__WIN32)
+#include <windows.h>
+
+
+void throw_with_last_error(std::string_view msg) {
+    auto err = GetLastError();
+    throw CtProcess::CtProcessError(fmt::format("{}; ERROR: {}", msg, err));
+}
+
+void create_child_process(std::string_view process_name, void* write_handle, void* read_handle)
+{
+    PROCESS_INFORMATION process_info;
+    ZeroMemory(&process_info, sizeof(PROCESS_INFORMATION));
+    
+    STARTUPINFO start_info;
+    ZeroMemory(&start_info, sizeof(STARTUPINFO));
+    
+    start_info.cb = sizeof(STARTUPINFO);
+    start_info.hStdError = write_handle;
+    start_info.hStdOutput = write_handle;
+    start_info.hStdInput = read_handle;
+    start_info.dwFlags |= STARTF_USESTDHANDLES;
+    
+    
+    std::vector<char> chs;
+    chs.reserve(process_name.size());
+    
+    for (auto ch : process_name) {
+        chs.emplace_back(ch);
+    }
+    
+    bool did_succeed = CreateProcess(nullptr, chs.data(), nullptr, nullptr, true, 0, nullptr, nullptr, &start_info, &process_info);
+    
+    if (!did_succeed) {
+        throw_with_last_error("Error occurred in CreateProcess");
+    }
+    
+    CloseHandle(process_info.hProcess);
+    CloseHandle(process_info.hThread);
+    
+    CloseHandle(write_handle);
+    CloseHandle(read_handle);
+    
+}
+
+
+
+#else
 #include <unistd.h>
 
 
@@ -52,18 +101,68 @@ pid_t io_fork(int fds[2], const std::function<void(int, int)>& func) {
     throw CtProcess::CtProcessError("fork() returned error code");
 }
 
+#endif  // IFDEF __WIN32
 
 void CtProcess::run(const std::vector<std::string>& args, std::ostream &output) {
     
     // The casts here are safe because the exec family do not modify their args, its just for compatibility
-    std::vector<char*> process_args;
-    process_args.emplace_back(const_cast<char*>(_process_name.c_str()));
-    for (const auto& arg : args) {
-        process_args.emplace_back(const_cast<char*>(arg.c_str()));
+    std::vector<char *> process_args;
+    process_args.emplace_back(const_cast<char *>(_process_name.c_str()));
+    for (const auto &arg : args) {
+        process_args.emplace_back(const_cast<char *>(arg.c_str()));
     }
     process_args.emplace_back(nullptr);
+
+#if defined(__WIN32)
+    SECURITY_ATTRIBUTES sec_attrs;
     
-   
+    spdlog::debug("Start of parent exe");
+    
+    sec_attrs.nLength              = sizeof(sec_attrs);
+    sec_attrs.bInheritHandle       = true;
+    sec_attrs.lpSecurityDescriptor = nullptr;
+    
+    HANDLE child_in_wd;
+    HANDLE child_in_rd;
+    HANDLE child_out_rd;
+    HANDLE child_out_wd;
+    
+    
+    if (!CreatePipe(&child_out_rd, &child_out_wd, &sec_attrs, 0)) {
+        throw_with_last_error("Failed to create output pipes for child");
+    }
+    
+    if (!SetHandleInformation(child_out_rd, HANDLE_FLAG_INHERIT, 0)) {
+        throw_with_last_error("Failed to set read handle inheritance for child");
+    }
+    
+    if (!CreatePipe(&child_in_rd, &child_in_wd, &sec_attrs, 0)) {
+        throw_with_last_error("Failed to create input pipes for child");
+    }
+    
+    if (!SetHandleInformation(child_in_wd, HANDLE_FLAG_INHERIT, 0)) {
+        throw_with_last_error("Failed to set handle inheritance for child stdin");
+    }
+    
+    create_child_process("echo", child_out_wd, child_in_rd);
+    
+    /*while(true) {
+        bool success = WriteFile(child_in_wd, )
+        
+        
+    }*/
+    DWORD                 dw_read;
+    std::array<char, 267> buff{};
+    
+    while (true) {
+        bool success = ReadFile(child_out_rd, buff.data(), buff.size() - 1, &dw_read, nullptr);
+        if (!success || dw_read == 0) break;
+        
+        spdlog::debug("GOT: {}", buff.data());
+        output << buff.data();
+    }
+    
+#else
    auto func = [process_args, this](int read_fs, int write_fs){
     
        dup2(write_fs, STDOUT_FILENO);
@@ -105,8 +204,8 @@ void CtProcess::run(const std::vector<std::string>& args, std::ostream &output) 
             throw CtProcessError(fmt::format("Error while reading from process; CODE: {}", errno));
         }
     }
+#endif // IFDEF __WIN32
 }
-
 
 
 void operator>>(CtProcess &process, std::ostream &output) {

--- a/future/src/ct/ct_process.h
+++ b/future/src/ct/ct_process.h
@@ -1,0 +1,64 @@
+/*
+ * ct_pandoc.h
+ *
+ * Copyright 2017-2020 Giuseppe Penone <giuspen@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#pragma once
+
+
+#include <string>
+#include <memory>
+#include <ostream>
+#include <istream>
+#include <vector>
+
+
+/**
+ * @brief Interface for executing external processes
+ * @class CtProcess
+ */
+class CtProcess {
+public:
+    /**
+     * @brief Thrown when an error occurs due to an external process
+     * @class CtProcessError
+     */
+    class CtProcessError: public std::runtime_error {
+    public:
+        using std::runtime_error::runtime_error;
+    };
+    
+    explicit CtProcess(std::string process_name) : _process_name(std::move(process_name)) {}
+
+    void args(std::vector<std::string> args) { _args = std::move(args); }
+    void append_arg(std::string arg) { _args.emplace_back(std::move(arg)); }
+    
+    constexpr void input(std::istream* input) { _input_data = input; }
+    
+    void run(const std::vector<std::string>&, std::ostream& output);
+    void run(std::ostream& output);
+    
+    
+    friend void operator>>(CtProcess& process, std::ostream& output);
+private:
+    std::string _process_name;
+    std::istream* _input_data = nullptr;
+    std::vector<std::string> _args;
+};
+

--- a/future/src/ct/ct_process.h
+++ b/future/src/ct/ct_process.h
@@ -1,5 +1,5 @@
 /*
- * ct_pandoc.h
+ * ct_process.h
  *
  * Copyright 2017-2020 Giuseppe Penone <giuspen@gmail.com>
  *


### PR DESCRIPTION
This implements some of #878, with the ability to import files by running the contents through Pandoc.

Currently it will only work if the pandoc executable is in the user's PATH. This is more or less an arbitrary restriction which just needs an option to be added to the preferences and used instead of the hard-coded `pandoc` but I think it is quite minor and maybe not needed.

It does work on windows using the win32 api, however I am getting compile + link times of 20+ minutes (just for ct_process) which I am not sure if is a problem with my computer or mingw being slow. 

Exporting will be next I think, but is going to be difficult to keep both cherrytree "native" formatting and whatever formatting pandoc applies. It may have to be done on a select text to export basis.