### PR TITLE
Implement custom link actions

### DIFF
--- a/future/src/ct/ct_actions_export.cc
+++ b/future/src/ct/ct_actions_export.cc
@@ -185,8 +185,10 @@ void CtActions::_export_to_html(Glib::ustring auto_path, bool auto_overwrite)
         if (export2html.prepare_html_folder("", folder_name, false, ret_html_path))
             export2html.node_export_to_html(_pCtMainWin->curr_tree_iter(), _export_options, "", iter_start.get_offset(), iter_end.get_offset());
     }
-    if (!ret_html_path.empty())
-       CtFileSystem::external_folderpath_open(ret_html_path, _pCtMainWin->get_ct_config());
+    if (!ret_html_path.empty()) {
+        std::string path(ret_html_path.begin(), ret_html_path.end());
+       CtFileSystem::external_folderpath_open(path, _pCtMainWin->get_ct_config());
+    }
 }
 
 // Export To Plain Text Multiple (or single) Files

--- a/future/src/ct/ct_actions_export.cc
+++ b/future/src/ct/ct_actions_export.cc
@@ -186,7 +186,7 @@ void CtActions::_export_to_html(Glib::ustring auto_path, bool auto_overwrite)
             export2html.node_export_to_html(_pCtMainWin->curr_tree_iter(), _export_options, "", iter_start.get_offset(), iter_end.get_offset());
     }
     if (!ret_html_path.empty())
-       CtFileSystem::external_folderpath_open(ret_html_path);
+       CtFileSystem::external_folderpath_open(ret_html_path, _pCtMainWin->get_ct_config());
 }
 
 // Export To Plain Text Multiple (or single) Files

--- a/future/src/ct/ct_actions_help.cc
+++ b/future/src/ct/ct_actions_help.cc
@@ -36,7 +36,7 @@ void CtActions::dialog_about()
 
 void CtActions::folder_cfg_open()
 {
-    CtFileSystem::external_folderpath_open(Glib::build_filename(Glib::get_user_config_dir(), CtConst::APP_NAME));
+    CtFileSystem::external_folderpath_open(Glib::get_user_config_dir() / CtFileSystem::path(CtConst::APP_NAME), _pCtMainWin->get_ct_config());
 }
 
 void CtActions::check_for_newer_version()

--- a/future/src/ct/ct_actions_others.cc
+++ b/future/src/ct/ct_actions_others.cc
@@ -32,6 +32,8 @@
 #include "ct_logging.h"
 #include <spdlog/fmt/bundled/printf.h>
 
+namespace fs = CtFileSystem;
+
 // Cut Link
 void CtActions::link_cut()
 {
@@ -159,7 +161,7 @@ void CtActions::embfile_open()
 
     spdlog::debug("embfile_open {}", static_cast<std::string>(filepath));
 
-    CtFileSystem::external_filepath_open(filepath, false, _pCtMainWin->get_ct_config());
+    CtFileSystem::external_filepath_open(filepath.c_str(), false, _pCtMainWin->get_ct_config());
     _embfiles_opened[filepath] = CtFileSystem::getmtime(filepath);
 
     if (not _embfiles_timeout_connection)
@@ -277,26 +279,26 @@ void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_
      }
      else if (vec[0] == CtConst::LINK_TYPE_FILE) // link to file
      {
-         Glib::ustring filepath = CtExport2Html::_link_process_filepath(vec[1]);
-         if (not Glib::file_test(filepath, Glib::FILE_TEST_IS_REGULAR))
+         fs::path filepath = CtExport2Html::_link_process_filepath(vec[1]).c_str();
+         if (not Glib::file_test(filepath.string(), Glib::FILE_TEST_IS_REGULAR))
          {
-             CtDialogs::error_dialog(str::format(_("The File Link '%s' is Not Valid"), std::string(filepath)), *_pCtMainWin);
+             CtDialogs::error_dialog(fmt::format("The File Link '{}' is Not Valid", filepath), *_pCtMainWin);
              return;
          }
          if (from_wheel)
-             filepath = Glib::path_get_dirname(CtFileSystem::abspath(filepath));
+             filepath = Glib::path_get_dirname(CtFileSystem::abspath(filepath).string());
          CtFileSystem::external_filepath_open(filepath, true, _pCtMainWin->get_ct_config());
      }
      else if (vec[0] == CtConst::LINK_TYPE_FOLD) // link to folder
      {
-         Glib::ustring folderpath = CtExport2Html::_link_process_folderpath(vec[1]);
-         if (not Glib::file_test(folderpath, Glib::FILE_TEST_IS_DIR))
+         fs::path folderpath = CtExport2Html::_link_process_folderpath(vec[1]).c_str();
+         if (not fs::is_directory(folderpath))
          {
-             CtDialogs::error_dialog(str::format(_("The Folder Link '%s' is Not Valid"), std::string(folderpath)), *_pCtMainWin);
+             CtDialogs::error_dialog(fmt::format("The Folder Link '{}' is Not Valid", folderpath), *_pCtMainWin);
              return;
          }
          if (from_wheel)
-             folderpath = Glib::path_get_dirname(CtFileSystem::abspath(folderpath));
+             folderpath = Glib::path_get_dirname(CtFileSystem::abspath(folderpath).string());
          CtFileSystem::external_folderpath_open(folderpath, _pCtMainWin->get_ct_config());
      }
      else if (vec[0] == CtConst::LINK_TYPE_NODE) // link to a tree node

