### PR TITLE
Set architecture to any

### DIFF
--- a/future/debian/control
+++ b/future/debian/control
@@ -21,7 +21,7 @@ Vcs-Git: https://github.com/giuspen/cherrytree.git
 Vcs-Browser: https://github.com/giuspen/cherrytree
 
 Package: cherrytree
-Architecture: amd64
+Architecture: any
 Depends:
  libgtkmm-3.0-1v5,
  libgtksourceviewmm-3.0-0v5,


### PR DESCRIPTION
This lets us build the package on arm64, armhf, armel and i386 instead
of just amd64.