### PR TITLE
Add CSV handling to CtTable in the C++ port

### DIFF
--- a/future/src/ct/ct_actions_others.cc
+++ b/future/src/ct/ct_actions_others.cc
@@ -679,7 +679,7 @@ void CtActions::table_export()
         curr_table_anchor->to_csv(outfile);
     } catch(std::exception& e) {
         spdlog::error("Exception caught while exporting table: {}", e.what());
-        CtDialogs::error_dialog("Exception occured while exporting table, see log for details");
+        CtDialogs::error_dialog("Exception occured while exporting table, see log for details", *_pCtMainWin);
     }
 }
 

--- a/future/src/ct/ct_actions_others.cc
+++ b/future/src/ct/ct_actions_others.cc
@@ -658,23 +658,29 @@ void CtActions::table_edit_properties()
 }
 
 void CtActions::table_export()
-{    
-    // todo: find good csv lib
-    return;
-
-    /*
-    CtDialogs::file_select_args args = {
-        .pParentWin=_pCtMainWin,
-        .curr_folder=_pCtMainWin->get_ct_config()->pickDirCsv,
-        .curr_file_name="",
-        .filter_name=_("CSV File"),
-        .filter_pattern={"*.csv"}
-    };
+{     
+    CtDialogs::file_select_args args(_pCtMainWin); 
+    args.curr_folder=_pCtMainWin->get_ct_config()->pickDirCsv;
+    args.curr_file_name="";
+    args.filter_name=_("CSV File");
+    args.filter_pattern={"*.csv"};
+    
+   
     Glib::ustring filename = CtDialogs::file_save_as_dialog(args);
     if (filename.empty()) return;
-    if (str::endswith(filename, ".csv")) filename += ".csv";
+    if (!str::endswith(filename, ".csv")) filename += ".csv";
     _pCtMainWin->get_ct_config()->pickDirCsv = Glib::path_get_dirname(filename);
-*/
+
+    try {
+        std::ofstream outfile;
+        outfile.exceptions(std::ios::failbit);
+        outfile.open(filename);
+
+        curr_table_anchor->to_csv(outfile);
+    } catch(std::exception& e) {
+        spdlog::error("Exception caught while exporting table: {}", e.what());
+        CtDialogs::error_dialog("Exception occured while exporting table, see log for details");
+    }
 }
 
 // Anchor Edit Dialog

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -39,6 +39,93 @@
     #include <shellapi.h>
 #endif
 