--- a/future/src/ct/ct_actions_others.cc
+++ b/future/src/ct/ct_actions_others.cc
@@ -282,7 +282,7 @@ void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_
          fs::path filepath = CtExport2Html::_link_process_filepath(vec[1]).c_str();
          if (not Glib::file_test(filepath.string(), Glib::FILE_TEST_IS_REGULAR))
          {
-             CtDialogs::error_dialog(fmt::format("The File Link '{}' is Not Valid", filepath), *_pCtMainWin);
+             CtDialogs::error_dialog(fmt::format(_("The File Link '{}' is Not Valid"), filepath), *_pCtMainWin);
              return;
          }
          if (from_wheel)
@@ -294,7 +294,7 @@ void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_
          fs::path folderpath = CtExport2Html::_link_process_folderpath(vec[1]).c_str();
          if (not fs::is_directory(folderpath))
          {
-             CtDialogs::error_dialog(fmt::format("The Folder Link '{}' is Not Valid", folderpath), *_pCtMainWin);
+             CtDialogs::error_dialog(fmt::format(_("The Folder Link '{}' is Not Valid"), folderpath), *_pCtMainWin);
              return;
          }
          if (from_wheel)

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -945,6 +945,10 @@ bool CtFileSystem::copy_file(const std::string& from_file, const std::string& to
     return rFileFrom->copy(rFileTo, Gio::FILE_COPY_OVERWRITE);
 }
 
+bool CtFileSystem::is_directory(const fs::path& path) {
+    return Glib::file_test(path.string(), Glib::FILE_TEST_IS_DIR);
+}
+
 bool CtFileSystem::move_file(const std::string& from_file, const std::string& to_file)
 {
     Glib::RefPtr<Gio::File> rFileFrom = Gio::File::create_for_path(from_file);
@@ -952,9 +956,9 @@ bool CtFileSystem::move_file(const std::string& from_file, const std::string& to
     return rFileFrom->move(rFileTo, Gio::FILE_COPY_OVERWRITE);
 }
 
-std::string CtFileSystem::abspath(const std::string& path)
+fs::path CtFileSystem::abspath(const fs::path& path)
 {
-    Glib::RefPtr<Gio::File> rFile = Gio::File::create_for_path(path);
+    Glib::RefPtr<Gio::File> rFile = Gio::File::create_for_path(path.string());
     return rFile->get_path();
 }
 
@@ -995,7 +999,7 @@ std::string CtFileSystem::get_file_stem(const std::string& path)
 }
 
 bool CtFileSystem::exists(const CtFileSystem::path& filepath) {
-    return g_file_test(filepath.c_str(), G_FILE_TEST_EXISTS);
+    return Glib::file_test(filepath.c_str(), Glib::FILE_TEST_EXISTS);
 }
 
 // Open Filepath with External App

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -33,13 +33,15 @@
 #include <glib/gstdio.h> // to get stats
 #include <fstream>
 #include <curl/curl.h>
