### PR TITLE
concurrently convert images into string before node saving

### DIFF
--- a/future/src/ct/ct_clipboard.cc
+++ b/future/src/ct/ct_clipboard.cc
@@ -194,7 +194,7 @@ void CtClipboard::_paste_clipboard(Gtk::TextView* pTextView, CtCodebox* /*pCodeb
 void CtClipboard::table_row_to_clipboard(CtTable* pTable)
 {
     CtClipboardData* clip_data = new CtClipboardData();
-    pTable->to_xml(clip_data->xml_doc.create_root_node("root"), 0);
+    pTable->to_xml(clip_data->xml_doc.create_root_node("root"), 0, nullptr);
     clip_data->html_text = CtExport2Html(_pCtMainWin).table_export_to_html(pTable);
 
     _set_clipboard_data({TARGET_CTD_TABLE, TARGETS_HTML[0]}, clip_data);
@@ -245,7 +245,7 @@ void CtClipboard::_rich_text_process_slot(xmlpp::Element* root, int start_offset
     if (obj_element != nullptr)
     {
         xmlpp::Element* elm_dom_iter = root->add_child("slot");
-        obj_element->to_xml(elm_dom_iter, 0);
+        obj_element->to_xml(elm_dom_iter, 0, nullptr);
     }
 }
 
@@ -299,7 +299,7 @@ void CtClipboard::_selection_to_clipboard(Glib::RefPtr<Gtk::TextBuffer> text_buf
             else if (CtTable* table = dynamic_cast<CtTable*>(widget_vector.front()))
             {
                 CtClipboardData* clip_data = new CtClipboardData();
-                table->to_xml(clip_data->xml_doc.create_root_node("root"), 0);
+                table->to_xml(clip_data->xml_doc.create_root_node("root"), 0, nullptr);
                 clip_data->html_text = CtExport2Html(_pCtMainWin).table_export_to_html(table);
                 clip_data->plain_text = CtExport2Txt(_pCtMainWin).get_table_plain(table);
 
@@ -309,7 +309,7 @@ void CtClipboard::_selection_to_clipboard(Glib::RefPtr<Gtk::TextBuffer> text_buf
             else if (CtCodebox* codebox = dynamic_cast<CtCodebox*>(widget_vector.front()))
             {
                 CtClipboardData* clip_data = new CtClipboardData();
-                codebox->to_xml(clip_data->xml_doc.create_root_node("root"), 0);
+                codebox->to_xml(clip_data->xml_doc.create_root_node("root"), 0, nullptr);
                 clip_data->html_text = CtExport2Html(_pCtMainWin).codebox_export_to_html(codebox);
                 if (num_chars == 1) // just copy one codebox
                     clip_data->plain_text = _codebox_to_yaml(codebox);

--- a/future/src/ct/ct_codebox.cc
+++ b/future/src/ct/ct_codebox.cc
@@ -178,7 +178,7 @@ void CtCodebox::apply_syntax_highlighting()
     _pCtMainWin->apply_syntax_highlighting(get_buffer(), _syntaxHighlighting);
 }
 
-void CtCodebox::to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment)
+void CtCodebox::to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment, CtStorageCache*)
 {
     // todo: fix code duplicates in void CtHtml2Xml::_insert_codebox()
     xmlpp::Element* p_codebox_node = p_node_parent->add_child("codebox");
@@ -193,7 +193,7 @@ void CtCodebox::to_xml(xmlpp::Element* p_node_parent, const int offset_adjustmen
     p_codebox_node->add_child_text(get_text_content());
 }
 
-bool CtCodebox::to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment)
+bool CtCodebox::to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment, CtStorageCache*)
 {
     bool retVal{true};
     sqlite3_stmt *p_stmt;

--- a/future/src/ct/ct_codebox.h
+++ b/future/src/ct/ct_codebox.h
@@ -74,8 +74,8 @@ public:
 
     void apply_width_height(const int parentTextWidth) override;
     void apply_syntax_highlighting() override;
-    void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment) override;
-    bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) override;
+    void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment, CtStorageCache* cache) override;
+    bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment, CtStorageCache* cache) override;
     void set_modified_false() override { set_text_buffer_modified_false(); }
     CtAnchWidgType get_type() override { return CtAnchWidgType::CodeBox; }
     std::shared_ptr<CtAnchoredWidgetState> get_state() override;

--- a/future/src/ct/ct_image.h
+++ b/future/src/ct/ct_image.h
@@ -72,8 +72,8 @@ public:
                const std::string& justification);
     virtual ~CtImagePng() override {}
 
-    void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment) override;
-    bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) override;
+    void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment, CtStorageCache* cache) override;
+    bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment, CtStorageCache* cache) override;
     CtAnchWidgType get_type() override { return CtAnchWidgType::ImagePng; }
     std::shared_ptr<CtAnchoredWidgetState> get_state() override;
 
@@ -98,8 +98,8 @@ public:
                   const std::string& justification);
     virtual ~CtImageAnchor() override {}
 
-    void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment) override;
-    bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) override;
+    void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment, CtStorageCache* cache) override;
+    bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment, CtStorageCache* cache) override;
     CtAnchWidgType get_type() override { return CtAnchWidgType::ImageAnchor; }
     std::shared_ptr<CtAnchoredWidgetState> get_state() override;
 
@@ -125,8 +125,8 @@ public:
                    const std::string& justification);
     virtual ~CtImageEmbFile() override {}
 
-    void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment) override;
-    bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) override;
+    void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment, CtStorageCache* cache) override;
+    bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment, CtStorageCache* cache) override;
     CtAnchWidgType get_type() override { return CtAnchWidgType::ImageEmbFile; }
     std::shared_ptr<CtAnchoredWidgetState> get_state() override;
 

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -80,6 +80,8 @@ bool mime_type_contains(const std::string& filepath, const std::string& type);
 enum class URI_TYPE { LOCAL_FILEPATH, WEB_URL, UNKNOWN };
 URI_TYPE get_uri_type(const std::string& uri);
 
+void parallel_for(size_t first, size_t last, std::function<void(size_t)> f);
+
 } // namespace CtMiscUtil
 
 namespace CtTextIterUtil {

--- a/future/src/ct/ct_storage_control.h
+++ b/future/src/ct/ct_storage_control.h
@@ -21,6 +21,7 @@
 
 #pragma once
 #include "ct_types.h"
+#include <glibmm/miscutils.h>
 
 class CtMainWin;
 class CtStorageControl
@@ -75,4 +76,18 @@ private:
     bool                             _need_backup{true};   // create a backup once, on the first saving
     std::unique_ptr<CtStorageEntity> _storage;
     CtStorageSyncPending             _syncPending;
+};
+
+
+class CtImagePng;
+class CtStorageCache
+{
+public:
+    void generate_cache(CtMainWin* pCtMainWin, const CtStorageSyncPending* pending, bool xml);
+
+    void parallel_fetch_pixbufers(const std::vector<CtImagePng*>& image_widgets, bool xml);
+    bool get_cached_image(CtImagePng* image, std::string& cached_image);
+
+private:
+    std::map<CtImagePng*, std::string> _cached_images;
 };

--- a/future/src/ct/ct_storage_sqlite.h
+++ b/future/src/ct/ct_storage_sqlite.h
@@ -31,6 +31,7 @@
 class CtMainWin;
 class CtAnchoredWidget;
 class CtTreeIter;
+class CtStorageCache;
 
 class CtStorageSqlite : public CtStorageEntity
 {
@@ -82,7 +83,8 @@ private:
                                           const gint64 sequence,
                                           const gint64 node_father_id,
                                           const CtStorageNodeState& write_dict,
-                                          const int start_offset, const int end_offset);
+                                          const int start_offset, const int end_offset,
+                                          CtStorageCache* storage_cache);
 
     std::list<gint64>   _get_children_node_ids_from_db(gint64 father_id);
     void                _remove_db_node_with_children(const gint64 node_id);

--- a/future/src/ct/ct_storage_xml.h
+++ b/future/src/ct/ct_storage_xml.h
@@ -36,6 +36,7 @@ class CtAnchoredWidget;
 class CtMainWin;
 class CtTreeIter;
 class CtTableCell;
+class CtStorageCache;
 
 class CtStorageXml : public CtStorageEntity
 {    
@@ -57,7 +58,7 @@ public:
                                                       std::list<CtAnchoredWidget*>& widgets) const override;
 private:
     Gtk::TreeIter  _node_from_xml(xmlpp::Element* xml_element, Gtk::TreeIter parent_iter, gint64 new_id);
-    void           _nodes_to_xml(CtTreeIter* ct_tree_iter, xmlpp::Element* p_node_parent);
+    void           _nodes_to_xml(CtTreeIter* ct_tree_iter, xmlpp::Element* p_node_parent, CtStorageCache* storage_cache);
 
 private:
     CtMainWin* _pCtMainWin{nullptr};
@@ -70,7 +71,7 @@ class CtStorageXmlHelper
 public:
     CtStorageXmlHelper(CtMainWin* pCtMainWin);
 
-    xmlpp::Element*           node_to_xml(CtTreeIter* ct_tree_iter, xmlpp::Element* p_node_parent, bool with_widgets);
+    xmlpp::Element*           node_to_xml(CtTreeIter* ct_tree_iter, xmlpp::Element* p_node_parent, bool with_widgets, CtStorageCache* storage_cache);
 
     Glib::RefPtr<Gsv::Buffer> create_buffer_and_widgets_from_xml(xmlpp::Element* parent_xml_element, const Glib::ustring& syntax,
                                                           std::list<CtAnchoredWidget*>& widgets, Gtk::TextIter* text_insert_pos, int force_offset);

--- a/future/src/ct/ct_table.cc
+++ b/future/src/ct/ct_table.cc
@@ -115,7 +115,7 @@ void CtTable::apply_syntax_highlighting()
     _apply_styles_to_cells();
 }
 
-void CtTable::to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment)
+void CtTable::to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment, CtStorageCache*)
 {
     // todo: fix a duplicate in imports.cc
     xmlpp::Element* p_table_node = p_node_parent->add_child("table");
@@ -147,7 +147,7 @@ void CtTable::_populate_xml_rows_cells(xmlpp::Element* p_table_node)
     row_to_xml(_tableMatrix.front());
 }
 
-bool CtTable::to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment)
+bool CtTable::to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment, CtStorageCache*)
 {
     bool retVal{true};
     sqlite3_stmt *p_stmt;

--- a/future/src/ct/ct_table.h
+++ b/future/src/ct/ct_table.h
@@ -60,8 +60,8 @@ public:
 
     void apply_width_height(const int /*parentTextWidth*/) override {}
     void apply_syntax_highlighting() override;
