### PR TITLE
Feature improved markdown

### DIFF
--- a/future/src/ct/ct_imports.cc
+++ b/future/src/ct/ct_imports.cc
@@ -44,6 +44,31 @@ xmlpp::Element* codebox_to_xml(xmlpp::Element* parent, const Glib::ustring& just
     p_codebox_node->set_attribute("show_line_numbers", std::to_string(show_line_numbers));
     return p_codebox_node;
 }
+
+void table_row_to_xml(const std::vector<std::string>& row, xmlpp::Element* parent) {
+    xmlpp::Element* row_element = parent->add_child("row");
+    for (const auto& cell : row) {
+        xmlpp::Element* cell_element = row_element->add_child("cell");
+        cell_element->set_child_text(cell);
+    }
+}
+
+xmlpp::Element* table_to_xml(const std::vector<std::vector<std::string>>& matrix, xmlpp::Element* parent, int char_offset, Glib::ustring justification, int col_min, int col_max)
+{
+    xmlpp::Element* tbl_node = parent->add_child("table");
+    tbl_node->set_attribute("char_offset", std::to_string(char_offset));
+    tbl_node->set_attribute(CtConst::TAG_JUSTIFICATION, justification);
+    tbl_node->set_attribute("col_min", std::to_string(col_min));
+    tbl_node->set_attribute("col_max", std::to_string(col_max));
+    
+    // Header goes at end
+    for (auto row_iter = matrix.cbegin() + 1; row_iter != matrix.cend(); ++row_iter) {
+        table_row_to_xml(*row_iter, tbl_node);
+    }
+    table_row_to_xml(matrix.front(), tbl_node);
+    
+    return tbl_node;
+}
 }
 
 