-#include <filesystem>
+#include <spdlog/fmt/bundled/printf.h>
 
 #ifdef _WIN32
     #include <windows.h>
     #include <shellapi.h>
 #endif
 
+
+namespace fs = CtFileSystem;
 
 namespace CtCSV {
 CtStringTable table_from_csv(std::istream& input)
@@ -992,61 +994,51 @@ std::string CtFileSystem::get_file_stem(const std::string& path)
     return name.substr(0, dot_pos);
 }
 
+bool CtFileSystem::exists(const CtFileSystem::path& filepath) {
+    return g_file_test(filepath.c_str(), G_FILE_TEST_EXISTS);
+}
+
 // Open Filepath with External App
-void CtFileSystem::external_filepath_open(const std::string& filepath, bool /*open_fold_if_no_app_error*/)
+void CtFileSystem::external_filepath_open(const fs::path& filepath, bool open_folder_if_file_not_exists, CtConfig* config)
 {
-    /* todo:
-    if self.filelink_custom_action[0]:
-        if cons.IS_WIN_OS: filepath = cons.CHAR_DQUOTE + filepath + cons.CHAR_DQUOTE
-        else: filepath = re.escape(filepath)
-        subprocess.call(self.filelink_custom_action[1] % filepath, shell=True)
-    else:
-        if cons.IS_WIN_OS:
-            try: os.startfile(filepath)
-            except:
-                if open_fold_if_no_app_error: os.startfile(os.path.dirname(filepath))
-        else: subprocess.call(config.LINK_CUSTOM_ACTION_DEFAULT_FILE % re.escape(filepath), shell=True)
-        */
-
     spdlog::debug("filepath to open: {}", filepath);
-
+    if (config->filelinkCustomOn) {
+        std::string cmd = fmt::sprintf(config->filelinkCustomAct, filepath.string());
+        std::system(cmd.c_str());
+    } else {
+        if (open_folder_if_file_not_exists && !fs::exists(filepath)) {
+            external_folderpath_open(filepath, config);
+        } else if (!fs::exists(filepath)) {
+            throw std::runtime_error(fmt::format("Filepath: {} does not exist and open_folder_if_not_exists is false", filepath.string()));
+        } else {
 #ifdef _WIN32
-    ShellExecute(GetActiveWindow(), "open", filepath.c_str(), NULL, NULL, SW_SHOWNORMAL);
+            ShellExecute(GetActiveWindow(), "open", filepath.c_str(), NULL, NULL, SW_SHOWNORMAL);
 #else
-    g_app_info_launch_default_for_uri(("file://" + filepath).c_str(), nullptr, nullptr);
+            g_app_info_launch_default_for_uri(("file://" + filepath).c_str(), nullptr, nullptr);
 #endif
+        }
+    }
 }
 
 // Open Folderpath with External App
