### PR TITLE
Implement Table of Contents inserting for C++

### DIFF
--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -33,6 +33,7 @@
 #include <filesystem>
 
 class CtMainWin;
+struct TocEntry;
 class CtActions
 {
 public:
@@ -304,6 +305,7 @@ public:
                                    const Glib::ustring& link, const Glib::ustring& image_justification);
     void          image_insert_anchor(Gtk::TextIter iter_insert, const Glib::ustring& name, const Glib::ustring& image_justification);
 
+    void _insert_toc_at_pos(Glib::RefPtr<Gtk::TextBuffer> text_buffer, const std::vector<TocEntry>& entries);
 public:
     // edit actions
     void insert_spec_char_action(gunichar ch);

--- a/future/src/ct/ct_actions_edit.cc
+++ b/future/src/ct/ct_actions_edit.cc
@@ -232,7 +232,8 @@ void CtActions::anchor_handle()
     _anchor_edit_dialog(nullptr, _curr_buffer()->get_insert()->get_iter(), nullptr);
 }
 
-struct TocEntry {
+struct TocEntry 
+{
     std::string anchor_link;
     std::string text;
     bool is_node = false;
@@ -243,7 +244,8 @@ struct TocEntry {
 };
 
 
-std::optional<Glib::ustring> iter_in_tag(const Gtk::TextIter& iter, const Glib::ustring& tag) {
+std::optional<Glib::ustring> iter_in_tag(const Gtk::TextIter& iter, const Glib::ustring& tag) 
+{
     for (const auto& iter_tag : iter.get_tags()) {
         Glib::ustring tag_name;
         iter_tag->get_property("name", tag_name);
@@ -256,7 +258,8 @@ std::optional<Glib::ustring> iter_in_tag(const Gtk::TextIter& iter, const Glib::
 }
 
 
-void anchor_insert_if_missing(CtActions& actions, Gtk::TextIter insert_iter, const Glib::ustring& default_value) {
+void anchor_insert_if_missing(CtActions& actions, Gtk::TextIter insert_iter, const Glib::ustring& default_value) 
+{
     auto anchor = insert_iter.get_child_anchor();
     if (anchor) {
         return;
@@ -267,7 +270,8 @@ void anchor_insert_if_missing(CtActions& actions, Gtk::TextIter insert_iter, con
 }
 
 
-TocEntry find_toc_entries(CtActions& actions, CtTreeIter& node, int depth) {
+TocEntry find_toc_entries(CtActions& actions, CtTreeIter& node, int depth) 
+{
     int node_id = node.get_node_id();
     TocEntry entry(fmt::format("node {}", node_id), true, node.get_node_name(), depth);
 
@@ -319,7 +323,8 @@ TocEntry find_toc_entries(CtActions& actions, CtTreeIter& node, int depth) {
 }
 
 
-void CtActions::_insert_toc_at_pos(Glib::RefPtr<Gtk::TextBuffer> text_buffer, const std::vector<TocEntry>& entries) {
+void CtActions::_insert_toc_at_pos(Glib::RefPtr<Gtk::TextBuffer> text_buffer, const std::vector<TocEntry>& entries) 
+{
     for (const auto& entry : entries) {
         
         Glib::ustring bullet_char;
@@ -328,7 +333,7 @@ void CtActions::_insert_toc_at_pos(Glib::RefPtr<Gtk::TextBuffer> text_buffer, co
         if (entry.is_node) {
             bullet_char = bullets_list[0];
         } else {
-            int bullet_index = entry.h_level + 1;
+            CtStringSplittable::size_type bullet_index = entry.h_level + 1;
             if (bullet_index >= bullets_list.size()) {
                 bullet_index = bullets_list.size() - 1;
             }
@@ -355,7 +360,8 @@ void CtActions::_insert_toc_at_pos(Glib::RefPtr<Gtk::TextBuffer> text_buffer, co
     }
 }
 
-void find_toc_entries_and_children(std::vector<TocEntry>& entries, CtActions& actions, CtMainWin& main_win, CtTreeIter& node, int depth) {
+void find_toc_entries_and_children(std::vector<TocEntry>& entries, CtActions& actions, CtMainWin& main_win, CtTreeIter& node, int depth) 
+{
     auto txt_buff = node.get_node_text_buffer();
     main_win.get_tree_store().treeview_safe_set_cursor(&main_win.get_tree_view(), node);
     TocEntry entry = find_toc_entries(actions, node, depth);
@@ -396,6 +402,8 @@ void CtActions::toc_insert()
             find_toc_entries_and_children(entries, *this, *_pCtMainWin, sib, 0);
             ++sib;
         }
+    } else {
+        return;
     }
 
     _insert_toc_at_pos(curr_node.get_node_text_buffer(), entries);

--- a/future/src/ct/ct_splittable.h
+++ b/future/src/ct/ct_splittable.h
@@ -51,6 +51,8 @@ class CtSplittable
 {
     using vect_t = std::vector<ITEM_T>;
 public:
+    using size_type = typename vect_t::size_type;
+
     /**
      * @brief Swap two CtVectorProxy objects
      * @param first


### PR DESCRIPTION
This implements Table of Contents inserting for the C++ port.

I think this matches the behaviour of the python version 100%, it uses the same anchor structure for nodes (`h<level>-<num>`) and the same character set for the list bullets.

There is a bug which I noticed which causes a segfault if an anchor is removed and then another node is selected. This is a general issue with anchors in the C++ version I think since I get the same bug if I use "insert anchor".