--- a/future/src/ct/ct_imports.cc
+++ b/future/src/ct/ct_imports.cc
@@ -32,7 +32,8 @@ namespace fs = std::filesystem;
 
 namespace CtXML {
 
-xmlpp::Element* codebox_to_xml(xmlpp::Element* parent, const Glib::ustring& justification, int char_offset, int frame_width, int frame_height, int width_in_pixels, const Glib::ustring& syntax_highlighting, bool highlight_brackets, bool show_line_numbers) {
+xmlpp::Element* codebox_to_xml(xmlpp::Element* parent, const Glib::ustring& justification, int char_offset, int frame_width, int frame_height, int width_in_pixels, const Glib::ustring& syntax_highlighting, bool highlight_brackets, bool show_line_numbers) 
+{
     xmlpp::Element* p_codebox_node = parent->add_child("codebox");
     p_codebox_node->set_attribute("char_offset", std::to_string(char_offset));
     p_codebox_node->set_attribute(CtConst::TAG_JUSTIFICATION, justification);
@@ -45,7 +46,8 @@ xmlpp::Element* codebox_to_xml(xmlpp::Element* parent, const Glib::ustring& just
     return p_codebox_node;
 }
 
-void table_row_to_xml(const std::vector<std::string>& row, xmlpp::Element* parent) {
+void table_row_to_xml(const std::vector<std::string>& row, xmlpp::Element* parent) 
+{
     xmlpp::Element* row_element = parent->add_child("row");
     for (const auto& cell : row) {
         xmlpp::Element* cell_element = row_element->add_child("cell");
@@ -70,7 +72,8 @@ xmlpp::Element* table_to_xml(const std::vector<std::vector<std::string>>& matrix
     return tbl_node;
 }
 
-xmlpp::Element *image_to_xml(xmlpp::Element *parent, const std::string &path, int char_offset, const Glib::ustring &justification, CtStatusBar* status_bar /* = nullptr */) {
+xmlpp::Element *image_to_xml(xmlpp::Element *parent, const std::string &path, int char_offset, const Glib::ustring &justification, CtStatusBar* status_bar /* = nullptr */) 
+{
     Glib::RefPtr<Gdk::Pixbuf> pixbuf;
     
     // Get uri type

--- a/future/src/ct/ct_imports.cc
+++ b/future/src/ct/ct_imports.cc
@@ -30,6 +30,23 @@
 
 namespace fs = std::filesystem;
 
+namespace CtXML {
+
+xmlpp::Element* codebox_to_xml(xmlpp::Element* parent, const Glib::ustring& justification, int char_offset, int frame_width, int frame_height, int width_in_pixels, const Glib::ustring& syntax_highlighting, bool highlight_brackets, bool show_line_numbers) {
+    xmlpp::Element* p_codebox_node = parent->add_child("codebox");
+    p_codebox_node->set_attribute("char_offset", std::to_string(char_offset));
+    p_codebox_node->set_attribute(CtConst::TAG_JUSTIFICATION, justification);
+    p_codebox_node->set_attribute("frame_width", std::to_string(frame_width));
+    p_codebox_node->set_attribute("frame_height", std::to_string(frame_height));
+    p_codebox_node->set_attribute("width_in_pixels", std::to_string(width_in_pixels));
+    p_codebox_node->set_attribute("syntax_highlighting", syntax_highlighting);
+    p_codebox_node->set_attribute("highlight_brackets", std::to_string(highlight_brackets));
+    p_codebox_node->set_attribute("show_line_numbers", std::to_string(show_line_numbers));
+    return p_codebox_node;
+}
+}
+
+
 const std::set<std::string> CtHtml2Xml::HTML_A_TAGS{"p", "b", "i", "u", "s", CtConst::TAG_PROP_VAL_H1,
             CtConst::TAG_PROP_VAL_H2, CtConst::TAG_PROP_VAL_H3, "span", "font"};
 

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -65,10 +65,12 @@ namespace CtImports {
 
 }
 
+struct CtStatusBar;
 
 namespace CtXML {
 xmlpp::Element* codebox_to_xml(xmlpp::Element* parent, const Glib::ustring& justification, int char_offset, int frame_width, int frame_height, int width_in_pixels, const Glib::ustring& syntax_highlighting, bool highlight_brackets, bool show_line_numbers);
 xmlpp::Element* table_to_xml(const std::vector<std::vector<std::string>> &matrix, xmlpp::Element *parent, int char_offset, Glib::ustring justification, int col_min, int col_max);
+xmlpp::Element* image_to_xml(xmlpp::Element* parent, const std::string& path, int char_offset, const Glib::ustring& justification, CtStatusBar* status_bar = nullptr);
 
 } // CtXML
 
@@ -85,7 +87,6 @@ public:
 
 // pygtk: HTMLHandler
 class CtConfig;
-struct CtStatusBar;
 class CtHtml2Xml : public CtHtmlParser
 {
 private:

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -258,7 +258,11 @@ protected:
 
     void _init_tokens() override;
     
-    bool _in_link = false;
+    const token_schema* _last_encountered_token = nullptr;
+    std::ostringstream _free_text;
+    
+    void _place_free_text();
+    void _add_scale_to_last(int level);
 public:
     CtMDParser(CtConfig* config) : CtParser(config), CtTextParser(config) {}
 

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -27,8 +27,11 @@
 #include <glibmm/ustring.h>
 #include <libxml2/libxml/HTMLparser.h>
 #include <libxml++/libxml++.h>
+#include <queue>
 
-
+namespace {
+using TableMatrx = std::queue<std::queue<std::string>>;
+}
 
 struct ct_imported_node
 {
@@ -65,6 +68,7 @@ namespace CtImports {
 
 namespace CtXML {
 xmlpp::Element* codebox_to_xml(xmlpp::Element* parent, const Glib::ustring& justification, int char_offset, int frame_width, int frame_height, int width_in_pixels, const Glib::ustring& syntax_highlighting, bool highlight_brackets, bool show_line_numbers);
+xmlpp::Element* table_to_xml(const std::vector<std::vector<std::string>> &matrix, xmlpp::Element *parent, int char_offset, Glib::ustring justification, int col_min, int col_max);
 
 } // CtXML
 
@@ -266,6 +270,16 @@ protected:
     
     void _place_free_text();
     void _add_scale_to_last(int level);
+    void _add_table_cell(std::string text);
+    /// Add the current table row to the table
+    void _pop_table_row();
+    /// Add the current table to the output xml
+    void _pop_table();
+    
+    using TableRow = std::vector<std::string>;
+    using TableMatrix = std::vector<TableRow>;
+    TableRow _current_table_row;
+    TableMatrix _current_table;
 public:
     CtMDParser(CtConfig* config) : CtParser(config), CtTextParser(config) {}
 

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -63,7 +63,10 @@ namespace CtImports {
 }
 
 
+namespace CtXML {
+xmlpp::Element* codebox_to_xml(xmlpp::Element* parent, const Glib::ustring& justification, int char_offset, int frame_width, int frame_height, int width_in_pixels, const Glib::ustring& syntax_highlighting, bool highlight_brackets, bool show_line_numbers);
 
+} // CtXML
 
 /**
  * @class CtImportException

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -33,6 +33,7 @@
 #include <glib/gstdio.h> // to get stats
 #include <fstream>
 #include <curl/curl.h>
+#include <filesystem>
 
 #ifdef _WIN32
     #include <windows.h>
@@ -311,6 +312,16 @@ bool CtMiscUtil::mime_type_contains(const std::string &filepath, const std::stri
     std::string mime_type = p_mime_type.get();
 
     return mime_type.find(type) != std::string::npos;
+}
+
+namespace CtMiscUtil {
+URI_TYPE get_uri_type(const std::string &uri) {
+    constexpr std::array<std::string_view, 2> http_ids = {"https://", "http://"};
+    constexpr std::array<std::string_view, 2> fs_ids = {"/", "C:\\\\"};
+    if (str::startswith_any(uri, http_ids)) return URI_TYPE::WEB_URL;
+    else if (str::startswith_any(uri, fs_ids) || std::filesystem::exists(uri)) return URI_TYPE::LOCAL_FILEPATH;
+    else return URI_TYPE::UNKNOWN;
+}
 }
 
 // Returns True if the characters compose a camel case word

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -75,6 +75,9 @@ Gtk::BuiltinIconSize getIconSize(int size);
  */
 bool mime_type_contains(const std::string& filepath, const std::string& type);
 
+enum class URI_TYPE { LOCAL_FILEPATH, WEB_URL, UNKNOWN };
+URI_TYPE get_uri_type(const std::string& uri);
+
 } // namespace CtMiscUtil
 
 namespace CtTextIterUtil {

--- a/future/src/ct/ct_parser.cc
+++ b/future/src/ct/ct_parser.cc
@@ -34,7 +34,8 @@ void CtParser::wipe()
     _current_element = nullptr;
 }
 
-void CtParser::_add_image(const std::string& path) noexcept {
+void CtParser::_add_image(const std::string& path) noexcept 
+{
     try {
         CtXML::image_to_xml(_current_element->get_parent(), path, 0, CtConst::TAG_PROP_VAL_LEFT);
         _close_current_tag();
@@ -144,7 +145,8 @@ void CtParser::_close_current_tag()
     }
 }
 
-void CtParser::_add_newline() {
+void CtParser::_add_newline() 
+{
     // Add a newline, if tags are empty no need to close the current tag
     _add_text(CtConst::CHAR_NEWLINE, !_open_tags.empty());
 }
@@ -164,7 +166,8 @@ void CtParser::_add_scale_tag(int level, std::optional<std::string> data)
 }
 
 
-void CtParser::_add_tag_data(std::string_view tag, std::string data) {
+void CtParser::_add_tag_data(std::string_view tag, std::string data) 
+{
     bool do_close = _open_tags[tag];
     
     _add_text(std::move(data), do_close);
@@ -172,7 +175,8 @@ void CtParser::_add_tag_data(std::string_view tag, std::string data) {
 }
 
 
-void CtParser::_build_token_maps() {
+void CtParser::_build_token_maps() 
+{
     if (_open_tokens_map.empty() || _close_tokens_map.empty()) {
         _init_tokens();
         

--- a/future/src/ct/ct_parser.cc
+++ b/future/src/ct/ct_parser.cc
@@ -23,6 +23,7 @@
 #include "ct_const.h"
 #include "ct_config.h"
 #include "ct_misc_utils.h"
+#include "ct_imports.h"
 #include <fmt/fmt.h>
 #include <iostream>
 
@@ -44,6 +45,14 @@ void CtParser::_add_subscript_tag(std::optional<std::string> text)
     _current_element->set_attribute(CtConst::TAG_SCALE, CtConst::TAG_PROP_VAL_SUB);
     
     if (text) _add_text(*text);
+}
+
+void CtParser::_add_codebox(const std::string& language, const std::string& text)
+{
+    _close_current_tag();
+    xmlpp::Element* p_codebox_node = CtXML::codebox_to_xml(_current_element->get_parent(), CtConst::TAG_PROP_VAL_LEFT, 0, 300, 150, true, language, false, false);
+    p_codebox_node->add_child_text(text);
+    _close_current_tag();
 }
 
 void CtParser::_add_ordered_list(unsigned int level, const std::string &data)

--- a/future/src/ct/ct_parser.cc
+++ b/future/src/ct/ct_parser.cc
@@ -185,6 +185,11 @@ void CtParser::_build_token_maps() {
 }
 
 
+void CtParser::_add_table(const std::vector<std::vector<std::string>>& table_matrix)
+{
+    CtXML::table_to_xml(table_matrix, _current_element->get_parent(), 0, CtConst::TAG_PROP_VAL_LEFT, 40, 400);
+    _close_current_tag();
+}
 
 
 void CtHtmlParser::feed(const std::string& html)

--- a/future/src/ct/ct_parser.cc
+++ b/future/src/ct/ct_parser.cc
@@ -24,6 +24,7 @@
 #include "ct_config.h"
 #include "ct_misc_utils.h"
 #include "ct_imports.h"
+#include "ct_logging.h"
 #include <fmt/fmt.h>
 #include <iostream>
 
@@ -31,6 +32,15 @@ void CtParser::wipe()
 { 
     _document = std::make_unique<xmlpp::Document>();
     _current_element = nullptr;
+}
+
+void CtParser::_add_image(const std::string& path) noexcept {
+    try {
+        CtXML::image_to_xml(_current_element->get_parent(), path, 0, CtConst::TAG_PROP_VAL_LEFT);
+        _close_current_tag();
+    } catch(std::exception& e) {
+        spdlog::error("Exception occured while adding image: {}", e.what());
+    }
 }
 
 void CtParser::_add_superscript_tag(std::optional<std::string> text)

--- a/future/src/ct/ct_parser.cc
+++ b/future/src/ct/ct_parser.cc
@@ -109,8 +109,10 @@ void CtParser::_add_text(std::string text, bool close_tag /* = true */)
         auto curr_text = _current_element->get_child_text();
         if (!curr_text) _current_element->set_child_text(std::move(text));
         else curr_text->set_content(curr_text->get_content() + std::move(text));
-    
-        if (close_tag) _close_current_tag();
+        if (close_tag) {
+            _last_element = _current_element;
+            _close_current_tag();
+        }
     }
 }
 

--- a/future/src/ct/ct_parser.cc
+++ b/future/src/ct/ct_parser.cc
@@ -83,6 +83,12 @@ void CtParser::_add_weight_tag(const Glib::ustring& level, std::optional<std::st
     }
 }
 
+void CtParser::_add_monospace_tag(std::optional<std::string> text)
+{
+    _current_element->set_attribute("family", "monospace");
+    if (text) _add_text(*text, false);
+}
+
 void CtParser::_add_link(const std::string& text)
 {
     auto val = CtStrUtil::get_internal_link_from_http_url(text);

--- a/future/src/ct/ct_parser.h
+++ b/future/src/ct/ct_parser.h
@@ -112,6 +112,7 @@ protected:
     void _add_text(std::string text, bool close_tag = true);
     void _close_current_tag();
     void _add_newline();
+    void _add_monospace_tag(std::optional<std::string> text);
     void _add_tag_data(std::string_view, std::string data);
     
     [[nodiscard]] constexpr bool _tag_empty() const
@@ -188,7 +189,7 @@ protected:
     std::vector<std::string> _tokenize(const std::string& text);
 
 private:
-    std::unordered_set<char> _possible_tokens;
+    std::unordered_map<char, std::vector<std::string>> _possible_tokens;
 
 public:
     using CtParser::CtParser;

--- a/future/src/ct/ct_parser.h
+++ b/future/src/ct/ct_parser.h
@@ -116,6 +116,7 @@ protected:
     void _add_monospace_tag(std::optional<std::string> text);
     void _add_tag_data(std::string_view, std::string data);
     void _add_codebox(const std::string& language, const std::string& text);
+    void _add_table(const std::vector<std::vector<std::string>>& table_matrix);
     
     [[nodiscard]] constexpr bool _tag_empty() const
     {

--- a/future/src/ct/ct_parser.h
+++ b/future/src/ct/ct_parser.h
@@ -115,6 +115,7 @@ protected:
     void _add_newline();
     void _add_monospace_tag(std::optional<std::string> text);
     void _add_tag_data(std::string_view, std::string data);
+    void _add_codebox(const std::string& language, const std::string& text);
     
     [[nodiscard]] constexpr bool _tag_empty() const
     {

--- a/future/src/ct/ct_parser.h
+++ b/future/src/ct/ct_parser.h
@@ -94,6 +94,7 @@ protected:
     
     // XML generation
     xmlpp::Element* _current_element = nullptr;
+    xmlpp::Element* _last_element = nullptr;
     std::unique_ptr<xmlpp::Document> _document{std::make_unique<xmlpp::Document>()};
     std::unordered_map<std::string_view, bool> _open_tags;
     

--- a/future/src/ct/ct_parser.h
+++ b/future/src/ct/ct_parser.h
@@ -117,6 +117,7 @@ protected:
     void _add_tag_data(std::string_view, std::string data);
     void _add_codebox(const std::string& language, const std::string& text);
     void _add_table(const std::vector<std::vector<std::string>>& table_matrix);
+    void _add_image(const std::string& path) noexcept;
     
     [[nodiscard]] constexpr bool _tag_empty() const
     {

--- a/future/src/ct/ct_parser_md.cc
+++ b/future/src/ct/ct_parser_md.cc
@@ -110,6 +110,10 @@ void CtMDParser::_init_tokens()
                         if ((_last_encountered_token->open_tag == "[") && (_last_encountered_token->close_tag == "]")) {
                             _add_link(data);
                             return;
+                        } else if ((_last_encountered_token->open_tag == "![") && (_last_encountered_token->close_tag == "]")) {
+                            // Image link
+                            _add_image(data);
+                            return;
                         }
                     }
                     // Just text in brackets
@@ -181,7 +185,9 @@ void CtMDParser::_init_tokens()
                 {"| -", true, false, [](const std::string& data){
                     // Since cherrytree tables don't use headers, this is not needed
                     spdlog::debug("Got divider: {}", data);
-                }, "- |\n"}
+                }, "- |\n"},
+                // Image link
+                {"![", true, false, [this](const std::string&){}, "]"}
         
         };
     }

--- a/future/src/ct/ct_parser_md.cc
+++ b/future/src/ct/ct_parser_md.cc
@@ -28,32 +28,6 @@
 void CtMDParser::_add_scale_to_last(int level) {
     xmlpp::Element* curr_tmp = _current_element;
     if (_last_element) _current_element = _last_element;
-   /* xmlpp::TextNode* curr_text = _current_element->get_child_text();*/
-    //if (curr_text) {
-        //// Seperate the last line
-        //Glib::ustring curr_txt = curr_text->get_content();
-        //auto iter = curr_txt.rbegin();
-        //bool found_nl = false;
-        //while (iter != curr_txt.rend()) {
-            //if (*iter == '\n') { 
-                //if (found_nl) {
-                    //break;
-                //} else {
-                    //found_nl = true;
-                //}    
-            //}
-            //++iter;
-        //}
-        //if (iter != curr_txt.rbegin()) {
-            //Glib::ustring last_txt(iter.base(), curr_txt.end());
-            //Glib::ustring prev_txt(curr_txt.begin(), iter.base());
-            //_current_element->set_child_text(prev_txt);
-            //_add_scale_tag(level, last_txt);
-            //return;
-        //}
-    //}
-
-
 
     _add_scale_tag(level, std::nullopt);
     _current_element = curr_tmp;
@@ -193,7 +167,8 @@ void CtMDParser::_init_tokens()
     }
 }
 
-void CtMDParser::_place_free_text() {
+void CtMDParser::_place_free_text() 
+{
     std::string free_txt = _free_text.str();
     if (!free_txt.empty()) {
         auto iter = free_txt.crbegin();
@@ -250,14 +225,14 @@ void CtMDParser::feed(std::istream& stream)
             _last_encountered_token = iter->first;
         }
         _place_free_text();
-        //if (!stream.eof()) _add_newline();
     } catch (std::exception& e) {
         spdlog::error("Exception while parsing line: '{}': {}", line, e.what());
     }
     
 }
 
-void CtMDParser::_add_table_cell(std::string text) {
+void CtMDParser::_add_table_cell(std::string text) 
+{
     if (!text.empty()) {
         // Parse it to see if a cell or end of row
         char last_ch = text.back();
@@ -274,12 +249,14 @@ void CtMDParser::_add_table_cell(std::string text) {
     }
 }
 
-void CtMDParser::_pop_table() {
+void CtMDParser::_pop_table() 
+{
     _add_table(_current_table);
     _current_table.clear();
 }
 
-void CtMDParser::_pop_table_row() {
+void CtMDParser::_pop_table_row() 
+{
     _current_table.emplace_back(_current_table_row);
     _current_table_row.clear();
 }

--- a/future/src/ct/ct_parser_md.cc
+++ b/future/src/ct/ct_parser_md.cc
@@ -28,6 +28,33 @@
 void CtMDParser::_add_scale_to_last(int level) {
     xmlpp::Element* curr_tmp = _current_element;
     if (_last_element) _current_element = _last_element;
+   /* xmlpp::TextNode* curr_text = _current_element->get_child_text();*/
+    //if (curr_text) {
+        //// Seperate the last line
+        //Glib::ustring curr_txt = curr_text->get_content();
+        //auto iter = curr_txt.rbegin();
+        //bool found_nl = false;
+        //while (iter != curr_txt.rend()) {
+            //if (*iter == '\n') { 
+                //if (found_nl) {
+                    //break;
+                //} else {
+                    //found_nl = true;
+                //}    
+            //}
+            //++iter;
+        //}
+        //if (iter != curr_txt.rbegin()) {
+            //Glib::ustring last_txt(iter.base(), curr_txt.end());
+            //Glib::ustring prev_txt(curr_txt.begin(), iter.base());
+            //_current_element->set_child_text(prev_txt);
+            //_add_scale_tag(level, last_txt);
+            //return;
+        //}
+    //}
+
+
+
     _add_scale_tag(level, std::nullopt);
     _current_element = curr_tmp;
 }
@@ -36,9 +63,25 @@ void CtMDParser::_init_tokens()
 {
     if (_token_schemas.empty()) {
         auto add_codebox = [this](const std::string& data) {
-            spdlog::debug("CODEBOX: {}", data);
+            auto data_iter = data.begin();
+            while (data_iter != data.end() && *data_iter != '\n') {
+                ++data_iter;
+            }
+            std::string text(data_iter, data.end());
+            std::string lang;
+            if (data_iter != data.begin()) {
+                lang.append(data.begin(), data_iter);
+
+            }
+            spdlog::debug("CODEBOX: {}, lang: {}", text, lang);
+            _add_codebox(lang, text);
+            
+
         };
         _token_schemas = {
+                /*{"   ", true, false, [this](const std::string& data){
+                    ++_list_level;
+                }, " "},*/
                 // Bold
                 {"__", true,  true,  [this](const std::string &data) {
                     _add_weight_tag(CtConst::TAG_PROP_VAL_HEAVY, data);
@@ -85,11 +128,13 @@ void CtMDParser::_init_tokens()
                 {"```", true, true, add_codebox, "```", true},
                 // List
                 {"* ", true, false, [this](const std::string &data) {
-                    _add_list(0, data);
+                    _add_list(_list_level, data + "\n");
+                    _list_level = 0;
                 }, "\n"},
                 // Also list
-                {"- ", true, false, [this](const std::string& data){
-                    _add_list(0, data);
+                {"\n- ", true, false, [this](const std::string& data){
+                    _add_list(_list_level, data + "\n");
+                    _list_level = 0;
                 }, "\n"},
                 // Strikethrough
                 {"~~", true,  true,  [this](const std::string &data) {
@@ -98,6 +143,7 @@ void CtMDParser::_init_tokens()
                 // Headers (h1, h2, etc)
                 {"#",  true, false, [this](const std::string &data) {
                     auto tag_num = 1;
+                    spdlog::debug("DATA: {}", data);
                     auto iter    = data.begin();
                     while (*iter == '#') {
                         ++tag_num;
@@ -115,22 +161,22 @@ void CtMDParser::_init_tokens()
                         str.replace(str.begin(), str.begin() + 1, "");
                     }
                     _close_current_tag();
-                    _add_scale_tag(tag_num, str);
-                }, "\n", true},
+                    _add_scale_tag(tag_num, str + "\n");
+                }, "\n"},
                 // H1
-                {"==", true, false, [this](const std::string&){
+                {"\n==", true, false, [this](const std::string&){
                     _add_scale_to_last(1);
+                    _add_newline();
                 }, "\n"},
                 // H2
-                {"----", true, false, [this](const std::string&){
+                {"\n----", true, false, [this](const std::string&){
                     _add_scale_to_last(2);
+                    _add_newline();
                 }, "\n"},
                 // Horizontal divider
-                {"---", true, false, [this](const std::string&){
-                    _add_text(_pCtConfig->hRule, true);
-                }, "\n"},
                 {"***\n", true, false, [this](const std::string&){
-                    _add_text(_pCtConfig->hRule, true);          
+                    _add_text(_pCtConfig->hRule + "\n", true);
+                    _add_newline();
                 }, " "}
         
         };
@@ -140,10 +186,20 @@ void CtMDParser::_init_tokens()
 void CtMDParser::_place_free_text() {
     std::string free_txt = _free_text.str();
     if (!free_txt.empty()) {
-        _add_text(free_txt);
+        bool found_nl = false;
+        auto iter = free_txt.crbegin();
+        for (;iter != free_txt.crend(); ++iter) {
+            if (*iter == '\n') break;
+        }
+        std::string last_line(iter.base(), free_txt.cend());
+        std::string other_txt(free_txt.cbegin(), iter.base());
+        spdlog::debug("ORIG: {}; last_line: {}; other: {}", free_txt, last_line, other_txt); 
+        _add_text(other_txt);
+        _add_text(last_line); // This may be neeeded for headers
+
+        std::ostringstream tmp_ss;
+        _free_text.swap(tmp_ss);
     }
-    std::ostringstream tmp_ss;
-    _free_text.swap(tmp_ss);
 }
 
 void CtMDParser::feed(std::istream& stream)

--- a/future/src/ct/ct_parser_md.cc
+++ b/future/src/ct/ct_parser_md.cc
@@ -33,6 +33,15 @@ void CtMDParser::_init_tokens()
                 {"__", true,  true,  [this](const std::string &data) {
                     _add_italic_tag(data);
                 }},
+                // Italic
+                {"*", true, true, [this](const std::string& data){
+                    _add_italic_tag(data);
+                }},
+                // Bold and italic
+                {"***", true, true, [this](const std::string& data){
+                    _add_italic_tag(data);
+                    _add_weight_tag(CtConst::TAG_PROP_VAL_HEAVY, std::nullopt);
+                }},
                 // Bold
                 {"**", true,  true,  [this](const std::string &data) {
                     _add_weight_tag(CtConst::TAG_PROP_VAL_HEAVY, data);
@@ -53,6 +62,10 @@ void CtMDParser::_init_tokens()
                         _add_text("(" + data + ")");
                     }
                 }, ")", true},
+                // Monospace
+                {"`", true, true, [this](const std::string& data){
+                    _add_monospace_tag(data);
+                }},
                 // List
                 {"* ", false, false, [this](const std::string &data) {
                     _add_list(0, data);

--- a/future/src/ct/ct_parser_text.cc
+++ b/future/src/ct/ct_parser_text.cc
@@ -73,7 +73,11 @@ std::vector<std::string> CtTextParser::_tokenize(const std::string& text)
     if (_possible_tokens.empty()) {
         _possible_tokens = build_pos_tokens(open_tags);
         auto other_pos  = build_pos_tokens(close_tags);
-        _possible_tokens.insert(other_pos.begin(), other_pos.end());
+        for (const auto& token : other_pos) {
+            auto& tokens_full =  _possible_tokens[token.first];
+            tokens_full.insert(tokens_full.end(), token.second.begin(), token.second.end());
+        }
+        //_possible_tokens.insert(other_pos.begin(), other_pos.end());
     }
     
     std::vector<std::string> tokens;

--- a/future/src/ct/ct_parser_text.cc
+++ b/future/src/ct/ct_parser_text.cc
@@ -40,7 +40,7 @@ constexpr bool nor(bool a, bool b) {
 template<class ITER_T>
 bool do_token_branch(ITER_T begin, ITER_T end, std::string_view match) {
     std::string buff;
-    while (begin != end) {
+    while ((begin != end) && (buff.size() < match.size())) {
         buff += *begin;
         if (buff == match) {
             return true;
@@ -179,7 +179,7 @@ std::vector<std::pair<const CtParser::token_schema *, std::string>> CtTextParser
                     curr_open_tags.second += *token;
                     continue;
                 } else if (curr_open_tags.first.front()->close_tag == *token) {
-                    if (nb_open_tags > 0) {
+                    if (nb_open_tags > 1) {
                         --nb_open_tags;
                         curr_open_tags.second += *token;
                         continue;
@@ -198,7 +198,8 @@ std::vector<std::pair<const CtParser::token_schema *, std::string>> CtTextParser
             }
             open_tags[token_iter->first] = false;
             keep_parsing = true;
-        
+            
+            nb_open_tags = 0;
             curr_open_tags.second.clear();
             curr_open_tags.first.clear();
         } else if (curr_open_tags.first.empty()) {

--- a/future/tests/tests_misc_utils.cpp
+++ b/future/tests/tests_misc_utils.cpp
@@ -313,6 +313,19 @@ TEST(MiscUtilsGroup, get_cherrytree_localedir)
     STRCMP_EQUAL(Glib::canonicalize_filename(Glib::build_filename(_CMAKE_SOURCE_DIR, "po")).c_str(), CtFileSystem::get_cherrytree_localedir().c_str());
 }
 
+TEST(MiscUtilsGroup, get__uri_type)
+{
+    CHECK(CtMiscUtil::get_uri_type("https://google.com") == CtMiscUtil::URI_TYPE::WEB_URL);
+    CHECK(CtMiscUtil::get_uri_type("http://google.com") == CtMiscUtil::URI_TYPE::WEB_URL);
+    
+    CHECK(CtMiscUtil::get_uri_type("/home") == CtMiscUtil::URI_TYPE::LOCAL_FILEPATH);
+    CHECK(CtMiscUtil::get_uri_type("C:\\\\windows") == CtMiscUtil::URI_TYPE::LOCAL_FILEPATH);
+    CHECK(CtMiscUtil::get_uri_type(unitTestsDataDir) == CtMiscUtil::URI_TYPE::LOCAL_FILEPATH);
+    
+    CHECK(CtMiscUtil::get_uri_type("smb://localhost") == CtMiscUtil::URI_TYPE::UNKNOWN);
+    CHECK(CtMiscUtil::get_uri_type("my invalid uri") == CtMiscUtil::URI_TYPE::UNKNOWN);
+}
+
 TEST(MiscUtilsGroup, mime__type_contains) 
 {
 // some tests don't work on TRAVIS with WIN32


### PR DESCRIPTION
This is a much improved version of the markdown parser. 

It adds
- Codeboxes
- Tables
- Headers using `==` and `----`
- Images 
- Monospace
- Horizontal spacers
- Bold and italic at the same time

And fixes several issues with conflicting symbols.

This also includes functions for image, codebox, and table xml serialising under the `CtXML` namespace. I have not changed the existing functions in `CtHtml2Xml` or the respective widgets but they can now be changed to use the needed function instead of duplication.

Note that widgets (such as codeboxes, tables, and images) are still inserted into the active node when import is selected. Which I am guessing has something to do with `from_xml_to_buffer`.