-void CtFileSystem::external_folderpath_open(const std::string& folderpath)
+void CtFileSystem::external_folderpath_open(const fs::path& folderpath, CtConfig* config)
 {
-     /* todo:
-    if self.folderlink_custom_action[0]:
-        if cons.IS_WIN_OS: filepath = cons.CHAR_DQUOTE + filepath + cons.CHAR_DQUOTE
-        else: filepath = re.escape(filepath)
-        subprocess.call(self.folderlink_custom_action[1] % filepath, shell=True)
-    else:
-        if cons.IS_WIN_OS: os.startfile(filepath)
-        else: subprocess.call(config.LINK_CUSTOM_ACTION_DEFAULT_FILE % re.escape(filepath), shell=True)
-        */
-   
-   spdlog::debug("dir to open: {}", folderpath);
-
-    // https://stackoverflow.com/questions/42442189/how-to-open-spawn-a-file-with-glib-gtkmm-in-windows
+    spdlog::debug("dir to open: {}", folderpath.string());
+    if (config->folderlinkCustomOn) {
+        std::string cmd = fmt::sprintf(config->filelinkCustomAct, folderpath.string());
+        std::system(cmd.c_str());
+    } else {
+    
+        // https://stackoverflow.com/questions/42442189/how-to-open-spawn-a-file-with-glib-gtkmm-in-windows
 #ifdef _WIN32
-    ShellExecute(NULL, "open", folderpath.c_str(), NULL, NULL, SW_SHOWDEFAULT);
+        ShellExecute(NULL, "open", folderpath.c_str(), NULL, NULL, SW_SHOWDEFAULT);
 #elif defined(__APPLE__)
-    std::vector<std::string> argv = { "open", folderpath };
+        std::vector<std::string> argv = { "open", folderpath.string() };
     Glib::spawn_async("", argv, Glib::SpawnFlags::SPAWN_SEARCH_PATH);
 #else
-    gchar *path = g_filename_to_uri(folderpath.c_str(), NULL, NULL);
-    std::string xgd = "xdg-open " + std::string(path);
-    const auto retVal = system(xgd.c_str());
-    if (retVal != 0) {
-        g_warning("system(%s) returned %d", xgd.c_str(), retVal);
-    }
-    g_free(path);
+        g_app_info_launch_default_for_uri(("file://" + folderpath.string()).c_str(), nullptr, nullptr);
 #endif
+    }
 }
 
 std::string CtFileSystem::prepare_export_folder(const std::string& dir_place, std::string new_folder, bool overwrite_existing)

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -999,7 +999,7 @@ std::string CtFileSystem::get_file_stem(const std::string& path)
 }
 
 bool CtFileSystem::exists(const CtFileSystem::path& filepath) {
-    return Glib::file_test(filepath.c_str(), Glib::FILE_TEST_EXISTS);
+    return Glib::file_test(filepath.string(), Glib::FILE_TEST_EXISTS);
 }
 
 // Open Filepath with External App
@@ -1018,7 +1018,9 @@ void CtFileSystem::external_filepath_open(const fs::path& filepath, bool open_fo
 #ifdef _WIN32
             ShellExecute(GetActiveWindow(), "open", filepath.c_str(), NULL, NULL, SW_SHOWNORMAL);
 #else
-            g_app_info_launch_default_for_uri(("file://" + filepath).c_str(), nullptr, nullptr);
+            fs::path f_path("file://");
+            f_path += filepath;
+            g_app_info_launch_default_for_uri(f_path.c_str(), nullptr, nullptr);
 #endif
         }
     }
@@ -1040,7 +1042,9 @@ void CtFileSystem::external_folderpath_open(const fs::path& folderpath, CtConfig
         std::vector<std::string> argv = { "open", folderpath.string() };
     Glib::spawn_async("", argv, Glib::SpawnFlags::SPAWN_SEARCH_PATH);
 #else
-        g_app_info_launch_default_for_uri(("file://" + folderpath.string()).c_str(), nullptr, nullptr);
+        fs::path path("file://");
+        path += folderpath;
+        g_app_info_launch_default_for_uri(folderpath.c_str(), nullptr, nullptr);
 #endif
     }
 }

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -418,9 +418,11 @@ bool copy_file(const std::string& from_file, const std::string& to_file);
 
 bool move_file(const std::string& from_file, const std::string& to_file);
 
-std::string abspath(const std::string& path);
+path abspath(const path& path);
 
 bool exists(const path& filepath);
+
+bool is_directory(const path& path);
 
 time_t getmtime(const std::string& path);
 