+
+namespace CtCSV {
+CtStringTable table_from_csv(std::istream& input)
+{
+    // Disable exceptions 
+    auto except_bit_before = input.exceptions();
+    input.exceptions(std::ios::goodbit);
+
+    CtStringTable tbl_matrix;
+    std::string line;
+    
+    std::array<char, 256> chunk_buff{};
+    input.read(chunk_buff.data(), chunk_buff.size());
+    std::streamsize pos;
+    std::vector<std::string> tbl_row;
+    std::ostringstream cell_buff;  
+    constexpr char cell_tag = '"';
+    constexpr char cell_sep = ',';
+    constexpr char esc = '\\';
+    bool in_string = false;
+    bool escape_next = false;
+    while (input || (pos = input.gcount()) != 0) {    
+        for (auto ch : chunk_buff) {
+            
+            if (ch == '\0') break;
+            if (escape_next) {
+                escape_next = false;
+                cell_buff << ch;
+                continue;
+            }
+            if (ch == esc ) {
+                // `\` escapes anything `"` escapes a quote
+                escape_next = true;
+                continue;
+            }
+            bool is_newline = ch == '\n';
+            if ((ch == cell_sep || is_newline) && !in_string) {
+                // Close the cell
+                tbl_row.emplace_back(cell_buff.str());
+                std::ostringstream tmp_buff;
+                cell_buff.swap(tmp_buff);
+                
+                if (is_newline) {
+                    tbl_matrix.emplace_back(tbl_row);
+                    tbl_row.clear();
+                    continue;
+                }
+
+            } else if (ch == cell_tag) {
+                in_string = !in_string;
+            } else {
+                cell_buff << ch;
+            } 
+        }
+
+        if (pos != 0) input.read(chunk_buff.data(), chunk_buff.size());
+    }
+
+    // Reset exception bit
+    input.exceptions(except_bit_before);
+    return tbl_matrix;
+}
+
+std::string escape_to_csv(const std::string& input) {
+    std::ostringstream out;
+    for (const auto ch : input) {
+        if (ch == '"') {
+            out << '\\';
+        }
+        out << ch;
+    }
+    return out.str();
+}
+
+void table_to_csv(const CtStringTable& table, std::ostream& output) {
+    for (const auto& row : table) {
+        for (const auto& cell : row) {
+            output << fmt::format("\"{}\"", escape_to_csv(cell));
+
+            if (cell != row.back()) output << ",";
+        }
+        output << "\n";
+    }
+}
+
+}
+
 std::string CtMiscUtil::get_ct_language()
 {
     std::string retLang{CtConst::LANG_DEFAULT};

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -37,6 +37,13 @@ template<class F> auto scope_guard(F&& f) {
     return std::unique_ptr<void, typename std::decay<F>::type>{(void*)1, std::forward<F>(f)};
 }
 
+
+namespace CtCSV {
+    using CtStringTable = std::vector<std::vector<std::string>>;
+    CtStringTable table_from_csv(std::istream& input);
+    void table_to_csv(const CtStringTable& table, std::ostream& output);
+}
+
 namespace CtMiscUtil {
 
 std::string get_ct_language();

--- a/future/src/ct/ct_table.h
+++ b/future/src/ct/ct_table.h
@@ -48,10 +48,24 @@ public:
             const std::string& justification);
     virtual ~CtTable();
 
+    /**
+     * @brief Build a table from csv
+     * The input csv should be compatable with the excel csv format
+     * @param input 
+     * @return CtTable 
+     */
+    static std::unique_ptr<CtTable> from_csv(std::istream& input, CtMainWin* main_win, const Glib::ustring& syntax_highlighting, int col_min, int col_max, int offset, const Glib::ustring& justification);
+
     void apply_width_height(const int /*parentTextWidth*/) override {}
     void apply_syntax_highlighting() override;
     void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment) override;
     bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) override;
+    /**
+     * @brief Serialise to csv format
+     * The output CSV excel csv with double quotes around cells and newlines for each record
+     * @param output 
+     */
+    void to_csv(std::ostream& output) const;
     void set_modified_false() override;
     CtAnchWidgType get_type() override { return CtAnchWidgType::Table; }
     std::shared_ptr<CtAnchoredWidgetState> get_state() override;

--- a/future/src/ct/ct_table.h
+++ b/future/src/ct/ct_table.h
@@ -23,6 +23,15 @@
 
 #include "ct_codebox.h"
 #include "ct_widgets.h"
+#include <ostream>
+#include <istream>
+
+namespace CtCSV {
+    using CtStringTable = std::vector<std::vector<std::string>>;
+    CtStringTable table_from_csv(std::istream& input);
+    void table_to_csv(const CtStringTable& table, std::ostream& output);
+}
+
 
 class CtTextCell;
 class CtTableCell : public CtTextCell, public Gtk::EventBox
@@ -36,7 +45,6 @@ public:
 
 typedef std::vector<CtTableCell*> CtTableRow;
 typedef std::vector<CtTableRow> CtTableMatrix;
-
 class CtTable : public CtAnchoredWidget
 {
 public:
@@ -73,7 +81,6 @@ public:
     const CtTableMatrix& get_table_matrix() { return _tableMatrix; }
     int get_col_max() { return _colMax; }
     int get_col_min() { return _colMin; }
-
 public:
     int  current_row() { return _currentRow < (int)_tableMatrix.size() ? _currentRow : 0; }
     int  current_column() { return _currentColumn < (int)_tableMatrix[0].size() ? _currentColumn : 0; }

--- a/future/src/ct/ct_table.h
+++ b/future/src/ct/ct_table.h
@@ -26,12 +26,6 @@
 #include <ostream>
 #include <istream>
 
-namespace CtCSV {
-    using CtStringTable = std::vector<std::vector<std::string>>;
-    CtStringTable table_from_csv(std::istream& input);
-    void table_to_csv(const CtStringTable& table, std::ostream& output);
-}
-
 
 class CtTextCell;
 class CtTableCell : public CtTextCell, public Gtk::EventBox


### PR DESCRIPTION
Supports excel style csv with comma field delims and double quotes for strings.

The reason it for the ugly code in `from_csv` where it reads the data in chunks is because it needs to be able to handle newlines in cells