### PR TITLE
Improve HTML output

### DIFF
--- a/future/data/script3.js
+++ b/future/data/script3.js
@@ -1,3 +1,7 @@
+right_arrow_heavy = '&#129090;'
+left_arrow_heavy = '&#129088;'
+
+
 function changeFrame(file_path){
 	var iframe = document.getElementById("page_frame");
 	iframe.src = file_path;
@@ -5,7 +9,7 @@ function changeFrame(file_path){
 
 function toggleSubTree(element){
 	var nextSibling = element.parentElement.nextElementSibling;
-	if(nextSibling.tagName == 'UL'){
+	if(nextSibling.tagName === 'UL'){
 		nextSibling.classList.toggle('hide');
 		if(element.textContent === '+'){
 			element.textContent = '-'
@@ -32,25 +36,40 @@ function collapseAllSubtrees(element){
 		subtree.previousElementSibling.firstChild.textContent = '+';
 	}
 }
-
+function toggle_tree_panel() {
+	var tree = get_tree_panel();
+	var toggle_btn = document.getElementById('tree_panel_toggle_btn')
+	if (tree.style.display === 'none') {
+		tree.style.display = 'inline'
+		toggle_btn.innerHTML = left_arrow_heavy
+		toggle_btn.onmouseenter = null
+	} else {
+		tree.style.display = 'none'
+		toggle_btn.innerHTML = right_arrow_heavy
+		toggle_btn.onmouseenter = toggle_tree_panel
+	}
+}
 
 function get_tree() {
 	return document.getElementsByClassName("tree")[0]
 }
+function get_tree_panel() {
+	return document.getElementsByClassName("tree-panel")[0]
+}
 
 
-window.onload = function(){ 
+window.onload = function() {
 	var show_page = window.location.hash.substr(1);
 	if (show_page !== '') {
 		changeFrame(show_page);
 	}
 
 	// Unwrap the header
-	var tree = get_tree()
-	var para = tree.children[0]
+	let tree = get_tree()
+	let para = tree.children[0]
 
-	var index_txt = para.children[0].innerHTML
-	var index_title = document.createElement("h1")
+	let index_txt = para.children[0].innerHTML
+	let index_title = document.createElement("h1")
 	index_title.innerHTML = index_txt
 	index_title.id = 'index_header'
 	tree.insertBefore(index_title, tree.children[0])
@@ -58,4 +77,24 @@ window.onload = function(){
 
 	// Remove unwrapped elements
 	para.removeChild(para.children[0])
+
+	// Keybinds
+	document.onkeydown = handle_keypress
+
+	// Toggle tree panel button
+	let panels = document.getElementsByClassName("two-panels")[0]
+	let toggle_btn = document.createElement("button")
+	toggle_btn.onclick = toggle_tree_panel
+	toggle_btn.innerHTML = left_arrow_heavy
+	toggle_btn.id = 'tree_panel_toggle_btn'
+	panels.insertBefore(toggle_btn, panels.children[1])
+
+}
+
+function handle_keypress(ev) {
+	switch(ev.key) {
+		case "Escape":
+			toggle_tree_panel()
+			break
+	}
 }

--- a/future/data/script3.js
+++ b/future/data/script3.js
@@ -7,7 +7,7 @@ function toggleSubTree(element){
 	var nextSibling = element.parentElement.nextElementSibling;
 	if(nextSibling.tagName == 'UL'){
 		nextSibling.classList.toggle('hide');
-		if(element.textContent == '+'){
+		if(element.textContent === '+'){
 			element.textContent = '-'
 		}else{
 			element.textContent = '+'
@@ -33,9 +33,29 @@ function collapseAllSubtrees(element){
 	}
 }
 
+
+function get_tree() {
+	return document.getElementsByClassName("tree")[0]
+}
+
+
 window.onload = function(){ 
 	var show_page = window.location.hash.substr(1);
 	if (show_page !== '') {
 		changeFrame(show_page);
 	}
+
+	// Unwrap the header
+	var tree = get_tree()
+	var para = tree.children[0]
+
+	var index_txt = para.children[0].innerHTML
+	var index_title = document.createElement("h1")
+	index_title.innerHTML = index_txt
+	index_title.id = 'index_header'
+	tree.insertBefore(index_title, tree.children[0])
+
+
+	// Remove unwrapped elements
+	para.removeChild(para.children[0])
 }

--- a/future/data/styles3.css
+++ b/future/data/styles3.css
@@ -77,8 +77,7 @@ div.page-panel {
 }
 
 div.page-panel iframe {
-    width: 79vw;
-    margin-left: 1vw;
+    width: 100%;
     border: 0px;
     margin-top: 0px;
     height: 100%;

--- a/future/data/styles3.css
+++ b/future/data/styles3.css
@@ -24,6 +24,25 @@ body {
     white-space: pre-wrap;
 }
 
+button {
+    border: none;
+    padding: 0 5px;
+    background: none;
+    margin: 0;
+}
+
+button:hover {
+    color: #666666;
+}
+
+#index_header {
+    text-align: center;
+}
+
+.two-panels {
+    background: #EEEEEE;
+}
+
 div.two-panels {
     height: inherit;
     margin: 0;
@@ -94,10 +113,6 @@ div.tree a, div.tree a:visited {
     text-decoration: none;
 }
 
-div.tree a:hover {
-    text-decoration: underline;
-}
-
 div.tree ul {
     padding-inline-start: 20px;
     list-style-type: none;
@@ -115,6 +130,18 @@ div.tree li.leaf {
     padding-inline-start: 10px;
     line-height: 2;
 }
+.tree li a {
+    width: 100%;
+    display: inline-block;
+}
+
+.tree li:hover {
+    background: rgba(193, 193, 193, 0.7);
+    color: white;
+}
+.tree li {
+    white-space: nowrap;
+}
 
 div.tree a.show, div.tree a.hide { display: none; }
 
@@ -129,17 +156,19 @@ div.tree a.show, div.tree a.hide { display: none; }
 /* TABLES */
 
 table {
-    border: 1px solid #AAAAAA;
+    border: 1px solid #202A2C;
+    border-collapse: collapse;
 }
 
 th {
-    background-color: #EEEEEE;
+    background-color: rgb(193, 193, 193);
 }
 
-td {
+td, th {
     padding-left: 5px;
     padding-right: 5px;
-    border-top: 1px solid #AAAAAA;
+    border: 1px solid #202A2C;
+    text-align: center;
 }
 
 /* HEADINGS */
@@ -150,7 +179,11 @@ div.page h1 {
 }
 
 div.page h1.title {
-    text-decoration: underline;
+    text-align: center;
+    background: rgb(193, 193, 193);
+    margin: 0 auto 1vh auto;
+    width: 100%;
+    display: inline-block;
 }
 
 div.page h2 {
@@ -192,7 +225,13 @@ div.codebox, div.page code, div.page pre {
     font-weight: normal;
     font-size: 13px;
     background-color: #EEEEEE;
-    border: 1px solid #DDDDDD;
+    border: 1px solid #202A2C;
+}
+
+div .codebox {
+    display: inline-block;
+    padding: 5px 7px;
+    min-width: 30%;
 }
 
 div.page p.tagged-text,

--- a/future/src/ct/ct_export2html.cc
+++ b/future/src/ct/ct_export2html.cc
@@ -331,12 +331,16 @@ Glib::ustring CtExport2Html::_get_table_html(CtTable* table)
     for (const auto& row: table->get_table_matrix())
     {
         table_html += "<tr>";
-        for (auto cell: row)
+        for (auto cell: row) {
+            Glib::ustring content = str::xml_escape(cell->get_text_content());
+            if (content.empty()) content = " "; // Otherwise the table will render with squashed cells
+    
             if (first) {
-                table_html += "<th>" + str::xml_escape(cell->get_text_content()) + "</th>";
+                table_html += "<th>" + content + "</th>";
             } else {
-                table_html += "<td>" + str::xml_escape(cell->get_text_content()) + "</td>";
+                table_html += "<td>" + content + "</td>";
             }
+        }
         
         if (first) first = false;
         table_html += "</tr>";

--- a/future/src/ct/ct_export2html.cc
+++ b/future/src/ct/ct_export2html.cc
@@ -327,17 +327,18 @@ Glib::ustring CtExport2Html::_get_codebox_html(CtCodebox* codebox)
 Glib::ustring CtExport2Html::_get_table_html(CtTable* table)
 {
     Glib::ustring table_html = "<table class=\"table\">";
-    for (auto row: table->get_table_matrix())
+    bool first = true;
+    for (const auto& row: table->get_table_matrix())
     {
         table_html += "<tr>";
-        bool first = true;
         for (auto cell: row)
             if (first) {
                 table_html += "<th>" + str::xml_escape(cell->get_text_content()) + "</th>";
-                first = false;
             } else {
                 table_html += "<td>" + str::xml_escape(cell->get_text_content()) + "</td>";
             }
+        
+        if (first) first = false;
         table_html += "</tr>";
     }
     table_html += "</table>";


### PR DESCRIPTION
This improves the styling of the output HTML, mostly it only uses `style3.css` but there is also some html injection using `script3.js`.

Changes:
- Tree panel can be shown/hidden using a button between it and the `page_frame` iframe, mousing over the button when closed will open it
- Background is now `#EEEEEE` for everything
- Backgrounds for widgets (i.e tables) is now `rgb(197, 197, 197)` (`#FFC1C1C1`)
- Links on the tree expand to the full width of the row and the row lights up (`rgba(197, 197, 197, 0.7)`) on mouse over instead of the link being underlined
- The `+/-` buttons on the tree no longer have borders and are vertically centred in the row
- The `index` text at the top of the tree panel has been moved up and made `h1`
- Buttons no longer have borders or backgrounds and instead their text is lightened when moused over
- Headers for node titles have been centred, moved up, and given a background so that they at least somewhat resemble the node headers in cherrytree
- Codeboxes are now `inline-block`, meaning they will resize to fit their contents instead of being the width of the page (with a minimum width of `30%`)
- Codeboxes and tables now have a black border instead of grey
- Tables now have solid borders instead of disjointed lines

I realise that users can do all of this themselves by changing `style3.css` and `script3.js` in the config folder but I think these are better "defaults" as it were. They will of course not take affect unless the user replaces their existing config files

I have also changed the C++ version when exporting tables to correct the issue of headers being all the far left cells instead of the first row and squashed table cells due to empty contents