@@ -451,21 +453,26 @@ class path {
     using path_type = std::string;
 public:
     path(path_type path) : _path(std::move(path)) {}
-    path(const Glib::ustring& path) : _path(path.begin(), path.end()) {}
     path(const char* path) : _path(path) {}
     
     ~path() = default;
     
     void append(const path& other) {
-        _path = g_build_filename(_path.c_str(), other.c_str(), nullptr);
+        _path = Glib::build_filename(_path, other._path);
+    }
+
+    path& operator=(std::string other) {
+        _path.swap(other);
+        return *this;
     }
 
 
     friend path operator/(const path& lhs, const path& rhs) {
-       return path(g_build_filename(lhs.c_str(), rhs.c_str(), nullptr)); 
+        return path(Glib::build_filename(lhs._path, rhs._path));
     }
+
     friend path operator/(const path& lhs, const std::string& rhs) {
-        return path(g_build_filename(lhs.c_str(), rhs.c_str(), nullptr));
+        return path(Glib::build_filename(lhs._path, rhs));
     }
 
     friend path operator+(const path& lhs, const path& rhs) { return path(lhs._path + rhs._path); }

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -33,6 +33,8 @@
 #include <spdlog/fmt/ostr.h> // to support Glib::ustring formatting
 #include <type_traits>
 
+class CtConfig;
+
 template<class F> auto scope_guard(F&& f) {
     return std::unique_ptr<void, typename std::decay<F>::type>{(void*)1, std::forward<F>(f)};
 }
@@ -408,7 +410,7 @@ bool exists(const MAP& m, const KEY& key)
 } // namespace map
 
 namespace CtFileSystem {
-
+class path;
 // From Slash to Backslash when needed
 std::string get_proper_platform_filepath(std::string filepath);
 
@@ -418,6 +420,8 @@ bool move_file(const std::string& from_file, const std::string& to_file);
 
 std::string abspath(const std::string& path);
 
+bool exists(const path& filepath);
+
 time_t getmtime(const std::string& path);
 
 int getsize(const std::string& path);
@@ -425,8 +429,8 @@ int getsize(const std::string& path);
 std::list<std::string> get_dir_entries(const std::string& dir);
 std::string get_file_stem(const std::string& path);
 
-void external_filepath_open(const std::string& filepath, bool open_fold_if_no_app_error);
-void external_folderpath_open(const std::string& folderpath);
+void external_filepath_open(const path& filepath, bool open_folder_if_file_not_exists, CtConfig* config);
+void external_folderpath_open(const path& folderpath, CtConfig* config);
 
 std::string prepare_export_folder(const std::string& dir_place, std::string new_folder, bool overwrite_existing);
 
@@ -439,4 +443,46 @@ std::string get_cherrytree_lang_filepath();
 
 std::string download_file(const std::string& filepath);
 
+/**
+ * @class path
+ * @brief An object representing a filepath
+ */
+class path {
+    using path_type = std::string;
+public:
+    path(path_type path) : _path(std::move(path)) {}
+    path(const Glib::ustring& path) : _path(path.begin(), path.end()) {}
+    path(const char* path) : _path(path) {}
+    
+    ~path() = default;
+    
+    void append(const path& other) {
+        _path = g_build_filename(_path.c_str(), other.c_str(), nullptr);
+    }
+
+
+    friend path operator/(const path& lhs, const path& rhs) {
+       return path(g_build_filename(lhs.c_str(), rhs.c_str(), nullptr)); 
+    }
+    friend path operator/(const path& lhs, const std::string& rhs) {
+        return path(g_build_filename(lhs.c_str(), rhs.c_str(), nullptr));
+    }
+
+    friend path operator+(const path& lhs, const path& rhs) { return path(lhs._path + rhs._path); }
+    
+    const char* c_str() const { return string().c_str(); };
+    std::string string() const { return get_proper_platform_filepath(_path); }
+private:
+    path_type _path;
+};
 } // namespace CtFileSystem
+
+template<>
+struct fmt::formatter<CtFileSystem::path> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template<typename FormatContext>
+        auto format(const CtFileSystem::path& path, FormatContext& ctx) {
+            return format_to(ctx.out(), "{}", path.string());
+        }
+};
+

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -475,7 +475,8 @@ public:
         return path(Glib::build_filename(lhs._path, rhs));
     }
 
-    friend path operator+(const path& lhs, const path& rhs) { return path(lhs._path + rhs._path); }
+    friend void operator+=(path& lhs, const path& rhs) { lhs._path += rhs._path; }
+    friend void operator+=(path& lhs, const std::string& rhs) { lhs._path += rhs; }
     
     const char* c_str() const { return string().c_str(); };
     std::string string() const { return get_proper_platform_filepath(_path); }


### PR DESCRIPTION
This implements custom link actions for the C++ port.

It invokes the external application using `std::system`, GSubprocess is a bit heavy for this I think but it does have the issue that output of the child muddies the output of cherrytree 

It also adds a `path` class to `CtFileSystem` which is basically a version of `std::filesystem::path` with only the bits that are currently needed. I added this because I needed a way to format paths correctly across platforms and didn't want to write `get_proper_platform_path` every time, but it also has `operator/` overloaded for `g_build_filename`. 

