### PR TITLE
fixes reading double backslashes from config file

### DIFF
--- a/future/src/ct/ct_config.h
+++ b/future/src/ct/ct_config.h
@@ -200,7 +200,7 @@ protected:
         {
             try
             {
-                *pTarget = _uKeyFile->get_value(_currentGroup, key);
+                *pTarget = _uKeyFile->get_string(_currentGroup, key);
                 gotIt = true;
             }
             catch (Glib::KeyFileError& kferror)


### PR DESCRIPTION
Resolves  #930

But config.cfg will old file paths will still show double backslashes, to users have to themselves to remove them one way or another.