-    void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment) override;
-    bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) override;
+    void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment, CtStorageCache* cache) override;
+    bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment, CtStorageCache* cache) override;
     /**
      * @brief Serialise to csv format
      * The output CSV excel csv with double quotes around cells and newlines for each record

--- a/future/src/ct/ct_widgets.h
+++ b/future/src/ct/ct_widgets.h
@@ -48,8 +48,11 @@ protected:
     std::unordered_map<std::string,gchar*> _mapHiddenFiles;
 };
 
+
+
 class CtMainWin;
 class CtAnchoredWidgetState;
+class CtStorageCache;
 
 class CtAnchoredWidget : public Gtk::EventBox
 {
@@ -62,8 +65,8 @@ public:
 
     virtual void apply_width_height(const int parentTextWidth) = 0;
     virtual void apply_syntax_highlighting() = 0;
-    virtual void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment) = 0;
-    virtual bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment) = 0;
+    virtual void to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment, CtStorageCache* cache) = 0;
+    virtual bool to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adjustment, CtStorageCache* cache) = 0;
     virtual void set_modified_false() = 0;
     virtual CtAnchWidgType get_type() = 0;
     virtual std::shared_ptr<CtAnchoredWidgetState> get_state() = 0;

--- a/future/tests/tests_misc_utils.cpp
+++ b/future/tests/tests_misc_utils.cpp
@@ -346,7 +346,7 @@ TEST(MiscUtilsGroup, mime__type_contains)
 
 TEST(MiscUtilsGroup, parallel_for)
 {
-    auto check_vec = [](const std::vector<int>& vec, const size_t& first, const size_t& last) -> bool {
+    auto check_range_in_vec = [](const std::vector<int>& vec, const size_t& first, const size_t& last) -> bool {
         for (size_t i = 0; i < vec.size(); ++i) {
             if (i >= first && i < last) {
                 if (vec[i] != 1)
@@ -357,20 +357,24 @@ TEST(MiscUtilsGroup, parallel_for)
         return true;
     };
 
-    // test check_vec
+    // test check_range_in_vec
     std::vector<int> vec(4, 0);
-    CHECK(check_vec(vec, 0, 0) == true);
-    CHECK(check_vec(vec, 0, 1) == false);
+    CHECK(check_range_in_vec(vec, 0, 0) == true);
+    CHECK(check_range_in_vec(vec, 0, 1) == false);
     vec[1] = 1;
-    CHECK(check_vec(vec, 1, 1) == false);
-    CHECK(check_vec(vec, 1, 2) == true);
+    CHECK(check_range_in_vec(vec, 1, 1) == false);
+    CHECK(check_range_in_vec(vec, 1, 2) == true);
     vec[1] = 2;
-    CHECK(check_vec(vec, 1, 1) == false);
-    CHECK(check_vec(vec, 1, 2) == false);
+    CHECK(check_range_in_vec(vec, 1, 1) == false);
+    CHECK(check_range_in_vec(vec, 1, 2) == false);
 
 
 
-    // check all possible index combinations
+    // parallel_for splits the given range on slices, one slice per thread.
+    // The formula to calculate slices is not simple, so the unit test checks that every element
+    // in the given range is processed, processed only once, no one is skipped,
+    // and elements that are out of the range should not be touched.
+    // To be sure, it is checked for different combinations of ranges, including empty range.
     size_t vec_len = 30;
     for (size_t first = 0; first < vec_len; ++first)
         for (size_t last = first; last < vec_len; ++last)
@@ -379,7 +383,7 @@ TEST(MiscUtilsGroup, parallel_for)
             CtMiscUtil::parallel_for(first, last, [&](size_t index){
                 vec[index] += 1;
             });
-            CHECK(check_vec(vec, first, last));
+            CHECK(check_range_in_vec(vec, first, last));
         }
 }
 

--- a/future/tests/tests_misc_utils.cpp
+++ b/future/tests/tests_misc_utils.cpp
@@ -344,6 +344,46 @@ TEST(MiscUtilsGroup, mime__type_contains)
 }
 
 
+TEST(MiscUtilsGroup, parallel_for)
+{
+    auto check_vec = [](const std::vector<int>& vec, const size_t& first, const size_t& last) -> bool {
+        for (size_t i = 0; i < vec.size(); ++i) {
+            if (i >= first && i < last) {
+                if (vec[i] != 1)
+                    return false;
+            } else if (vec[i] != 0)
+                return false;
+        }
+        return true;
+    };
+
+    // test check_vec
+    std::vector<int> vec(4, 0);
+    CHECK(check_vec(vec, 0, 0) == true);
+    CHECK(check_vec(vec, 0, 1) == false);
+    vec[1] = 1;
+    CHECK(check_vec(vec, 1, 1) == false);
+    CHECK(check_vec(vec, 1, 2) == true);
+    vec[1] = 2;
+    CHECK(check_vec(vec, 1, 1) == false);
+    CHECK(check_vec(vec, 1, 2) == false);
+
+
+
+    // check all possible index combinations
+    size_t vec_len = 30;
+    for (size_t first = 0; first < vec_len; ++first)
+        for (size_t last = first; last < vec_len; ++last)
+        {
+            std::vector<int> vec(vec_len + 1, 0);
+            CtMiscUtil::parallel_for(first, last, [&](size_t index){
+                vec[index] += 1;
+            });
+            CHECK(check_vec(vec, first, last));
+        }
+}
+
+
 
 TEST_GROUP(FileSystemGroup)
 {
@@ -360,6 +400,7 @@ TEST(FileSystemGroup, get_file_stem)
     STRCMP_EQUAL(".txt", CtFileSystem::get_file_stem("/root/.txt").c_str());
 #endif
 }
+
 
 
 int main(int ac, char** av)


### PR DESCRIPTION
Resolves #854

**Issue**: saving pixbuffers into buffers is slow. Many images (e.g. when nodes are imported, or edited node has a lot of images) noticeably slow down saving.
**Solution**: gather all pixbuffers and save them into buffers concurrently. Pass saved buffers in `CtStorageCache` (which can be skipped, then code will work as it worked before)

Notes:
- `tbb::parallel_for` is ideal here, but that adds `libtbb-dev` dependency. Concurrent STL also uses `tbb`, and for some reason it doesn't parallel calculation, I don't know why. Glib has some task classes, but they are really complicated and I concur they have different purpose.
I wrote `parallel_for` by using `std::thread` and `std::packaged_task`. The function is covered by unit tests.
- on my machine, 50 images: old code - 16 seconds; new code - 4.3 seconds.
- improvement works for sqlite and xml

Someone comments?
