### PR TITLE
Use Pandoc when exporting to HTML

### DIFF
--- a/future/src/ct/ct_config.h
+++ b/future/src/ct/ct_config.h
@@ -178,6 +178,7 @@ public:
     int                                         backupNum{3};
     bool                                        autosaveOnQuit{false};
     int                                         limitUndoableSteps{20};
+    bool                                        usePandoc{true}; // Whether to use Pandoc for exporting
 
     // [keyboard]
     std::map<std::string, std::string>          customKbShortcuts;

--- a/future/src/ct/ct_export2html.cc
+++ b/future/src/ct/ct_export2html.cc
@@ -351,7 +351,8 @@ Glib::ustring CtExport2Html::_html_get_from_code_buffer(const Glib::RefPtr<Gsv::
     code_buffer->ensure_highlight(curr_iter, code_buffer->end());
     if (_pCtMainWin->get_ct_config()->usePandoc && CtPandoc::supports_syntax(syntax_highlighting)) {
         if (CtPandoc::has_pandoc()) {
-            Glib::ustring      input_txt(curr_iter, code_buffer->end());
+            Gtk::TextIter end_iter = sel_end >= 0 ? code_buffer->get_iter_at_offset(sel_end) : code_buffer->end();
+            Glib::ustring      input_txt(curr_iter, end_iter);
             std::istringstream ibuff(input_txt);
             std::ostringstream html_out;
             CtPandoc::to_html(ibuff, html_out, syntax_highlighting);
@@ -678,7 +679,7 @@ bool has_pandoc()
 }
 
 
-void to_html(std::istream& input, std::ostream& output, std::string from_format /* = "markdown" */)
+void to_html(std::istream& input, std::ostream& output, std::string from_format)
 {
     auto process = pandoc_process();
     process->append_arg("--from");

--- a/future/src/ct/ct_export2html.h
+++ b/future/src/ct/ct_export2html.h
@@ -59,7 +59,7 @@ private:
     Glib::ustring _get_codebox_html(CtCodebox* codebox);
     Glib::ustring _get_table_html(CtTable* table);
 
-    Glib::ustring _html_get_from_code_buffer(Glib::RefPtr<Gsv::Buffer> code_buffer, int sel_start, int sel_end);
+    Glib::ustring _html_get_from_code_buffer(const Glib::RefPtr<Gsv::Buffer>& code_buffer, int sel_start, int sel_end, const std::string &syntax_highlighting);
     void          _html_get_from_treestore_node(CtTreeIter node_iter, int sel_start, int sel_end,
                                        std::vector<Glib::ustring>& out_slots, std::vector<CtAnchoredWidget*>& out_widgets);
     Glib::ustring _html_process_slot(int start_offset, int end_offset, Glib::RefPtr<Gtk::TextBuffer> curr_buffer);
@@ -93,7 +93,17 @@ namespace CtPandoc {
 
 bool has_pandoc();
 
-void to_html(std::istream& input, std::ostream& output);
+constexpr bool supports_syntax(std::string_view syntax) {
+    constexpr const std::array<std::string_view, 2> supported_syntaxes = {"markdown", "latex"};
+    for (const auto& supported_syntax : supported_syntaxes) {
+        if (syntax == supported_syntax) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void to_html(std::istream& input, std::ostream& output, std::string from_format = "markdown");
 
 void to_html(const std::filesystem::path& file, std::ostream& output);
 

--- a/future/src/ct/ct_export2html.h
+++ b/future/src/ct/ct_export2html.h
@@ -103,7 +103,7 @@ constexpr bool supports_syntax(std::string_view syntax) {
     return false;
 }
 
-void to_html(std::istream& input, std::ostream& output, std::string from_format = "markdown");
+void to_html(std::istream& input, std::ostream& output, std::string from_format);
 
 void to_html(const std::filesystem::path& file, std::ostream& output);
 


### PR DESCRIPTION
This adds Pandoc usage to the HTML parser. If the syntax format is supported (currently `markdown` and `latex`) then it will be run through pandoc (with a warning if pandoc could not be found). This works for codeboxes and nodes with syntax highlighting.

I have also added a switch in `CtConfig` as `usePandoc` which currently is always true but can be used to disable pandoc exporting in the future (i.e if the user wants unformatted text for some reason)

Ref #878