### PR TITLE
Refractor CtFileSystem

### DIFF
--- a/future/src/ct/CMakeLists.txt
+++ b/future/src/ct/CMakeLists.txt
@@ -59,6 +59,7 @@ set(CT_SHARED_FILES
     ct_parser_md.cc
     ct_parser.cc
     ct_process.cc
+    ct_filesystem.cc
     )
 
 add_library(cherrytree_shared STATIC ${CT_SHARED_FILES})

--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -57,7 +57,7 @@ private:
 
 private:
     size_t                          _next_opened_emb_file_id{1};
-    std::map<Glib::ustring, time_t> _embfiles_opened;
+    std::map<fs::path, time_t>      _embfiles_opened;
     sigc::connection                _embfiles_timeout_connection;
 
 private:
@@ -418,13 +418,13 @@ public:
 
 private:
     // helper for export actions
-    void _export_print(bool save_to_pdf, Glib::ustring auto_path, bool auto_overwrite);
-    void _export_to_html(Glib::ustring auto_path, bool auto_overwrite);
-    void _export_to_txt(bool is_single, Glib::ustring auto_path, bool auto_overwrite);
+    void _export_print(bool save_to_pdf, const fs::path& auto_path, bool auto_overwrite);
+    void _export_to_html(const fs::path& auto_path, bool auto_overwrite);
+    void _export_to_txt(bool is_single, const fs::path& auto_path, bool auto_overwrite);
 
-    Glib::ustring _get_pdf_filepath(Glib::ustring proposed_name);
-    Glib::ustring _get_txt_filepath(Glib::ustring proposed_name);
-    Glib::ustring _get_txt_folder(Glib::ustring dir_place, Glib::ustring new_folder, bool export_overwrite);
+    fs::path _get_pdf_filepath(const fs::path& proposed_name);
+    fs::path _get_txt_filepath(const fs::path& proposed_name);
+    fs::path _get_txt_folder(fs::path dir_place, fs::path new_folder, bool export_overwrite);
 
 public:
     // export actions

--- a/future/src/ct/ct_actions_edit.cc
+++ b/future/src/ct/ct_actions_edit.cc
@@ -184,7 +184,7 @@ void CtActions::embfile_insert()
     if (filepath.empty()) return;
 
     _pCtMainWin->get_ct_config()->pickDirFile = Glib::path_get_dirname(filepath);
-    if (CtFileSystem::file_size(filepath) > static_cast<uintmax_t>(_pCtMainWin->get_ct_config()->embfileMaxSize * 1024 * 1024))
+    if (fs::file_size(filepath) > static_cast<uintmax_t>(_pCtMainWin->get_ct_config()->embfileMaxSize * 1024 * 1024))
     {
         CtDialogs::error_dialog(str::format(_("The Maximum Size for Embedded Files is %s MB"), _pCtMainWin->get_ct_config()->embfileMaxSize), *_pCtMainWin);
         return;

--- a/future/src/ct/ct_actions_edit.cc
+++ b/future/src/ct/ct_actions_edit.cc
@@ -184,7 +184,7 @@ void CtActions::embfile_insert()
     if (filepath.empty()) return;
 
     _pCtMainWin->get_ct_config()->pickDirFile = Glib::path_get_dirname(filepath);
-    if (CtFileSystem::getsize(filepath) > _pCtMainWin->get_ct_config()->embfileMaxSize*1024*1024)
+    if (CtFileSystem::file_size(filepath) > static_cast<uintmax_t>(_pCtMainWin->get_ct_config()->embfileMaxSize * 1024 * 1024))
     {
         CtDialogs::error_dialog(str::format(_("The Maximum Size for Embedded Files is %s MB"), _pCtMainWin->get_ct_config()->embfileMaxSize), *_pCtMainWin);
         return;

--- a/future/src/ct/ct_actions_export.cc
+++ b/future/src/ct/ct_actions_export.cc
@@ -85,22 +85,22 @@ void CtActions::export_to_txt_auto(const std::string& dir, bool overwrite)
 }
 
 
-void CtActions::_export_print(bool save_to_pdf, Glib::ustring auto_path, bool auto_overwrite)
+void CtActions::_export_print(bool save_to_pdf, const fs::path& auto_path, bool auto_overwrite)
 {
     if (!_is_there_selected_node_or_error()) return;
-    auto export_type = auto_path != "" ? CtDialogs::CtProcessNode::ALL_TREE
+    auto export_type = !auto_path.empty() ? CtDialogs::CtProcessNode::ALL_TREE
                                        : CtDialogs::selnode_selnodeandsub_alltree_dialog(*_pCtMainWin, true, &_export_options.include_node_name,
                                                                                          &_export_options.new_node_page, nullptr);
     if (export_type == CtDialogs::CtProcessNode::NONE) return;
 
-    Glib::ustring pdf_filepath;
+    fs::path pdf_filepath;
     if (export_type == CtDialogs::CtProcessNode::CURRENT_NODE)
     {
         if (save_to_pdf)
         {
             pdf_filepath = CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter());
             pdf_filepath = _get_pdf_filepath(pdf_filepath);
-            if (pdf_filepath == "") return;
+            if (pdf_filepath.empty()) return;
         }
         CtExport2Pdf(_pCtMainWin).node_export_print(pdf_filepath, _pCtMainWin->curr_tree_iter(), _export_options, -1, -1);
     }
@@ -115,10 +115,10 @@ void CtActions::_export_print(bool save_to_pdf, Glib::ustring auto_path, bool au
     }
     else if (export_type == CtDialogs::CtProcessNode::ALL_TREE)
     {
-        if (auto_path != "")
+        if (!auto_path.empty())
         {
-            pdf_filepath = Glib::build_filename(auto_path, _pCtMainWin->get_ct_storage()->get_file_name() + ".pdf");
-            if (!auto_overwrite && Glib::file_test(pdf_filepath, Glib::FILE_TEST_IS_REGULAR)) {
+            pdf_filepath = auto_path / (_pCtMainWin->get_ct_storage()->get_file_name().string() + ".pdf");
+            if (!auto_overwrite && fs::is_regular_file(pdf_filepath)) {
                 spdlog::info("pdf exists and overwrite is off, export is stopped"); 
                 return;
             }
@@ -126,7 +126,7 @@ void CtActions::_export_print(bool save_to_pdf, Glib::ustring auto_path, bool au
         else if (save_to_pdf)
         {
             pdf_filepath = _get_pdf_filepath(_pCtMainWin->get_ct_storage()->get_file_name());
-            if (pdf_filepath == "") return;
+            if (pdf_filepath.empty()) return;
         }
         CtExport2Pdf(_pCtMainWin).tree_export_print(pdf_filepath, _pCtMainWin->get_tree_store().get_ct_iter_first(), _export_options);
     }
@@ -147,7 +147,7 @@ void CtActions::_export_print(bool save_to_pdf, Glib::ustring auto_path, bool au
 }
 
 // Export to HTML
-void CtActions::_export_to_html(Glib::ustring auto_path, bool auto_overwrite)
+void CtActions::_export_to_html(const fs::path& auto_path, bool auto_overwrite)
 {
     if (!_is_there_selected_node_or_error()) return;
     auto export_type = auto_path != "" ? CtDialogs::CtProcessNode::ALL_TREE
@@ -156,22 +156,22 @@ void CtActions::_export_to_html(Glib::ustring auto_path, bool auto_overwrite)
     if (export_type == CtDialogs::CtProcessNode::NONE) return;
 
     CtExport2Html export2html(_pCtMainWin);
-    Glib::ustring ret_html_path;
+    fs::path ret_html_path;
     if (export_type == CtDialogs::CtProcessNode::CURRENT_NODE)
     {
-        Glib::ustring folder_name = CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter());
+        std::string folder_name = CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter());
         if (export2html.prepare_html_folder("", folder_name, false, ret_html_path))
             export2html.node_export_to_html(_pCtMainWin->curr_tree_iter(), _export_options, "", -1, -1);
     }
     else if (export_type == CtDialogs::CtProcessNode::CURRENT_NODE_AND_SUBNODES)
     {
-        Glib::ustring folder_name = CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter());
+        std::string folder_name = CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter());
         if (export2html.prepare_html_folder("", folder_name, false, ret_html_path))
             export2html.nodes_all_export_to_html(false, _export_options);
     }
     else if (export_type == CtDialogs::CtProcessNode::ALL_TREE)
     {
-        Glib::ustring folder_name = _pCtMainWin->get_ct_storage()->get_file_name();
+        fs::path folder_name = _pCtMainWin->get_ct_storage()->get_file_name();
         if (export2html.prepare_html_folder(auto_path, folder_name, auto_overwrite, ret_html_path))
             export2html.nodes_all_export_to_html(true, _export_options);
     }
@@ -181,18 +181,17 @@ void CtActions::_export_to_html(Glib::ustring auto_path, bool auto_overwrite)
         Gtk::TextIter iter_start, iter_end;
         _curr_buffer()->get_selection_bounds(iter_start, iter_end);
 
-        Glib::ustring folder_name = CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter());
+        std::string folder_name = CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter());
         if (export2html.prepare_html_folder("", folder_name, false, ret_html_path))
             export2html.node_export_to_html(_pCtMainWin->curr_tree_iter(), _export_options, "", iter_start.get_offset(), iter_end.get_offset());
     }
     if (!ret_html_path.empty()) {
-        std::string path(ret_html_path.begin(), ret_html_path.end());
-       CtFileSystem::external_folderpath_open(path, _pCtMainWin->get_ct_config());
+       CtFileSystem::external_folderpath_open(ret_html_path, _pCtMainWin->get_ct_config());
     }
 }
 
 // Export To Plain Text Multiple (or single) Files
-void CtActions::_export_to_txt(bool is_single, Glib::ustring auto_path, bool auto_overwrite)
+void CtActions::_export_to_txt(bool is_single, const fs::path& auto_path, bool auto_overwrite)
 {
     if (!_is_there_selected_node_or_error()) return;
     CtDialogs::CtProcessNode export_type;
@@ -207,23 +206,23 @@ void CtActions::_export_to_txt(bool is_single, Glib::ustring auto_path, bool aut
 
     if (export_type == CtDialogs::CtProcessNode::CURRENT_NODE)
     {
-        Glib::ustring txt_filepath = CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter());
+        fs::path txt_filepath = CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter());
         txt_filepath = _get_txt_filepath(txt_filepath);
-        if (txt_filepath == "") return;
+        if (txt_filepath.empty()) return;
         CtExport2Txt(_pCtMainWin).node_export_to_txt(_pCtMainWin->curr_tree_iter(), txt_filepath, _export_options, -1, -1);
     }
     else if (export_type == CtDialogs::CtProcessNode::CURRENT_NODE_AND_SUBNODES)
     {
         if (is_single)
         {
-           Glib::ustring txt_filepath = _get_txt_filepath(_pCtMainWin->get_ct_storage()->get_file_name());
-           if (txt_filepath == "") return;
+           fs::path txt_filepath = _get_txt_filepath(_pCtMainWin->get_ct_storage()->get_file_name());
+           if (txt_filepath.empty()) return;
            CtExport2Txt(_pCtMainWin).nodes_all_export_to_txt(false, "", txt_filepath, _export_options);
         }
         else
         {
-            Glib::ustring folder_path = _get_txt_folder("", CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter()), false);
-            if (folder_path == "") return;
+            fs::path folder_path = _get_txt_folder("", CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter()), false);
+            if (folder_path.empty()) return;
             CtExport2Txt(_pCtMainWin).nodes_all_export_to_txt(false, folder_path, "", _export_options);
         }
     }
@@ -231,18 +230,18 @@ void CtActions::_export_to_txt(bool is_single, Glib::ustring auto_path, bool aut
     {
         if (is_single)
         {
-            Glib::ustring txt_filepath = _get_txt_filepath(_pCtMainWin->get_ct_storage()->get_file_name());
-            if (txt_filepath == "") return;
+            fs::path txt_filepath = _get_txt_filepath(_pCtMainWin->get_ct_storage()->get_file_name());
+            if (txt_filepath.empty()) return;
             CtExport2Txt(_pCtMainWin).nodes_all_export_to_txt(true, "", txt_filepath, _export_options);
         }
         else
         {
-            Glib::ustring folder_path;
-            if (auto_path != "")
+            fs::path folder_path;
+            if (!auto_path.empty())
                 folder_path = _get_txt_folder(auto_path, _pCtMainWin->get_ct_storage()->get_file_name(), auto_overwrite);
             else
                 folder_path = _get_txt_folder("", _pCtMainWin->get_ct_storage()->get_file_name(), false);
-            if (folder_path == "") return;
+            if (folder_path.empty()) return;
             CtExport2Txt(_pCtMainWin).nodes_all_export_to_txt(true, folder_path, "", _export_options);
         }
     }
@@ -252,52 +251,51 @@ void CtActions::_export_to_txt(bool is_single, Glib::ustring auto_path, bool aut
         Gtk::TextIter iter_start, iter_end;
         _curr_buffer()->get_selection_bounds(iter_start, iter_end);
 
-        Glib::ustring txt_filepath = CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter());
+        fs::path txt_filepath = CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter());
         txt_filepath = _get_txt_filepath(txt_filepath);
-        if (txt_filepath == "") return;
+        if (txt_filepath.empty()) return;
         CtExport2Txt(_pCtMainWin).node_export_to_txt(_pCtMainWin->curr_tree_iter(), txt_filepath, _export_options, iter_start.get_offset(), iter_end.get_offset());
     }
 }
 
-Glib::ustring CtActions::_get_pdf_filepath(Glib::ustring proposed_name)
+fs::path CtActions::_get_pdf_filepath(const fs::path& proposed_name)
 {
     CtDialogs::file_select_args args(_pCtMainWin);
     args.curr_folder = _pCtMainWin->get_ct_config()->pickDirExport;
-    args.curr_file_name = proposed_name + ".pdf";
+    args.curr_file_name = proposed_name.string() + ".pdf";
     args.filter_name = _("PDF File");
     args.filter_pattern = {"*.pdf"};
 
-    Glib::ustring filename = CtDialogs::file_save_as_dialog(args);
-    if (filename != "")
+    fs::path filename = CtDialogs::file_save_as_dialog(args);
+    if (!filename.empty())
     {
-        if (!str::endswith(filename, ".pdf")) filename += ".pdf";
-        _pCtMainWin->get_ct_config()->pickDirExport = Glib::path_get_dirname(filename);
+        if (filename.extension() != ".pdf") filename += ".pdf";
+        _pCtMainWin->get_ct_config()->pickDirExport = filename.parent_path().string();
     }
     return filename;
 }
 
 // Prepare for the txt file save
-Glib::ustring CtActions::_get_txt_filepath(Glib::ustring proposed_name)
+fs::path CtActions::_get_txt_filepath(const fs::path& proposed_name)
 {
     CtDialogs::file_select_args args(_pCtMainWin);
     args.curr_folder = _pCtMainWin->get_ct_config()->pickDirExport;
-    args.curr_file_name = proposed_name + ".txt";
+    args.curr_file_name = proposed_name.string() + ".txt";
     args.filter_name = _("Plain Text Document");
     args.filter_pattern = {"*.txt"};
 
-    Glib::ustring filename = CtDialogs::file_save_as_dialog(args);
-    if (filename != "")
+    fs::path filename = CtDialogs::file_save_as_dialog(args);
+    if (!filename.empty())
     {
-        if (!str::endswith(filename, ".txt")) filename += ".txt";
-        _pCtMainWin->get_ct_config()->pickDirExport = Glib::path_get_dirname(filename);
+        if (filename.extension() != ".txt") filename += ".txt";
+        _pCtMainWin->get_ct_config()->pickDirExport = filename.parent_path().string();
 
-        if (Glib::file_test(filename, Glib::FILE_TEST_IS_REGULAR))
-            g_remove(filename.c_str());
+        if (fs::is_regular_file(filename)) fs::remove(filename);
     }
     return filename;
 }
 
-Glib::ustring CtActions::_get_txt_folder(Glib::ustring dir_place, Glib::ustring new_folder, bool export_overwrite)
+fs::path CtActions::_get_txt_folder(fs::path dir_place, fs::path new_folder, bool export_overwrite)
 {
     if (dir_place == "")
     {
@@ -305,9 +303,9 @@ Glib::ustring CtActions::_get_txt_folder(Glib::ustring dir_place, Glib::ustring 
         if (dir_place == "")
             return "";
     }
-    new_folder = CtMiscUtil::clean_from_chars_not_for_filename(new_folder) + "_TXT";
+    new_folder = CtMiscUtil::clean_from_chars_not_for_filename(new_folder.string()) + "_TXT";
     new_folder = CtFileSystem::prepare_export_folder(dir_place, new_folder, export_overwrite);
-    Glib::ustring export_dir = Glib::build_filename(dir_place, new_folder);
+    fs::path export_dir = dir_place / new_folder;
     g_mkdir_with_parents(export_dir.c_str(), 0777);
 
     return export_dir;

--- a/future/src/ct/ct_actions_export.cc
+++ b/future/src/ct/ct_actions_export.cc
@@ -186,7 +186,7 @@ void CtActions::_export_to_html(const fs::path& auto_path, bool auto_overwrite)
             export2html.node_export_to_html(_pCtMainWin->curr_tree_iter(), _export_options, "", iter_start.get_offset(), iter_end.get_offset());
     }
     if (!ret_html_path.empty()) {
-       CtFileSystem::external_folderpath_open(ret_html_path, _pCtMainWin->get_ct_config());
+       fs::external_folderpath_open(ret_html_path, _pCtMainWin->get_ct_config());
     }
 }
 
@@ -304,7 +304,7 @@ fs::path CtActions::_get_txt_folder(fs::path dir_place, fs::path new_folder, boo
             return "";
     }
     new_folder = CtMiscUtil::clean_from_chars_not_for_filename(new_folder.string()) + "_TXT";
-    new_folder = CtFileSystem::prepare_export_folder(dir_place, new_folder, export_overwrite);
+    new_folder = fs::prepare_export_folder(dir_place, new_folder, export_overwrite);
     fs::path export_dir = dir_place / new_folder;
     g_mkdir_with_parents(export_dir.c_str(), 0777);
 

--- a/future/src/ct/ct_actions_file.cc
+++ b/future/src/ct/ct_actions_file.cc
@@ -60,11 +60,11 @@ void CtActions::file_save_as()
         return;
     }
     CtDialogs::storage_select_args storageSelArgs(_pCtMainWin);
-    std::string currDocFilepath = _pCtMainWin->get_ct_storage()->get_file_path();
+    fs::path currDocFilepath = _pCtMainWin->get_ct_storage()->get_file_path();
     if (not currDocFilepath.empty())
     {
-        storageSelArgs.ctDocType = CtMiscUtil::get_doc_type(currDocFilepath);
-        storageSelArgs.ctDocEncrypt = CtMiscUtil::get_doc_encrypt(currDocFilepath);
+        storageSelArgs.ctDocType = fs::get_doc_type(currDocFilepath);
+        storageSelArgs.ctDocEncrypt = fs::get_doc_encrypt(currDocFilepath);
     }
     if (not CtDialogs::choose_data_storage_dialog(storageSelArgs))
     {
@@ -73,9 +73,9 @@ void CtActions::file_save_as()
     CtDialogs::file_select_args fileSelArgs(_pCtMainWin);
     if (not currDocFilepath.empty())
     {
-        fileSelArgs.curr_folder = Glib::path_get_dirname(currDocFilepath);
-        const std::string suggested_basename = Glib::path_get_basename(currDocFilepath);
-        fileSelArgs.curr_file_name = suggested_basename.substr(0, suggested_basename.size()-4)+CtMiscUtil::get_doc_extension(storageSelArgs.ctDocType, storageSelArgs.ctDocEncrypt);
+        fileSelArgs.curr_folder = currDocFilepath.parent_path();
+        fs::path suggested_basename = currDocFilepath.filename();
+        fileSelArgs.curr_file_name = suggested_basename.stem().string() + CtMiscUtil::get_doc_extension(storageSelArgs.ctDocType, storageSelArgs.ctDocEncrypt);
     }
     fileSelArgs.filter_name = _("CherryTree Document");
     std::string fileExtension = CtMiscUtil::get_doc_extension(storageSelArgs.ctDocType, storageSelArgs.ctDocEncrypt);

--- a/future/src/ct/ct_actions_find.cc
+++ b/future/src/ct/ct_actions_find.cc
@@ -873,7 +873,7 @@ Glib::ustring CtActions::_check_pattern_in_object(Glib::RefPtr<Glib::Regex> patt
 {
     if (CtImageEmbFile* image = dynamic_cast<CtImageEmbFile*>(obj))
     {
-        if (pattern->match(image->get_file_name())) return image->get_file_name();
+        if (pattern->match(image->get_file_name().string())) return image->get_file_name().string();
     }
     else if (CtImageAnchor* image = dynamic_cast<CtImageAnchor*>(obj))
     {

--- a/future/src/ct/ct_actions_help.cc
+++ b/future/src/ct/ct_actions_help.cc
@@ -45,7 +45,7 @@ void CtActions::check_for_newer_version()
     statusbar.update_status(_("Checking for Newer Version..."));
     while (gtk_events_pending()) gtk_main_iteration();
 
-    const std::string latest_version_from_server = str::trim(CtFileSystem::download_file("https://www.giuspen.com/software/version_cherrytree"));
+    std::string latest_version_from_server = str::trim(CtFileSystem::download_file("https://www.giuspen.com/software/version_cherrytree"));
     //g_print("v='%s'\n", latest_version_from_server.c_str());
     if (latest_version_from_server.empty() or latest_version_from_server.size() > 10) {
         statusbar.update_status(_("Failed to Retrieve Latest Version Information - Try Again Later"));

--- a/future/src/ct/ct_actions_help.cc
+++ b/future/src/ct/ct_actions_help.cc
@@ -36,7 +36,7 @@ void CtActions::dialog_about()
 
 void CtActions::folder_cfg_open()
 {
-    CtFileSystem::external_folderpath_open(Glib::get_user_config_dir() / CtFileSystem::path(CtConst::APP_NAME), _pCtMainWin->get_ct_config());
+    fs::external_folderpath_open(Glib::get_user_config_dir() / fs::path(CtConst::APP_NAME), _pCtMainWin->get_ct_config());
 }
 
 void CtActions::check_for_newer_version()
@@ -45,7 +45,7 @@ void CtActions::check_for_newer_version()
     statusbar.update_status(_("Checking for Newer Version..."));
     while (gtk_events_pending()) gtk_main_iteration();
 
-    std::string latest_version_from_server = str::trim(CtFileSystem::download_file("https://www.giuspen.com/software/version_cherrytree"));
+    std::string latest_version_from_server = str::trim(fs::download_file("https://www.giuspen.com/software/version_cherrytree"));
     //g_print("v='%s'\n", latest_version_from_server.c_str());
     if (latest_version_from_server.empty() or latest_version_from_server.size() > 10) {
         statusbar.update_status(_("Failed to Retrieve Latest Version Information - Try Again Later"));

--- a/future/src/ct/ct_actions_others.cc
+++ b/future/src/ct/ct_actions_others.cc
@@ -286,7 +286,7 @@ void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_
              return;
          }
          if (from_wheel)
-             filepath = Glib::path_get_dirname(CtFileSystem::absolute(filepath).string());
+             filepath = CtFileSystem::absolute(filepath).parent_path();
          CtFileSystem::external_filepath_open(filepath, true, _pCtMainWin->get_ct_config());
      }
      else if (vec[0] == CtConst::LINK_TYPE_FOLD) // link to folder

--- a/future/src/ct/ct_actions_others.cc
+++ b/future/src/ct/ct_actions_others.cc
@@ -32,8 +32,6 @@
 #include "ct_logging.h"
 #include <spdlog/fmt/bundled/printf.h>
 
-namespace fs = fs;
-
 // Cut Link
 void CtActions::link_cut()
 {

--- a/future/src/ct/ct_actions_others.cc
+++ b/future/src/ct/ct_actions_others.cc
@@ -149,17 +149,17 @@ void CtActions::embfile_open()
         curr_file_anchor->set_data("open_id", (void*)open_id);
     }
 
-    Glib::ustring filename = std::to_string(_pCtMainWin->curr_tree_iter().get_node_id()) +
+    fs::path filename = std::to_string(_pCtMainWin->curr_tree_iter().get_node_id()) +
             CtConst::CHAR_MINUS + std::to_string(open_id) +
             CtConst::CHAR_MINUS + std::to_string(getpid())+
-            CtConst::CHAR_MINUS + curr_file_anchor->get_file_name();
-    Glib::ustring filepath = _pCtMainWin->get_ct_tmp()->getHiddenFilePath(filename);
-    std::fstream file(filepath, std::ios::out | std::ios::binary);
+            CtConst::CHAR_MINUS + curr_file_anchor->get_file_name().string();
+    fs::path filepath = _pCtMainWin->get_ct_tmp()->getHiddenFilePath(filename);
+    std::fstream file(filepath.string(), std::ios::out | std::ios::binary);
     long size = (long)curr_file_anchor->get_raw_blob().size();
     file.write(curr_file_anchor->get_raw_blob().c_str(), size);
     file.close();
 
-    spdlog::debug("embfile_open {}", static_cast<std::string>(filepath));
+    spdlog::debug("embfile_open {}", filepath);
 
     CtFileSystem::external_filepath_open(filepath.c_str(), false, _pCtMainWin->get_ct_config());
     _embfiles_opened[filepath] = CtFileSystem::getmtime(filepath);
@@ -279,14 +279,14 @@ void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_
      }
      else if (vec[0] == CtConst::LINK_TYPE_FILE) // link to file
      {
-         fs::path filepath = CtExport2Html::_link_process_filepath(vec[1]).c_str();
+         fs::path filepath = CtExport2Html::_link_process_filepath(vec[1]);
          if (not Glib::file_test(filepath.string(), Glib::FILE_TEST_IS_REGULAR))
          {
              CtDialogs::error_dialog(fmt::format(_("The File Link '{}' is Not Valid"), filepath), *_pCtMainWin);
              return;
          }
          if (from_wheel)
-             filepath = Glib::path_get_dirname(CtFileSystem::abspath(filepath).string());
+             filepath = Glib::path_get_dirname(CtFileSystem::absolute(filepath).string());
          CtFileSystem::external_filepath_open(filepath, true, _pCtMainWin->get_ct_config());
      }
      else if (vec[0] == CtConst::LINK_TYPE_FOLD) // link to folder
@@ -298,7 +298,7 @@ void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_
              return;
          }
          if (from_wheel)
-             folderpath = Glib::path_get_dirname(CtFileSystem::abspath(folderpath).string());
+             folderpath = Glib::path_get_dirname(CtFileSystem::absolute(folderpath).string());
          CtFileSystem::external_folderpath_open(folderpath, _pCtMainWin->get_ct_config());
      }
      else if (vec[0] == CtConst::LINK_TYPE_NODE) // link to a tree node
@@ -418,7 +418,7 @@ void CtActions::exec_code()
         code_type = _pCtMainWin->curr_tree_iter().get_node_syntax_highlighting();
         code_val = _curr_buffer()->begin().get_text(_curr_buffer()->end());
     }
-    Glib::ustring binary_cmd = [&]() -> Glib::ustring {
+    std::string binary_cmd = [&]() -> std::string {
         for (auto& it: _pCtMainWin->get_ct_config()->customCodexecType)
             if (it.first == code_type) return it.second;
         for (const auto& it: CtConst::CODE_EXEC_TYPE_CMD_DEFAULT)
@@ -429,7 +429,7 @@ void CtActions::exec_code()
         CtDialogs::warning_dialog(str::format(_("You must associate a command to '%s'.\nDo so in the Preferences Dialog"), code_type), *_pCtMainWin);
         return;
     }
-    Glib::ustring code_type_ext = [&]() -> Glib::ustring {
+    std::string code_type_ext = [&]() -> std::string {
         for (auto& it: _pCtMainWin->get_ct_config()->customCodexecExt)
             if (it.first == code_type) return it.second;
         for (const auto& it: CtConst::CODE_EXEC_TYPE_EXT_DEFAULT)
@@ -438,10 +438,10 @@ void CtActions::exec_code()
     }();
     Glib::ustring code_exec_term = CtPrefDlg::get_code_exec_term_run(_pCtMainWin);
 
-    Glib::ustring filepath_src_tmp = _pCtMainWin->get_ct_tmp()->getHiddenFilePath("exec_code." + code_type_ext);
-    Glib::ustring filepath_bin_tmp = _pCtMainWin->get_ct_tmp()->getHiddenFilePath("exec_code.exe");
-    binary_cmd = str::replace(binary_cmd, CtConst::CODE_EXEC_TMP_SRC, filepath_src_tmp);
-    binary_cmd = str::replace(binary_cmd, CtConst::CODE_EXEC_TMP_BIN, filepath_bin_tmp);
+    fs::path filepath_src_tmp = _pCtMainWin->get_ct_tmp()->getHiddenFilePath("exec_code." + code_type_ext);
+    fs::path filepath_bin_tmp = _pCtMainWin->get_ct_tmp()->getHiddenFilePath("exec_code.exe");
+    binary_cmd = str::replace(binary_cmd, CtConst::CODE_EXEC_TMP_SRC, filepath_src_tmp.string());
+    binary_cmd = str::replace(binary_cmd, CtConst::CODE_EXEC_TMP_BIN, filepath_bin_tmp.string());
     Glib::ustring terminal_cmd = str::replace(code_exec_term, CtConst::CODE_EXEC_COMMAND, binary_cmd);
 
     if (!CtDialogs::question_dialog(std::string("<b>")+_("Do you want to Execute the Code?")+"</b>", *_pCtMainWin))
@@ -718,8 +718,8 @@ bool CtActions::_on_embfiles_sentinel_timeout()
 {
     for(auto& item : _embfiles_opened)
     {
-        const Glib::ustring& filepath = item.first;
-        if (not Glib::file_test(filepath, Glib::FILE_TEST_IS_REGULAR))
+        const fs::path& filepath = item.first;
+        if (not fs::is_regular_file(filepath))
         {
             spdlog::debug("embdrop{}", filepath);
             _embfiles_opened.erase(filepath);
@@ -728,7 +728,7 @@ bool CtActions::_on_embfiles_sentinel_timeout()
         if (item.second != CtFileSystem::getmtime(filepath))
         {
            _embfiles_opened[filepath] = CtFileSystem::getmtime(filepath);
-           auto data_vec = str::split(Glib::path_get_basename(filepath), CtConst::CHAR_MINUS);
+           auto data_vec = str::split(filepath.filename().string(), CtConst::CHAR_MINUS);
            gint64 node_id = std::stoll(data_vec[0]);
            size_t embfile_id = std::stol(data_vec[1]);
 
@@ -745,7 +745,7 @@ bool CtActions::_on_embfiles_sentinel_timeout()
                 if (CtImageEmbFile* embFile = dynamic_cast<CtImageEmbFile*>(widget))
                     if (((size_t)embFile->get_data("open_id")) == embfile_id)
                     {
-                        auto file = std::fstream(filepath, std::ios::in | std::ios::binary);
+                        auto file = std::fstream(filepath.string(), std::ios::in | std::ios::binary);
                         std::vector<char> buffer(std::istreambuf_iterator<char>(file), {});
                         file.close();
                         embFile->set_raw_blob(buffer.data(), buffer.size());
@@ -753,7 +753,7 @@ bool CtActions::_on_embfiles_sentinel_timeout()
                         embFile->update_tooltip();
 
                         _pCtMainWin->update_window_save_needed(CtSaveNeededUpdType::nbuf);
-                        _pCtMainWin->get_status_bar().update_status(_("Embedded File Automatically Updated:") + std::string(CtConst::CHAR_SPACE) + embFile->get_file_name());
+                        _pCtMainWin->get_status_bar().update_status(_("Embedded File Automatically Updated:") + std::string(CtConst::CHAR_SPACE) + embFile->get_file_name().string());
                         break;
                     }
            }

--- a/future/src/ct/ct_actions_others.cc
+++ b/future/src/ct/ct_actions_others.cc
@@ -32,7 +32,7 @@
 #include "ct_logging.h"
 #include <spdlog/fmt/bundled/printf.h>
 
-namespace fs = CtFileSystem;
+namespace fs = fs;
 
 // Cut Link
 void CtActions::link_cut()
@@ -161,8 +161,8 @@ void CtActions::embfile_open()
 
     spdlog::debug("embfile_open {}", filepath);
 
-    CtFileSystem::external_filepath_open(filepath.c_str(), false, _pCtMainWin->get_ct_config());
-    _embfiles_opened[filepath] = CtFileSystem::getmtime(filepath);
+    fs::external_filepath_open(filepath.c_str(), false, _pCtMainWin->get_ct_config());
+    _embfiles_opened[filepath] = fs::getmtime(filepath);
 
     if (not _embfiles_timeout_connection)
         _embfiles_timeout_connection = Glib::signal_timeout().connect(sigc::mem_fun(*this, &CtActions::_on_embfiles_sentinel_timeout), 500);
@@ -282,24 +282,24 @@ void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_
          fs::path filepath = CtExport2Html::_link_process_filepath(vec[1]);
          if (not Glib::file_test(filepath.string(), Glib::FILE_TEST_IS_REGULAR))
          {
-             CtDialogs::error_dialog(fmt::format(_("The File Link '{}' is Not Valid"), filepath), *_pCtMainWin);
+             CtDialogs::error_dialog(str::format(_("The File Link '%s' is Not Valid"), filepath.string()), *_pCtMainWin);
              return;
          }
          if (from_wheel)
-             filepath = CtFileSystem::absolute(filepath).parent_path();
-         CtFileSystem::external_filepath_open(filepath, true, _pCtMainWin->get_ct_config());
+             filepath = fs::absolute(filepath).parent_path();
+         fs::external_filepath_open(filepath, true, _pCtMainWin->get_ct_config());
      }
      else if (vec[0] == CtConst::LINK_TYPE_FOLD) // link to folder
      {
          fs::path folderpath = CtExport2Html::_link_process_folderpath(vec[1]).c_str();
          if (not fs::is_directory(folderpath))
          {
-             CtDialogs::error_dialog(fmt::format(_("The Folder Link '{}' is Not Valid"), folderpath), *_pCtMainWin);
+             CtDialogs::error_dialog(str::format(_("The Folder Link '%s' is Not Valid"), folderpath.string()), *_pCtMainWin);
              return;
          }
          if (from_wheel)
-             folderpath = Glib::path_get_dirname(CtFileSystem::absolute(folderpath).string());
-         CtFileSystem::external_folderpath_open(folderpath, _pCtMainWin->get_ct_config());
+             folderpath = Glib::path_get_dirname(fs::absolute(folderpath).string());
+         fs::external_folderpath_open(folderpath, _pCtMainWin->get_ct_config());
      }
      else if (vec[0] == CtConst::LINK_TYPE_NODE) // link to a tree node
      {
@@ -725,9 +725,9 @@ bool CtActions::_on_embfiles_sentinel_timeout()
             _embfiles_opened.erase(filepath);
             break;
         }
-        if (item.second != CtFileSystem::getmtime(filepath))
+        if (item.second != fs::getmtime(filepath))
         {
-           _embfiles_opened[filepath] = CtFileSystem::getmtime(filepath);
+           _embfiles_opened[filepath] = fs::getmtime(filepath);
            auto data_vec = str::split(filepath.filename().string(), CtConst::CHAR_MINUS);
            gint64 node_id = std::stoll(data_vec[0]);
            size_t embfile_id = std::stol(data_vec[1]);

--- a/future/src/ct/ct_app.cc
+++ b/future/src/ct/ct_app.cc
@@ -52,8 +52,8 @@ CtApp::CtApp() : Gtk::Application("com.giuspen.cherrytree", Gio::APPLICATION_HAN
 
     _rLanguageManager = Gsv::LanguageManager::create();
     std::vector<std::string> searchPath = _rLanguageManager->get_search_path();
-    const std::string ctLanguagesSpecsPath = Glib::build_filename(CtFileSystem::get_cherrytree_datadir(), "language-specs");
-    searchPath.push_back(ctLanguagesSpecsPath);
+    fs::path ctLanguagesSpecsPath = CtFileSystem::get_cherrytree_datadir() /"language-specs";
+    searchPath.push_back(ctLanguagesSpecsPath.string());
     _rLanguageManager->set_search_path(searchPath);
 
     _rStyleSchemeManager = Gsv::StyleSchemeManager::create();

--- a/future/src/ct/ct_app.cc
+++ b/future/src/ct/ct_app.cc
@@ -100,7 +100,7 @@ void CtApp::on_activate()
         CtMainWin* pAppWindow = _create_window(false);
         if (not CtApp::_uCtCfg->recentDocsFilepaths.empty())
         {
-            Glib::RefPtr<Gio::File> r_file = Gio::File::create_for_path(CtApp::_uCtCfg->recentDocsFilepaths.front());
+            Glib::RefPtr<Gio::File> r_file = Gio::File::create_for_path(CtApp::_uCtCfg->recentDocsFilepaths.front().string());
             if (r_file->query_exists())
             {
                 if (not pAppWindow->file_open(r_file->get_path(), ""))

--- a/future/src/ct/ct_app.cc
+++ b/future/src/ct/ct_app.cc
@@ -52,7 +52,7 @@ CtApp::CtApp() : Gtk::Application("com.giuspen.cherrytree", Gio::APPLICATION_HAN
 
     _rLanguageManager = Gsv::LanguageManager::create();
     std::vector<std::string> searchPath = _rLanguageManager->get_search_path();
-    fs::path ctLanguagesSpecsPath = CtFileSystem::get_cherrytree_datadir() /"language-specs";
+    fs::path ctLanguagesSpecsPath = fs::get_cherrytree_datadir() / "language-specs";
     searchPath.push_back(ctLanguagesSpecsPath.string());
     _rLanguageManager->set_search_path(searchPath);
 

--- a/future/src/ct/ct_config.cc
+++ b/future/src/ct/ct_config.cc
@@ -22,6 +22,7 @@
  */
 
 #include <iostream>
+#include <memory>
 #include <gtkmm.h>
 #include "ct_config.h"
 #include "ct_misc_utils.h"
@@ -29,7 +30,7 @@
 #include "ct_filesystem.h"
 
 
-const std::string CtConfig::_defaultFilepath{Glib::build_filename(CtFileSystem::get_cherrytree_configdir(), "config.cfg")};
+const fs::path CtConfig::_defaultFilepath{CtFileSystem::get_cherrytree_configdir() / "config.cfg"};
 
 CtConfig::CtConfig()
 {
@@ -41,12 +42,12 @@ CtConfig::~CtConfig()
     //std::cout << "~CtConfig()" << std::endl;
 }
 
-bool CtConfig::load_from_file(const std::string& filepath)
+bool CtConfig::load_from_file(const fs::path& filepath)
 {
-    if (Glib::file_test(filepath, Glib::FILE_TEST_EXISTS))
+    if (fs::exists(filepath))
     {
-        _uKeyFile.reset(new Glib::KeyFile);
-        _uKeyFile->load_from_file(filepath);
+        _uKeyFile = std::make_unique<Glib::KeyFile>();
+        _uKeyFile->load_from_file(filepath.string());
         _populate_data_from_keyfile();
         _uKeyFile.reset(nullptr);
         spdlog::debug("{} parsed", filepath);
@@ -56,11 +57,11 @@ bool CtConfig::load_from_file(const std::string& filepath)
     return false;
 }
 
-bool CtConfig::write_to_file(const std::string& filepath)
+bool CtConfig::write_to_file(const fs::path& filepath)
 {
-    _uKeyFile.reset(new Glib::KeyFile);
+    _uKeyFile = std::make_unique<Glib::KeyFile>();
     _populate_keyfile_from_data();
-    const bool writeSucceeded = _uKeyFile->save_to_file(filepath);
+    const bool writeSucceeded = _uKeyFile->save_to_file(filepath.string());
     _uKeyFile.reset(nullptr);
     return writeSucceeded;
 }

--- a/future/src/ct/ct_config.cc
+++ b/future/src/ct/ct_config.cc
@@ -30,7 +30,7 @@
 #include "ct_filesystem.h"
 
 
-const fs::path CtConfig::_defaultFilepath{CtFileSystem::get_cherrytree_configdir() / "config.cfg"};
+const fs::path CtConfig::_defaultFilepath{fs::get_cherrytree_configdir() / "config.cfg"};
 
 CtConfig::CtConfig()
 {

--- a/future/src/ct/ct_config.cc
+++ b/future/src/ct/ct_config.cc
@@ -26,6 +26,7 @@
 #include "ct_config.h"
 #include "ct_misc_utils.h"
 #include "ct_logging.h"
+#include "ct_filesystem.h"
 
 
 const std::string CtConfig::_defaultFilepath{Glib::build_filename(CtFileSystem::get_cherrytree_configdir(), "config.cfg")};
@@ -157,11 +158,11 @@ void CtConfig::_populate_keyfile_from_data()
     // [state]
     _currentGroup = "state";
     guint i{0};
-    for (const std::string& filepath : recentDocsFilepaths)
+    for (const fs::path& filepath : recentDocsFilepaths)
     {
         snprintf(_tempKey, _maxTempKeySize, "doc_%d", i);
-        _uKeyFile->set_string(_currentGroup, _tempKey, filepath);
-        const CtRecentDocsRestore::iterator mapIt = recentDocsRestore.find(filepath);
+        _uKeyFile->set_string(_currentGroup, _tempKey, filepath.string());
+        const CtRecentDocsRestore::iterator mapIt = recentDocsRestore.find(filepath.string());
         if (mapIt != recentDocsRestore.end())
         {
             snprintf(_tempKey, _maxTempKeySize, "expcol_%d", i);
@@ -383,7 +384,7 @@ void CtConfig::_populate_data_from_keyfile()
         {
             recentDocRestore.node_path = str::replace(recentDocRestore.node_path, " ", ":");
             _populate_int_from_keyfile("cursor_position", &recentDocRestore.cursor_pos);
-            recentDocsRestore[recentDocsFilepaths.front()] = recentDocRestore;
+            recentDocsRestore[recentDocsFilepaths.front().string()] = recentDocRestore;
         }
     }
     _populate_string_from_keyfile("pick_dir_import", &pickDirImport);
@@ -418,7 +419,7 @@ void CtConfig::_populate_data_from_keyfile()
         std::string exp_coll_str;
         if (_populate_string_from_keyfile("expanded_collapsed_string", &exp_coll_str))
         {
-            recentDocsRestore[recentDocsFilepaths.front()].exp_coll_str = exp_coll_str;
+            recentDocsRestore[recentDocsFilepaths.front().string()].exp_coll_str = exp_coll_str;
         }
         for (guint i=1; i<=3; ++i)
         {
@@ -426,9 +427,9 @@ void CtConfig::_populate_data_from_keyfile()
             snprintf(_tempKey, _maxTempKeySize, "expcollnam%d", i);
             if (_populate_string_from_keyfile(_tempKey, &docName))
             {
-                for (const std::string& filepath : recentDocsFilepaths)
+                for (const fs::path& filepath : recentDocsFilepaths)
                 {
-                    if (Glib::path_get_basename(filepath) == docName)
+                    if (filepath.filename() == docName)
                     {
                         CtRecentDocRestore recentDocRestore;
                         snprintf(_tempKey, _maxTempKeySize, "expcollstr%d", i);
@@ -440,7 +441,7 @@ void CtConfig::_populate_data_from_keyfile()
                             snprintf(_tempKey, _maxTempKeySize, "expcollcur%d", i);
                             _populate_int_from_keyfile(_tempKey, &recentDocRestore.cursor_pos);
                         }
-                        recentDocsRestore[filepath] = recentDocRestore;
+                        recentDocsRestore[filepath.string()] = recentDocRestore;
                     }
                 }
             }

--- a/future/src/ct/ct_config.h
+++ b/future/src/ct/ct_config.h
@@ -38,8 +38,8 @@ public:
     CtConfig();
     virtual ~CtConfig();
 
-    bool load_from_file(const std::string& filepath=_defaultFilepath);
-    bool write_to_file(const std::string& filepath=_defaultFilepath);
+    bool load_from_file(const fs::path& filepath = _defaultFilepath);
+    bool write_to_file(const fs::path& filepath = _defaultFilepath);
 
     // [state]
     CtRecentDocsRestore                         recentDocsRestore;
@@ -221,7 +221,7 @@ protected:
     void _unexpected_keyfile_error(const gchar* key, const Glib::KeyFileError& kferror);
 
     static const size_t _maxTempKeySize{20};
-    static const std::string _defaultFilepath;
+    static const fs::path _defaultFilepath;
 
     gchar _tempKey[_maxTempKeySize];
     std::unique_ptr<Glib::KeyFile> _uKeyFile;

--- a/future/src/ct/ct_config.h
+++ b/future/src/ct/ct_config.h
@@ -29,6 +29,7 @@
 #include "ct_const.h"
 #include "ct_types.h"
 #include "ct_splittable.h"
+#include "ct_filesystem.h"
 
 class CtConfig
 {

--- a/future/src/ct/ct_dialogs.cc
+++ b/future/src/ct/ct_dialogs.cc
@@ -938,7 +938,7 @@ bool CtDialogs::link_handle_dialog(CtMainWin& ctMainWin,
         if (ctMainWin.get_ct_config()->linksRelative)
         {
             Glib::RefPtr<Gio::File> rFile = Gio::File::create_for_path(filepath);
-            Glib::RefPtr<Gio::File> rDir = Gio::File::create_for_path(ctMainWin.get_ct_storage()->get_file_dir());
+            Glib::RefPtr<Gio::File> rDir = Gio::File::create_for_path(ctMainWin.get_ct_storage()->get_file_dir().string());
             filepath = rFile->get_relative_path(rDir);
         }
         entry_file.set_text(filepath);
@@ -954,7 +954,7 @@ bool CtDialogs::link_handle_dialog(CtMainWin& ctMainWin,
         if (ctMainWin.get_ct_config()->linksRelative)
         {
             Glib::RefPtr<Gio::File> rFile = Gio::File::create_for_path(filepath);
-            Glib::RefPtr<Gio::File> rDir = Gio::File::create_for_path(ctMainWin.get_ct_storage()->get_file_dir());
+            Glib::RefPtr<Gio::File> rDir = Gio::File::create_for_path(ctMainWin.get_ct_storage()->get_file_dir().string());
             filepath = rFile->get_relative_path(rDir);
         }
         entry_folder.set_text(filepath);
@@ -1081,15 +1081,15 @@ std::string CtDialogs::file_select_dialog(const file_select_args& args)
     {
         chooser.set_position(Gtk::WIN_POS_CENTER);
     }
-    if (args.curr_folder.empty() || !Glib::file_test(args.curr_folder, Glib::FILE_TEST_IS_DIR))
+    if (args.curr_folder.empty() || !fs::is_directory(args.curr_folder))
     {
         chooser.set_current_folder(g_get_home_dir());
     }
     else
     {
-        chooser.set_current_folder(args.curr_folder);
+        chooser.set_current_folder(args.curr_folder.string());
     }
-    if (args.filter_pattern.size() || args.filter_mime.size())
+    if (!args.filter_pattern.empty() || !args.filter_mime.empty())
     {
         Glib::RefPtr<Gtk::FileFilter> rFileFilter = Gtk::FileFilter::create();
         rFileFilter->set_name(args.filter_name);
@@ -1155,17 +1155,17 @@ std::string CtDialogs::file_save_as_dialog(const file_select_args& args)
     {
         chooser.set_position(Gtk::WIN_POS_CENTER);
     }
-    if (args.curr_folder.empty() || !Glib::file_test(args.curr_folder, Glib::FILE_TEST_IS_DIR))
+    if (args.curr_folder.empty() || !fs::is_directory(args.curr_folder))
     {
         chooser.set_current_folder(g_get_home_dir());
     }
     else
     {
-        chooser.set_current_folder(args.curr_folder);
+        chooser.set_current_folder(args.curr_folder.string());
     }
     if (!args.curr_file_name.empty())
     {
-        chooser.set_current_name(args.curr_file_name);
+        chooser.set_current_name(args.curr_file_name.string());
     }
     if (!args.filter_pattern.empty())
     {

--- a/future/src/ct/ct_dialogs.h
+++ b/future/src/ct/ct_dialogs.h
@@ -24,7 +24,7 @@
 #pragma once
 
 #include "ct_misc_utils.h"
-
+#include "ct_filesystem.h"
 #include <gtkmm/dialog.h>
 #include <gtkmm/liststore.h>
 #include <gtkmm/treestore.h>
@@ -229,8 +229,8 @@ bool link_handle_dialog(CtMainWin& ctMainWin,
 struct file_select_args
 {
     Gtk::Window*                pParentWin{nullptr};
-    std::string                 curr_folder;
-    std::string                 curr_file_name;
+    fs::path                    curr_folder;
+    fs::path                    curr_file_name;
     Glib::ustring               filter_name;
     std::vector<std::string>    filter_pattern;
     std::vector<std::string>    filter_mime;

--- a/future/src/ct/ct_export2html.cc
+++ b/future/src/ct/ct_export2html.cc
@@ -69,9 +69,10 @@ bool CtExport2Html::prepare_html_folder(fs::path dir_place, fs::path new_folder,
     fs::path styles_js_filepath = config_dir / "script3.js";
     if (!fs::is_regular_file(styles_js_filepath))
     {
-        std::string script_js_original = Glib::build_filename(CtFileSystem::get_cherrytree_datadir(), "data", "script3.js");
+        fs::path script_js_original = CtFileSystem::get_cherrytree_datadir() / "data" / "script3.js";
         CtFileSystem::copy_file(script_js_original, styles_js_filepath);
     }
+
     CtFileSystem::copy_file(styles_js_filepath, _res_dir / "script3.js");
 
     export_path = _export_dir;

--- a/future/src/ct/ct_export2html.cc
+++ b/future/src/ct/ct_export2html.cc
@@ -47,7 +47,7 @@ bool CtExport2Html::prepare_html_folder(fs::path dir_place, fs::path new_folder,
             return false;
     }
     new_folder = CtMiscUtil::clean_from_chars_not_for_filename(new_folder.string()) + "_HTML";
-    new_folder = CtFileSystem::prepare_export_folder(dir_place, new_folder, export_overwrite);
+    new_folder = fs::prepare_export_folder(dir_place, new_folder, export_overwrite);
     _export_dir = dir_place / new_folder;
     _images_dir = _export_dir / "images";
     _embed_dir = _export_dir / "EmbeddedFiles";
@@ -61,19 +61,19 @@ bool CtExport2Html::prepare_html_folder(fs::path dir_place, fs::path new_folder,
     fs::path styles_css_filepath = config_dir / "styles3.css";
     if (!fs::is_regular_file(styles_css_filepath))
     {
-        fs::path styles_css_original = fs::path(CtFileSystem::get_cherrytree_datadir()) / fs::path("data") / "styles3.css";
-        CtFileSystem::copy_file(styles_css_original, styles_css_filepath);
+        fs::path styles_css_original = fs::path(fs::get_cherrytree_datadir()) / fs::path("data") / "styles3.css";
+        fs::copy_file(styles_css_original, styles_css_filepath);
     }
-    CtFileSystem::copy_file(styles_css_filepath, _res_dir / "styles3.css");
+    fs::copy_file(styles_css_filepath, _res_dir / "styles3.css");
     
     fs::path styles_js_filepath = config_dir / "script3.js";
     if (!fs::is_regular_file(styles_js_filepath))
     {
-        fs::path script_js_original = CtFileSystem::get_cherrytree_datadir() / "data" / "script3.js";
-        CtFileSystem::copy_file(script_js_original, styles_js_filepath);
+        fs::path script_js_original = fs::get_cherrytree_datadir() / "data" / "script3.js";
+        fs::copy_file(script_js_original, styles_js_filepath);
     }
 
-    CtFileSystem::copy_file(styles_js_filepath, _res_dir / "script3.js");
+    fs::copy_file(styles_js_filepath, _res_dir / "script3.js");
 
     export_path = _export_dir;
 

--- a/future/src/ct/ct_export2html.cc
+++ b/future/src/ct/ct_export2html.cc
@@ -38,41 +38,41 @@ CtExport2Html::CtExport2Html(CtMainWin* pCtMainWin)
 }
 
 //Prepare the website folder
-bool CtExport2Html::prepare_html_folder(Glib::ustring dir_place, Glib::ustring new_folder, bool export_overwrite, Glib::ustring& export_path)
+bool CtExport2Html::prepare_html_folder(fs::path dir_place, fs::path new_folder, bool export_overwrite, fs::path& export_path)
 {
-    if (dir_place == "")
+    if (dir_place.empty())
     {
         dir_place = CtDialogs::folder_select_dialog(_pCtMainWin->get_ct_config()->pickDirExport, _pCtMainWin);
-        if (dir_place == "")
+        if (dir_place.empty())
             return false;
     }
-    new_folder = CtMiscUtil::clean_from_chars_not_for_filename(new_folder) + "_HTML";
+    new_folder = CtMiscUtil::clean_from_chars_not_for_filename(new_folder.string()) + "_HTML";
     new_folder = CtFileSystem::prepare_export_folder(dir_place, new_folder, export_overwrite);
-    _export_dir = Glib::build_filename(dir_place, new_folder);
-    _images_dir = Glib::build_filename(_export_dir, "images");
-    _embed_dir = Glib::build_filename(_export_dir, "EmbeddedFiles");
-    _res_dir = Glib::build_filename(_export_dir, "res");
+    _export_dir = dir_place / new_folder;
+    _images_dir = _export_dir / "images";
+    _embed_dir = _export_dir / "EmbeddedFiles";
+    _res_dir = _export_dir / "res";
     g_mkdir_with_parents(_export_dir.c_str(), 0777);
     g_mkdir_with_parents(_images_dir.c_str(), 0777);
     g_mkdir_with_parents(_embed_dir.c_str(), 0777);
     g_mkdir_with_parents(_res_dir.c_str(), 0777);
 
-    Glib::ustring config_dir = Glib::build_filename(Glib::get_user_config_dir(), CtConst::APP_NAME);
-    Glib::ustring styles_css_filepath = Glib::build_filename(config_dir, "styles3.css");
-    if (!Glib::file_test(styles_css_filepath, Glib::FILE_TEST_IS_REGULAR))
+    fs::path config_dir = fs::path(Glib::get_user_config_dir()) / CtConst::APP_NAME;
+    fs::path styles_css_filepath = config_dir / "styles3.css";
+    if (!fs::is_regular_file(styles_css_filepath))
     {
-        std::string styles_css_original = Glib::build_filename(CtFileSystem::get_cherrytree_datadir(), "data", "styles3.css");
+        fs::path styles_css_original = fs::path(CtFileSystem::get_cherrytree_datadir()) / fs::path("data") / "styles3.css";
         CtFileSystem::copy_file(styles_css_original, styles_css_filepath);
     }
-    CtFileSystem::copy_file(styles_css_filepath, Glib::build_filename(_res_dir, "styles3.css"));
+    CtFileSystem::copy_file(styles_css_filepath, _res_dir / "styles3.css");
     
-    Glib::ustring styles_js_filepath = Glib::build_filename(config_dir, "script3.js");
-    if (!Glib::file_test(styles_js_filepath, Glib::FILE_TEST_IS_REGULAR))
+    fs::path styles_js_filepath = config_dir / "script3.js";
+    if (!fs::is_regular_file(styles_js_filepath))
     {
         std::string script_js_original = Glib::build_filename(CtFileSystem::get_cherrytree_datadir(), "data", "script3.js");
         CtFileSystem::copy_file(script_js_original, styles_js_filepath);
     }
-    CtFileSystem::copy_file(styles_js_filepath, Glib::build_filename(_res_dir, "script3.js"));
+    CtFileSystem::copy_file(styles_js_filepath, _res_dir / "script3.js");
 
     export_path = _export_dir;
 
@@ -131,7 +131,7 @@ void CtExport2Html::node_export_to_html(CtTreeIter tree_iter, const CtExportOpti
     html_text += "</div>"; // div class='page'
     html_text += HTML_FOOTER;
 
-    Glib::ustring node_html_filepath = Glib::build_filename(_export_dir, _get_html_filename(tree_iter));
+    fs::path node_html_filepath = _export_dir / _get_html_filename(tree_iter);
     g_file_set_contents(node_html_filepath.c_str(), html_text.c_str(), (gssize)html_text.bytes(), nullptr);
 }
 
@@ -171,7 +171,7 @@ void CtExport2Html::nodes_all_export_to_html(bool all_tree, const CtExportOption
         html_text += "<div class='page'>" + tree_links_text + "</div>";
     html_text += "<script src='res/script3.js'></script>\n";
     html_text += HTML_FOOTER;
-    Glib::ustring node_html_filepath = Glib::build_filename(_export_dir, "index.html");
+    fs::path node_html_filepath = _export_dir / "index.html";
     g_file_set_contents(node_html_filepath.c_str(), html_text.c_str(), (gssize)html_text.bytes(), nullptr);
 
     // create html pages
@@ -224,7 +224,7 @@ Glib::ustring CtExport2Html::selection_export_to_html(Glib::RefPtr<Gtk::TextBuff
     if (syntax_highlighting == CtConst::RICH_TEXT_ID)
     {
         int images_count = 0;
-        Glib::ustring tempFolder = _pCtMainWin->get_ct_tmp()->getHiddenDirPath("IMAGE_TEMP_FOLDER");
+        fs::path tempFolder = _pCtMainWin->get_ct_tmp()->getHiddenDirPath("IMAGE_TEMP_FOLDER");
 
         int start_offset = start_iter.get_offset();
         std::list<CtAnchoredWidget*> widgets = _pCtMainWin->curr_tree_iter().get_embedded_pixbufs_tables_codeboxes(start_iter.get_offset(), end_iter.get_offset());
@@ -267,15 +267,15 @@ Glib::ustring CtExport2Html::codebox_export_to_html(CtCodebox* codebox)
 }
 
 // Returns the HTML embedded file
-Glib::ustring CtExport2Html::_get_embfile_html(CtImageEmbFile* embfile, CtTreeIter tree_iter, Glib::ustring embed_dir)
+Glib::ustring CtExport2Html::_get_embfile_html(CtImageEmbFile* embfile, CtTreeIter tree_iter, fs::path embed_dir)
 {
     Glib::ustring embfile_align_text = _get_object_alignment_string(embfile->getJustification());
-    Glib::ustring embfile_name = std::to_string(tree_iter.get_node_id()) + "-" +  embfile->get_file_name();
-    Glib::ustring embfile_rel_path = Glib::build_filename("EmbeddedFiles", embfile_name);
+    fs::path embfile_name = std::to_string(tree_iter.get_node_id()) + "-" +  embfile->get_file_name().string();
+    fs::path embfile_rel_path = "EmbeddedFiles" / embfile_name;
     Glib::ustring embfile_html = "<table style=\"" + embfile_align_text + "\"><tr><td><a href=\"" +
-            embfile_rel_path + "\">Linked file: " + embfile->get_file_name() + " </a></td></tr></table>";
+            embfile_rel_path.string() + "\">Linked file: " + embfile->get_file_name().string() + " </a></td></tr></table>";
 
-    std::fstream file(Glib::build_filename(embed_dir, embfile_name), std::ios::out | std::ios::binary);
+    std::fstream file((embed_dir / embfile_name).string(), std::ios::out | std::ios::binary);
     long size = (long)embfile->get_raw_blob().size();
     file.write(embfile->get_raw_blob().c_str(), size);
     file.close();
@@ -284,7 +284,7 @@ Glib::ustring CtExport2Html::_get_embfile_html(CtImageEmbFile* embfile, CtTreeIt
 }
 
 // Returns the HTML Image
-Glib::ustring CtExport2Html::_get_image_html(CtImage* image, const Glib::ustring& images_dir, int& images_count, CtTreeIter* tree_iter)
+Glib::ustring CtExport2Html::_get_image_html(CtImage* image, const fs::path& images_dir, int& images_count, CtTreeIter* tree_iter)
 {
     if (CtImageAnchor* imageAnchor = dynamic_cast<CtImageAnchor*>(image))
         return "<a name=\"" + imageAnchor->get_anchor_name() + "\"></a>";
@@ -299,7 +299,7 @@ Glib::ustring CtExport2Html::_get_image_html(CtImage* image, const Glib::ustring
     else
     {
         image_name = std::to_string(images_count) + ".png";
-        image_rel_path = "file://" + Glib::build_filename (images_dir, image_name);
+        image_rel_path = "file://" + (images_dir / image_name).string();
     }
 
     Glib::ustring image_html = "<img src=\"" + image_rel_path + "\" alt=\"" + image_rel_path + "\" />";
@@ -309,7 +309,7 @@ Glib::ustring CtExport2Html::_get_image_html(CtImage* image, const Glib::ustring
         image_html = "<a href=\"" + href + "\">" + image_html + "</a>";
     }
 
-    image->save(Glib::build_filename (images_dir, image_name), "png");
+    image->save(images_dir / image_name, "png");
     return image_html;
 }
 
@@ -587,26 +587,26 @@ Glib::ustring CtExport2Html::_html_text_serialize(Gtk::TextIter start_iter, Gtk:
     return tagged_text;
 }
 
-Glib::ustring CtExport2Html::_get_href_from_link_prop_val(Glib::ustring link_prop_val)
+std::string CtExport2Html::_get_href_from_link_prop_val(Glib::ustring link_prop_val)
 {
     // todo: I saw the same function before, we need to join them
 
     if (link_prop_val == "")
         return "";
 
-    Glib::ustring href = "";
+    std::string href = "";
     auto vec = str::split(link_prop_val, " ");
     if (vec[0] == CtConst::LINK_TYPE_WEBS)
         href = vec[1];
     else if (vec[0] == CtConst::LINK_TYPE_FILE)
     {
-        Glib::ustring filepath = _link_process_filepath(vec[1]);
-        href = "file://" + filepath;
+        fs::path filepath = _link_process_filepath(vec[1]);
+        href = "file://" + filepath.string();
     }
     else if (vec[0] == CtConst::LINK_TYPE_FOLD)
     {
-        Glib::ustring folderpath = _link_process_folderpath(vec[1]);
-        href = "file://" + folderpath;
+        fs::path folderpath = _link_process_folderpath(vec[1]);
+        href = "file://" + folderpath.string();
     }
     else if (vec[0] == CtConst::LINK_TYPE_NODE)
     {
@@ -625,20 +625,18 @@ Glib::ustring CtExport2Html::_get_href_from_link_prop_val(Glib::ustring link_pro
     return href;
 }
 
-Glib::ustring CtExport2Html::_link_process_filepath(const Glib::ustring& filepath_raw)
+fs::path CtExport2Html::_link_process_filepath(const std::string& filepath_raw)
 {
-    std::string filepath_orig = Glib::Base64::decode(filepath_raw);
-    std::string filepath = CtFileSystem::get_proper_platform_filepath(filepath_orig);
+    fs::path filepath = Glib::Base64::decode(filepath_raw);
     // todo:
     //if not os.path.isabs(filepath) and os.path.isfile(os.path.join(self.file_dir, filepath)):
     //    filepath = os.path.join(self.file_dir, filepath)
     return filepath;
 }
 
-Glib::ustring CtExport2Html::_link_process_folderpath(const Glib::ustring& folderpath_raw)
+fs::path CtExport2Html::_link_process_folderpath(const std::string& folderpath_raw)
 {
-    std::string folderpath_orig = Glib::Base64::decode(folderpath_raw);
-    std::string folderpath = CtFileSystem::get_proper_platform_filepath(folderpath_orig);
+    fs::path folderpath = Glib::Base64::decode(folderpath_raw);
     // todo:
     //if not os.path.isabs(folderpath) and os.path.isdir(os.path.join(self.file_dir, folderpath)):
     //    folderpath = os.path.join(self.file_dir, folderpath)
@@ -698,9 +696,9 @@ void to_html(std::istream& input, std::ostream& output, std::string from_format)
 }
 
 
-void to_html(const std::string& file, std::ostream& output) {
+void to_html(const fs::path& file, std::ostream& output) {
     auto process = pandoc_process();
-    process->append_arg(file);
+    process->append_arg(file.string());
 
     try {
         process->run(output);

--- a/future/src/ct/ct_export2html.cc
+++ b/future/src/ct/ct_export2html.cc
@@ -601,13 +601,13 @@ std::string CtExport2Html::_get_href_from_link_prop_val(Glib::ustring link_prop_
         href = vec[1];
     else if (vec[0] == CtConst::LINK_TYPE_FILE)
     {
-        fs::path filepath = _link_process_filepath(vec[1]);
-        href = "file://" + filepath.string();
+        std::string filepath = _link_process_filepath(vec[1]);
+        href = "file://" + filepath;
     }
     else if (vec[0] == CtConst::LINK_TYPE_FOLD)
     {
-        fs::path folderpath = _link_process_folderpath(vec[1]);
-        href = "file://" + folderpath.string();
+        std::string folderpath = _link_process_folderpath(vec[1]);
+        href = "file://" + folderpath;
     }
     else if (vec[0] == CtConst::LINK_TYPE_NODE)
     {
@@ -626,22 +626,22 @@ std::string CtExport2Html::_get_href_from_link_prop_val(Glib::ustring link_prop_
     return href;
 }
 
-fs::path CtExport2Html::_link_process_filepath(const std::string& filepath_raw)
+std::string CtExport2Html::_link_process_filepath(const std::string& filepath_raw)
 {
     fs::path filepath = Glib::Base64::decode(filepath_raw);
     // todo:
     //if not os.path.isabs(filepath) and os.path.isfile(os.path.join(self.file_dir, filepath)):
     //    filepath = os.path.join(self.file_dir, filepath)
-    return filepath;
+    return filepath.native();
 }
 
-fs::path CtExport2Html::_link_process_folderpath(const std::string& folderpath_raw)
+std::string CtExport2Html::_link_process_folderpath(const std::string& folderpath_raw)
 {
     fs::path folderpath = Glib::Base64::decode(folderpath_raw);
     // todo:
     //if not os.path.isabs(folderpath) and os.path.isdir(os.path.join(self.file_dir, folderpath)):
     //    folderpath = os.path.join(self.file_dir, folderpath)
-    return folderpath;
+    return folderpath.native();
 }
 
 // Returns the style attribute(s) according to the alignment

--- a/future/src/ct/ct_export2html.h
+++ b/future/src/ct/ct_export2html.h
@@ -26,7 +26,7 @@
 #include "ct_image.h"
 #include "ct_treestore.h"
 #include "ct_dialogs.h" // CtExportOptions
-#include <filesystem>
+#include "ct_misc_utils.h"
 
 class CtExport2Html
 {
@@ -51,11 +51,11 @@ public:
                                            Gtk::TextIter end_iter, const Glib::ustring& syntax_highlighting);
     Glib::ustring table_export_to_html(CtTable* table);
     Glib::ustring codebox_export_to_html(CtCodebox* codebox);
-    bool          prepare_html_folder(Glib::ustring dir_place, Glib::ustring new_folder, bool export_overwrite, Glib::ustring& export_path);
+    bool          prepare_html_folder(fs::path dir_place, fs::path new_folder, bool export_overwrite, fs::path& export_path);
 
 private:
-    Glib::ustring _get_embfile_html(CtImageEmbFile* embfile, CtTreeIter tree_iter, Glib::ustring embed_dir);
-    Glib::ustring _get_image_html(CtImage* image, const Glib::ustring& images_dir, int& images_count, CtTreeIter* tree_iter);
+    Glib::ustring _get_embfile_html(CtImageEmbFile* embfile, CtTreeIter tree_iter, fs::path embed_dir);
+    Glib::ustring _get_image_html(CtImage* image, const fs::path& images_dir, int& images_count, CtTreeIter* tree_iter);
     Glib::ustring _get_codebox_html(CtCodebox* codebox);
     Glib::ustring _get_table_html(CtTable* table);
 
@@ -64,7 +64,7 @@ private:
                                        std::vector<Glib::ustring>& out_slots, std::vector<CtAnchoredWidget*>& out_widgets);
     Glib::ustring _html_process_slot(int start_offset, int end_offset, Glib::RefPtr<Gtk::TextBuffer> curr_buffer);
     Glib::ustring _html_text_serialize(Gtk::TextIter start_iter, Gtk::TextIter end_iter, const std::map<std::string_view, std::string>& curr_attributes);
-    Glib::ustring _get_href_from_link_prop_val(Glib::ustring link_prop_val);
+    std::string _get_href_from_link_prop_val(Glib::ustring link_prop_val);
     Glib::ustring _get_object_alignment_string(Glib::ustring alignment);
 
     void          _tree_links_text_iter(CtTreeIter tree_iter, Glib::ustring& tree_links_text, int tree_count_level, bool index_in_page);
@@ -72,15 +72,15 @@ private:
     Glib::ustring _get_html_filename(CtTreeIter tree_iter);
 
 public:
-    static Glib::ustring _link_process_filepath(const Glib::ustring& filepath_raw);
-    static Glib::ustring _link_process_folderpath(const Glib::ustring& folderpath_raw);
+    static fs::path _link_process_filepath(const std::string& filepath_raw);
+    static fs::path _link_process_folderpath(const std::string& folderpath_raw);
 
 private:
     CtMainWin*    _pCtMainWin;
-    Glib::ustring _export_dir;
-    Glib::ustring _images_dir;
-    Glib::ustring _embed_dir;
-    Glib::ustring _res_dir;
+    fs::path _export_dir;
+    fs::path _images_dir;
+    fs::path _embed_dir;
+    fs::path _res_dir;
 };
 
 
@@ -105,6 +105,6 @@ constexpr bool supports_syntax(std::string_view syntax) {
 
 void to_html(std::istream& input, std::ostream& output, std::string from_format);
 
-void to_html(const std::string& file, std::ostream& output);
+void to_html(const fs::path& file, std::ostream& output);
 
 } // CtPandoc

--- a/future/src/ct/ct_export2html.h
+++ b/future/src/ct/ct_export2html.h
@@ -72,8 +72,8 @@ private:
     Glib::ustring _get_html_filename(CtTreeIter tree_iter);
 
 public:
-    static fs::path _link_process_filepath(const std::string& filepath_raw);
-    static fs::path _link_process_folderpath(const std::string& folderpath_raw);
+    static std::string _link_process_filepath(const std::string& filepath_raw);
+    static std::string _link_process_folderpath(const std::string& folderpath_raw);
 
 private:
     CtMainWin*    _pCtMainWin;

--- a/future/src/ct/ct_export2pdf.cc
+++ b/future/src/ct/ct_export2pdf.cc
@@ -24,7 +24,7 @@
 
 #include <utility>
 
-void CtExport2Pdf::node_export_print(const Glib::ustring& pdf_filepath, CtTreeIter tree_iter, const CtExportOptions& options, int sel_start, int sel_end)
+void CtExport2Pdf::node_export_print(const fs::path& pdf_filepath, CtTreeIter tree_iter, const CtExportOptions& options, int sel_start, int sel_end)
 {
     std::vector<Glib::ustring> pango_slots;
     std::list<CtAnchoredWidget*> widgets;
@@ -46,7 +46,7 @@ void CtExport2Pdf::node_export_print(const Glib::ustring& pdf_filepath, CtTreeIt
                                            widgets, _pCtMainWin->get_text_view().get_allocation().get_width());
 }
 
-void CtExport2Pdf::node_and_subnodes_export_print(const Glib::ustring& pdf_filepath, CtTreeIter tree_iter, const CtExportOptions& options)
+void CtExport2Pdf::node_and_subnodes_export_print(const fs::path& pdf_filepath, CtTreeIter tree_iter, const CtExportOptions& options)
 {
     std::vector<Glib::ustring> tree_pango_slots;
     std::list<CtAnchoredWidget*> tree_widgets;
@@ -57,7 +57,7 @@ void CtExport2Pdf::node_and_subnodes_export_print(const Glib::ustring& pdf_filep
                                            tree_widgets, _pCtMainWin->get_text_view().get_allocation().get_width());
 }
 
-void CtExport2Pdf::tree_export_print(const Glib::ustring& pdf_filepath, CtTreeIter tree_iter, const CtExportOptions& options)
+void CtExport2Pdf::tree_export_print(const fs::path& pdf_filepath, CtTreeIter tree_iter, const CtExportOptions& options)
 {
     std::vector<Glib::ustring> tree_pango_slots;
     std::list<CtAnchoredWidget*> tree_widgets;
@@ -135,7 +135,7 @@ void CtPrint::run_page_setup_dialog(Gtk::Window* pWin)
 }
 
 // Start the Print Operations for Text
-void CtPrint::print_text(CtMainWin* pCtMainWin, const Glib::ustring& pdf_filepath,
+void CtPrint::print_text(CtMainWin* pCtMainWin, const fs::path& pdf_filepath,
                          const std::vector<Glib::ustring>& pango_text, const Glib::ustring& text_font, const Glib::ustring& code_font,
                          const std::list<CtAnchoredWidget*>& widgets, int text_window_width)
 {
@@ -166,7 +166,7 @@ void CtPrint::print_text(CtMainWin* pCtMainWin, const Glib::ustring& pdf_filepat
     print_data.operation->set_print_settings(_pPrintSettings);
     print_data.operation->signal_begin_print().connect(sigc::bind(fun_begin_print_text, &print_data));
     print_data.operation->signal_draw_page().connect(sigc::bind(fun_draw_page_text, &print_data));
-    print_data.operation->set_export_filename(pdf_filepath);
+    print_data.operation->set_export_filename(pdf_filepath.string());
     try
     {
         auto res = print_data.operation->run(!pdf_filepath.empty() ? Gtk::PRINT_OPERATION_ACTION_EXPORT : Gtk::PRINT_OPERATION_ACTION_PRINT_DIALOG);

--- a/future/src/ct/ct_export2pdf.h
+++ b/future/src/ct/ct_export2pdf.h
@@ -30,9 +30,9 @@ class CtExport2Pdf
 public:
     CtExport2Pdf(CtMainWin* pCtMainWin) { _pCtMainWin = pCtMainWin; }
 
-    void node_export_print(const Glib::ustring& pdf_filepath, CtTreeIter tree_iter, const CtExportOptions& options, int sel_start, int sel_end);
-    void node_and_subnodes_export_print(const Glib::ustring& pdf_filepath, CtTreeIter tree_iter, const CtExportOptions& options);
-    void tree_export_print(const Glib::ustring& pdf_filepath, CtTreeIter tree_iter, const CtExportOptions& options);
+    void node_export_print(const fs::path& pdf_filepath, CtTreeIter tree_iter, const CtExportOptions& options, int sel_start, int sel_end);
+    void node_and_subnodes_export_print(const fs::path& pdf_filepath, CtTreeIter tree_iter, const CtExportOptions& options);
+    void tree_export_print(const fs::path& pdf_filepath, CtTreeIter tree_iter, const CtExportOptions& options);
 
 private:
     void _nodes_all_export_print_iter(CtTreeIter tree_iter, const CtExportOptions& options,
@@ -149,7 +149,7 @@ public:
 public:
     void run_page_setup_dialog(Gtk::Window* pMainWin);
 
-    void print_text(CtMainWin* pCtMainWin, const Glib::ustring& pdf_filepath,
+    void print_text(CtMainWin* pCtMainWin, const fs::path& pdf_filepath,
                     const std::vector<Glib::ustring>& pango_text, const Glib::ustring& text_font, const Glib::ustring& code_font,
                     const std::list<CtAnchoredWidget*>& widgets, int text_window_width);
 

--- a/future/src/ct/ct_export2txt.cc
+++ b/future/src/ct/ct_export2txt.cc
@@ -28,7 +28,7 @@ CtExport2Txt::CtExport2Txt(CtMainWin* pCtMainWin)
 }
 
 // Export the Selected Node To Txt
-Glib::ustring CtExport2Txt::node_export_to_txt(CtTreeIter tree_iter, Glib::ustring filepath, CtExportOptions export_options, int sel_start, int sel_end)
+Glib::ustring CtExport2Txt::node_export_to_txt(CtTreeIter tree_iter, fs::path filepath, CtExportOptions export_options, int sel_start, int sel_end)
 {
     Glib::ustring plain_text;
     if (export_options.include_node_name)
@@ -41,7 +41,7 @@ Glib::ustring CtExport2Txt::node_export_to_txt(CtTreeIter tree_iter, Glib::ustri
 }
 
 // Export All Nodes To Txt
-void CtExport2Txt::nodes_all_export_to_txt(bool all_tree, Glib::ustring export_dir, Glib::ustring single_txt_filepath, CtExportOptions export_options)
+void CtExport2Txt::nodes_all_export_to_txt(bool all_tree, fs::path export_dir, fs::path single_txt_filepath, CtExportOptions export_options)
 {
     // function to iterate nodes
     Glib::ustring tree_plain_text;
@@ -51,7 +51,7 @@ void CtExport2Txt::nodes_all_export_to_txt(bool all_tree, Glib::ustring export_d
             tree_plain_text += node_export_to_txt(tree_iter, "", export_options, -1, -1);
         else
         {
-            Glib::ustring filepath = Glib::build_filename(export_dir, CtMiscUtil::get_node_hierarchical_name(tree_iter) + ".txt");
+            fs::path filepath = export_dir / (CtMiscUtil::get_node_hierarchical_name(tree_iter) + ".txt");
             node_export_to_txt(tree_iter, filepath, export_options, -1, -1);
         }
         for (auto& child: tree_iter->children())

--- a/future/src/ct/ct_export2txt.h
+++ b/future/src/ct/ct_export2txt.h
@@ -32,8 +32,8 @@ public:
     CtExport2Txt(CtMainWin* pCtMainWin);
 
 public:
-    Glib::ustring node_export_to_txt(CtTreeIter tree_iter, Glib::ustring filepath, CtExportOptions export_options, int sel_start, int sel_end);
-    void          nodes_all_export_to_txt(bool all_tree, Glib::ustring export_dir, Glib::ustring single_txt_filepath, CtExportOptions export_options);
+    Glib::ustring node_export_to_txt(CtTreeIter tree_iter, fs::path filepath, CtExportOptions export_options, int sel_start, int sel_end);
+    void          nodes_all_export_to_txt(bool all_tree, fs::path export_dir, fs::path single_txt_filepath, CtExportOptions export_options);
     Glib::ustring selection_export_to_txt(Glib::RefPtr<Gtk::TextBuffer> text_buffer, int sel_start, int sel_end, bool check_link_target);
 
     Glib::ustring get_table_plain(CtTable* table_orig);

--- a/future/src/ct/ct_filesystem.cc
+++ b/future/src/ct/ct_filesystem.cc
@@ -31,7 +31,7 @@
 #include "ct_logging.h"
 #include "ct_config.h"
 
-namespace CtFileSystem {
+namespace fs {
 void path::append(const path& other)
 { 
     _path = Glib::build_filename(_path, other._path); 
@@ -39,10 +39,15 @@ void path::append(const path& other)
 
 path path::extension() const
 {
-    auto last_pos = _path.find('.');
-    if (last_pos == std::string::npos) return path("");
-    else                               return path(_path.begin() + last_pos, _path.end());
+    std::string name = filename().string();
+    auto last_pos = name.find_last_of('.');
+    if (last_pos == std::string::npos || last_pos == name.size() - 1 || last_pos == 0) {
+        return path("");
+    } else {
+        return path(name.begin() + last_pos, name.end());
+    }
 }
+
 
 path& path::operator=(path::string_type other)
 {
@@ -52,7 +57,7 @@ path& path::operator=(path::string_type other)
 
 
 
-bool remove(const CtFileSystem::path& path)
+bool remove(const fs::path& path)
 {
     if (fs::is_directory(path)) {
         // rmdir
@@ -130,10 +135,10 @@ std::uintmax_t file_size(const path& path)
     return st.st_size;
 }
 
-std::list<CtFileSystem::path> get_dir_entries(const path& dir)
+std::list<fs::path> get_dir_entries(const path& dir)
 {
     Glib::Dir gdir(dir.string());
-    std::list<CtFileSystem::path> entries(gdir.begin(), gdir.end());
+    std::list<fs::path> entries(gdir.begin(), gdir.end());
     for (auto& entry: entries)
         entry = dir / entry;
     return entries;

--- a/future/src/ct/ct_filesystem.cc
+++ b/future/src/ct/ct_filesystem.cc
@@ -1,0 +1,337 @@
+/*
+ * ct_filesystem.cc
+ *
+ * Copyright 2017-2020 Giuseppe Penone <giuspen@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include <glibmm/miscutils.h>
+#include <glib/gstdio.h>
+#include <curl/curl.h>
+#include <spdlog/fmt/bundled/printf.h>
+#include <system_error>
+
+#include "ct_filesystem.h"
+#include "ct_misc_utils.h"
+#include "ct_const.h"
+#include "ct_logging.h"
+#include "ct_config.h"
+
+namespace CtFileSystem {
+void path::append(const path& other)
+{ 
+    _path = Glib::build_filename(_path, other._path); 
+}
+
+path path::extension() const
+{
+    auto riter = _path.crbegin();
+    while (riter != _path.crend() && *riter != '.') {
+        ++riter;
+    }
+    if (riter == _path.crbegin()) return path("");
+
+    return path(riter.base(), _path.cend());
+}
+
+path& path::operator=(path::string_type other)
+{
+    _path = _get_platform_path(std::move(other));
+    return *this;
+}
+
+
+
+bool remove(const CtFileSystem::path& path)
+{
+    if (fs::is_directory(path)) {
+        // rmdir
+        int retr = g_rmdir(path.c_str());
+        if (retr != 0) {
+            // error
+            throw fs::filesystem_error("Error occurred during g_rmdir", path, std::error_code(retr, std::generic_category()));
+        }
+        g_unlink(path.c_str());
+    }
+    return true;
+}
+
+bool is_regular_file(const path& file)
+{
+    return Glib::file_test(file.string(), Glib::FILE_TEST_IS_REGULAR);
+}
+
+
+std::string path::_get_platform_path(std::string filepath)
+{
+#ifdef _WIN32
+    filepath = str::replace(filepath, CtConst::CHAR_SLASH, CtConst::CHAR_BSLASH);
+#else
+    filepath = str::replace(filepath, CtConst::CHAR_BSLASH, CtConst::CHAR_SLASH);
+#endif
+    return filepath;
+}
+
+bool copy_file(const path& from, const path& to)
+{
+    Glib::RefPtr<Gio::File> rFileFrom = Gio::File::create_for_path(from.string());
+    Glib::RefPtr<Gio::File> rFileTo = Gio::File::create_for_path(to.string());
+    return rFileFrom->copy(rFileTo, Gio::FILE_COPY_OVERWRITE);
+}
+
+bool is_directory(const fs::path& path) {
+    return Glib::file_test(path.string(), Glib::FILE_TEST_IS_DIR);
+}
+
+bool move_file(const path& from, const path& to)
+{
+    Glib::RefPtr<Gio::File> rFileFrom = Gio::File::create_for_path(from.string());
+    Glib::RefPtr<Gio::File> rFileTo = Gio::File::create_for_path(to.string());
+    return rFileFrom->move(rFileTo, Gio::FILE_COPY_OVERWRITE);
+}
+
+fs::path absolute(const fs::path& path)
+{
+    Glib::RefPtr<Gio::File> rFile = Gio::File::create_for_path(path.string());
+    return rFile->get_path();
+}
+
+time_t getmtime(const path& path)
+{
+    time_t time = 0;
+    GStatBuf st;
+    if (g_stat(path.c_str(), &st) == 0)
+        time = st.st_mtime;
+    return time;
+}
+
+int getsize(const std::string& path)
+{
+    GStatBuf st;
+    if (g_stat(path.c_str(), &st) == 0)
+        return st.st_size;
+    return 0;
+}
+
+std::list<CtFileSystem::path> get_dir_entries(const path& dir)
+{
+    Glib::Dir gdir(dir.string());
+    std::list<CtFileSystem::path> entries(gdir.begin(), gdir.end());
+    for (auto& entry: entries)
+        entry = dir / entry;
+    return entries;
+}
+
+path path::stem() const
+{
+    if (empty()) return "";
+    std::string name = filename().string();
+    size_t dot_pos = name.find_last_of('.');
+    if (dot_pos == std::string::npos || dot_pos == 0)
+        return name;
+    return name.substr(0, dot_pos);
+}
+
+bool exists(const path& filepath) {
+    return Glib::file_test(filepath.string(), Glib::FILE_TEST_EXISTS);
+}
+
+// Open Filepath with External App
+void external_filepath_open(const fs::path& filepath, bool open_folder_if_file_not_exists, CtConfig* config)
+{
+    spdlog::debug("filepath to open: {}", filepath);
+    if (config->filelinkCustomOn) {
+        std::string cmd = fmt::sprintf(config->filelinkCustomAct, filepath.string());
+        std::system(cmd.c_str());
+    } else {
+        if (open_folder_if_file_not_exists && !fs::exists(filepath)) {
+            external_folderpath_open(filepath, config);
+        } else if (!fs::exists(filepath)) {
+            throw std::runtime_error(fmt::format("Filepath: {} does not exist and open_folder_if_not_exists is false", filepath.string()));
+        } else {
+#ifdef _WIN32
+            ShellExecute(GetActiveWindow(), "open", filepath.c_str(), NULL, NULL, SW_SHOWNORMAL);
+#else
+            fs::path f_path("file://");
+            f_path += filepath;
+            g_app_info_launch_default_for_uri(f_path.c_str(), nullptr, nullptr);
+#endif
+        }
+    }
+}
+
+// Open Folderpath with External App
+void external_folderpath_open(const fs::path& folderpath, CtConfig* config)
+{
+    spdlog::debug("dir to open: {}", folderpath.string());
+    if (config->folderlinkCustomOn) {
+        std::string cmd = fmt::sprintf(config->filelinkCustomAct, folderpath.string());
+        std::system(cmd.c_str());
+    } else {
+
+        // https://stackoverflow.com/questions/42442189/how-to-open-spawn-a-file-with-glib-gtkmm-in-windows
+#ifdef _WIN32
+        ShellExecute(NULL, "open", folderpath.c_str(), NULL, NULL, SW_SHOWDEFAULT);
+#elif defined(__APPLE__)
+        std::vector<std::string> argv = { "open", folderpath.string() };
+Glib::spawn_async("", argv, Glib::SpawnFlags::SPAWN_SEARCH_PATH);
+#else
+        fs::path path("file://");
+        path += folderpath;
+        g_app_info_launch_default_for_uri(folderpath.c_str(), nullptr, nullptr);
+#endif
+    }
+}
+
+path prepare_export_folder(const path& dir_place, path new_folder, bool overwrite_existing)
+{
+    if (fs::is_directory(dir_place / new_folder))
+    {
+        // todo:
+        if (overwrite_existing) {
+            spdlog::debug("removing dir: {}", dir_place / new_folder);
+            remove_all(dir_place / new_folder);
+        }
+        else {
+            int n = 2;
+            while (fs::is_directory(dir_place / (new_folder.string() + str::format("{:03d}", n))))
+                n += 1;
+            new_folder += str::format("{:03d}", n);
+        }
+    }
+    return new_folder;
+}
+
+std::uintmax_t remove_all(const path& dir)
+{
+    std::uintmax_t count = 0;
+    for (const auto& file : get_dir_entries(dir)) {
+        ++count;
+        if (is_directory(file)) {
+            count += remove_all(file);
+        }
+        remove(file);
+    }
+    return count;
+}
+
+std::string get_cherrytree_datadir()
+{
+    if (Glib::file_test(_CMAKE_BINARY_DIR, Glib::FILE_TEST_IS_DIR)) {
+        // we're running from the build sources
+        return _CMAKE_SOURCE_DIR;
+    }
+    return CHERRYTREE_DATADIR;
+}
+
+fs::path get_cherrytree_localedir()
+{
+    std::string sources_po_dir = Glib::canonicalize_filename(Glib::build_filename(_CMAKE_SOURCE_DIR, "po"));
+    if (Glib::file_test(sources_po_dir, Glib::FILE_TEST_IS_DIR)) {
+        // we're running from the build sources
+        return sources_po_dir;
+    }
+    return CHERRYTREE_LOCALEDIR;
+}
+
+std::string get_cherrytree_configdir()
+{
+    //TODO: define rule for local config.cfg/lang files at least for Windows portable
+    return Glib::build_filename(Glib::get_user_config_dir(), CtConst::APP_NAME);
+}
+
+std::string get_cherrytree_lang_filepath()
+{
+    return Glib::build_filename(get_cherrytree_configdir(), "lang");
+}
+
+std::string download_file(const std::string& filepath)
+{
+    struct local {
+        static size_t write_memory_callback(void *contents, size_t size, size_t nmemb, void *userp)
+        {
+            const size_t realsize = size*nmemb;
+            static_cast<std::string*>(userp)->append((char*)contents, realsize);
+            return realsize;
+        }
+    };
+
+    spdlog::debug("start downloading {}", filepath);
+
+    std::string buffer;
+    buffer.reserve(3 * 1024 * 1024); // preallocate 3mb
+
+    // from https://curl.haxx.se/libcurl/c/getinmemory.html
+    curl_global_init(CURL_GLOBAL_ALL);
+    CURL* pCurlHandle = curl_easy_init();
+
+    curl_easy_setopt(pCurlHandle, CURLOPT_URL, filepath.c_str());
+    curl_easy_setopt(pCurlHandle, CURLOPT_WRITEFUNCTION, local::write_memory_callback);
+    curl_easy_setopt(pCurlHandle, CURLOPT_WRITEDATA, (void*)&buffer);
+    curl_easy_setopt(pCurlHandle, CURLOPT_TIMEOUT, 3);
+    curl_easy_setopt(pCurlHandle, CURLOPT_USERAGENT, "libcurl-agent/1.0");
+    const CURLcode res = curl_easy_perform(pCurlHandle);
+    curl_easy_cleanup(pCurlHandle);
+    curl_global_cleanup();
+
+    if (res != CURLE_OK) {
+        spdlog::error("curl_easy_perform() failed: {}", curl_easy_strerror(res));
+        return "";
+    }
+
+    return buffer;
+}
+
+
+CtDocType get_doc_type(const fs::path& filename)
+{
+    CtDocType retDocType{CtDocType::None};
+    if ((filename.extension() == CtConst::CTDOC_XML_NOENC) or
+         (filename.extension() == CtConst::CTDOC_XML_ENC))
+    {
+        retDocType = CtDocType::XML;
+    }
+    else if ((filename.extension() == CtConst::CTDOC_SQLITE_NOENC) or
+             (filename.extension() == CtConst::CTDOC_SQLITE_ENC))
+    {
+        retDocType = CtDocType::SQLite;
+    }
+    return retDocType;
+}
+
+CtDocEncrypt get_doc_encrypt(const fs::path& filename)
+{
+    CtDocEncrypt retDocEncrypt{CtDocEncrypt::None};
+    if ( (filename.extension() == CtConst::CTDOC_XML_NOENC) or
+         (filename.extension() == CtConst::CTDOC_SQLITE_NOENC))
+    {
+        retDocEncrypt = CtDocEncrypt::False;
+    }
+    else if ( (filename.extension() == CtConst::CTDOC_XML_ENC) or
+              (filename.extension() == CtConst::CTDOC_SQLITE_ENC))
+    {
+        retDocEncrypt = CtDocEncrypt::True;
+    }
+    return retDocEncrypt;
+}
+
+path canonical(const path& path)
+{
+    return Glib::canonicalize_filename(path.string());
+}
+
+}

--- a/future/src/ct/ct_filesystem.cc
+++ b/future/src/ct/ct_filesystem.cc
@@ -1,5 +1,5 @@
 /*
- * ct_filesystem.cc
+  ct_filesystem.cc
  *
  * Copyright 2017-2020 Giuseppe Penone <giuspen@gmail.com>
  *
@@ -39,15 +39,9 @@ void path::append(const path& other)
 
 path path::extension() const
 {
-    auto iter = _path.cend();
-    while (iter != _path.cbegin()) {
-        --iter;
-        if (*iter == '.') break;
-        if (*iter == path_sep) return path(""); // Cannot have an extension if not yet found
-    }
-    if (iter == _path.cend() || (iter == _path.cbegin() && _path.size() > 1)) return path("");
-
-    return path(iter, _path.cend());
+    auto last_pos = _path.find('.');
+    if (last_pos == std::string::npos) return path("");
+    else                               return path(_path.begin() + last_pos, _path.end());
 }
 
 path& path::operator=(path::string_type other)
@@ -153,6 +147,11 @@ path path::stem() const
     if (dot_pos == std::string::npos || dot_pos == 0)
         return name;
     return name.substr(0, dot_pos);
+}
+
+std::string path::native() const
+{
+    return _get_platform_path(_path);
 }
 
 bool exists(const path& filepath) {

--- a/future/src/ct/ct_filesystem.cc
+++ b/future/src/ct/ct_filesystem.cc
@@ -39,13 +39,15 @@ void path::append(const path& other)
 
 path path::extension() const
 {
-    auto riter = _path.crbegin();
-    while (riter != _path.crend() && *riter != '.') {
-        ++riter;
+    auto iter = _path.cend();
+    while (iter != _path.cbegin()) {
+        --iter;
+        if (*iter == '.') break;
+        if (*iter == path_sep) return path(""); // Cannot have an extension if not yet found
     }
-    if (riter == _path.crbegin()) return path("");
+    if (iter == _path.cend() || (iter == _path.cbegin() && _path.size() > 1)) return path("");
 
-    return path(riter.base(), _path.cend());
+    return path(iter, _path.cend());
 }
 
 path& path::operator=(path::string_type other)
@@ -226,6 +228,8 @@ std::uintmax_t remove_all(const path& dir)
         }
         remove(file);
     }
+    remove(dir);
+    ++count;
     return count;
 }
 

--- a/future/src/ct/ct_filesystem.h
+++ b/future/src/ct/ct_filesystem.h
@@ -51,7 +51,6 @@ time_t getmtime(const path& path);
 int getsize(const std::string& path);
 
 std::list<path> get_dir_entries(const path& dir);
-std::string get_file_stem(const std::string& path);
 
 void external_filepath_open(const path& filepath, bool open_folder_if_file_not_exists, CtConfig* config);
 void external_folderpath_open(const path& folderpath, CtConfig* config);

--- a/future/src/ct/ct_filesystem.h
+++ b/future/src/ct/ct_filesystem.h
@@ -48,7 +48,7 @@ bool is_directory(const path& path);
 
 time_t getmtime(const path& path);
 
-int getsize(const std::string& path);
+std::uintmax_t file_size(const path& path);
 
 std::list<path> get_dir_entries(const path& dir);
 
@@ -73,11 +73,11 @@ std::uintmax_t remove_all(const path& dir);
 */
 bool remove(const path& path);
 
-std::string get_cherrytree_datadir();
+path get_cherrytree_datadir();
 path get_cherrytree_localedir();
-std::string get_cherrytree_configdir();
-std::string get_cherrytree_lang_filepath();
-
+path get_cherrytree_configdir();
+path get_cherrytree_lang_filepath();
+// Filepath is a url so not an fs::path
 std::string download_file(const std::string& filepath);
 
 /**
@@ -139,7 +139,7 @@ public:
     friend bool operator<=(const path& lhs, const path& rhs) { return lhs._path <= rhs._path; }
 
     friend void operator+=(path& lhs, const path& rhs) { lhs._path += rhs._path; }
-    friend void operator+=(path& lhs, const std::string& rhs) { lhs._path += _get_platform_path(rhs); }
+    friend void operator+=(path& lhs, const string_type& rhs) { lhs._path += _get_platform_path(rhs); }
     friend void operator+=(path& lhs, const value_type* rhs) { lhs._path += _get_platform_path(rhs); }
 
     [[nodiscard]] const char* c_str() const { return _path.c_str(); };
@@ -165,8 +165,8 @@ public:
     filesystem_error(const std::string& what_arg, const path& p1, std::error_code ec) : std::system_error(ec, what_arg), _p1(p1) {}
     filesystem_error(const std::string& what_arg, const path& p1, const path& p2, std::error_code ec) : std::system_error(ec, what_arg), _p1(p1), _p2(p2) {}
 
-    const path& path1() const { return _p1; }
-    const path& path2() const { return _p2; }
+    [[nodiscard]] const path& path1() const { return _p1; }
+    [[nodiscard]] const path& path2() const { return _p2; }
 private:
     path _p1;
     path _p2;

--- a/future/src/ct/ct_filesystem.h
+++ b/future/src/ct/ct_filesystem.h
@@ -40,13 +40,13 @@ bool move_file(const path& from, const path& to);
 
 bool is_regular_file(const path& file);
 
+bool is_directory(const path& path);
+
 path absolute(const path& path);
 
 path canonical(const path& path);
 
 bool exists(const path& filepath);
-
-bool is_directory(const path& path);
 
 time_t getmtime(const path& path);
 
@@ -114,9 +114,8 @@ public:
         swap(*this, other);
     }
 
-    void append(const path& other);
 
-    path& operator=(string_type other);
+    path& operator=(string_type other) { _path = other; return *this;};
     path& operator=(const value_type* other) { return operator=(string_type(other)); };
 
 
@@ -132,7 +131,6 @@ public:
     {
         return path(Glib::build_filename(lhs._path, rhs));
     }
-    void operator/=(const path& rhs) { append(rhs); }
 
     friend bool operator==(const path& lhs, const path& rhs) { return lhs._path == rhs._path; }
     friend bool operator!=(const path& lhs, const path& rhs) { return !(lhs == rhs); }
@@ -161,19 +159,6 @@ private:
     /// From Slash to Backslash when needed
     static std::string _get_platform_path(std::string filepath);
 
-};
-
-class filesystem_error: public std::system_error {
-public:
-    filesystem_error(const std::string& what_arg, std::error_code ec) : std::system_error(ec, what_arg) {}
-    filesystem_error(const std::string& what_arg, const path& p1, std::error_code ec) : std::system_error(ec, what_arg), _p1(p1) {}
-    filesystem_error(const std::string& what_arg, const path& p1, const path& p2, std::error_code ec) : std::system_error(ec, what_arg), _p1(p1), _p2(p2) {}
-
-    [[nodiscard]] const path& path1() const { return _p1; }
-    [[nodiscard]] const path& path2() const { return _p2; }
-private:
-    path _p1;
-    path _p2;
 };
 
 } // namespace CtFileSystem

--- a/future/src/ct/ct_filesystem.h
+++ b/future/src/ct/ct_filesystem.h
@@ -101,7 +101,7 @@ public:
 
     path() = default;
     path(string_type path) : _path(_get_platform_path(std::move(path))) {}
-    path(const value_type* path) : _path(string_type(path)) {}
+    path(const value_type* cpath) : path(string_type(cpath)) {}
     template<typename ITERATOR_T>
     path(ITERATOR_T begin, ITERATOR_T end) : path(string_type(begin, end)) {}
     ~path() = default;

--- a/future/src/ct/ct_filesystem.h
+++ b/future/src/ct/ct_filesystem.h
@@ -30,7 +30,7 @@
 
 class CtConfig;
 
-namespace CtFileSystem {
+namespace fs {
 class path;
 #include "ct_splittable.h"
 
@@ -178,13 +178,12 @@ private:
 
 } // namespace CtFileSystem
 
-namespace fs = CtFileSystem;
 
 template<>
-struct fmt::formatter<CtFileSystem::path> {
+struct fmt::formatter<fs::path> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     template<typename FormatContext>
-    auto format(const CtFileSystem::path& path, FormatContext& ctx) {
+    auto format(const fs::path& path, FormatContext& ctx) {
         return format_to(ctx.out(), "{}", path.string());
     }
 };

--- a/future/src/ct/ct_filesystem.h
+++ b/future/src/ct/ct_filesystem.h
@@ -1,0 +1,187 @@
+/*
+ * ct_filesystem.h
+ *
+ * Copyright 2017-2020 Giuseppe Penone <giuspen@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#pragma once
+#include <string>
+#include <list>
+#include <vector>
+#include "ct_types.h"
+#include <spdlog/fmt/fmt.h>
+#include <glibmm/miscutils.h>
+
+class CtConfig;
+
+namespace CtFileSystem {
+class path;
+
+bool copy_file(const path& from, const path& to);
+
+bool move_file(const path& from, const path& to);
+
+bool is_regular_file(const path& file);
+
+path absolute(const path& path);
+
+path canonical(const path& path);
+
+bool exists(const path& filepath);
+
+bool is_directory(const path& path);
+
+time_t getmtime(const path& path);
+
+int getsize(const std::string& path);
+
+std::list<path> get_dir_entries(const path& dir);
+std::string get_file_stem(const std::string& path);
+
+void external_filepath_open(const path& filepath, bool open_folder_if_file_not_exists, CtConfig* config);
+void external_folderpath_open(const path& folderpath, CtConfig* config);
+
+path prepare_export_folder(const path& dir_place, path new_folder, bool overwrite_existing);
+
+CtDocType get_doc_type(const path& fileName);
+CtDocEncrypt get_doc_encrypt(const path& fileName);
+
+/**
+* @brief Remove a directory and all its children
+* @param dir
+* @return
+*/
+std::uintmax_t remove_all(const path& dir);
+/**
+* @brief Remove a file or an empty directory
+* @param path
+* @return
+*/
+bool remove(const path& path);
+
+std::string get_cherrytree_datadir();
+path get_cherrytree_localedir();
+std::string get_cherrytree_configdir();
+std::string get_cherrytree_lang_filepath();
+
+std::string download_file(const std::string& filepath);
+
+/**
+* @class path
+* @brief An object representing a filepath
+*/
+class path {
+    using value_type = std::string::value_type;
+    using string_type = std::basic_string<value_type>;
+#ifdef __WIN32
+    value_type path_sep = '\\';
+#else
+    value_type path_sep = '/';
+#endif
+
+public:
+    friend void swap(path& lhs, path& rhs) noexcept {
+        using std::swap;
+        swap(lhs._path, rhs._path);
+    }
+
+    path() = default;
+    path(string_type path) : _path(_get_platform_path(std::move(path))) {}
+    path(const value_type* path) : _path(string_type(path)) {}
+    template<typename ITERATOR_T>
+    path(ITERATOR_T begin, ITERATOR_T end) : path(string_type(begin, end)) {}
+    ~path() = default;
+
+    void swap(path& other) noexcept {
+        using std::swap;
+        swap(*this, other);
+    }
+
+    void append(const path& other);
+
+    path& operator=(string_type other);
+    path& operator=(const value_type* other) { return operator=(string_type(other)); };
+
+
+    friend path operator/(const path& lhs, const path& rhs)
+    {
+        return path(Glib::build_filename(lhs._path, rhs._path));
+    }
+    friend path operator/(const path& lhs, const value_type* rhs) {
+        return path(Glib::build_filename(lhs._path, rhs));
+    }
+
+    friend path operator/(const path& lhs, const string_type& rhs)
+    {
+        return path(Glib::build_filename(lhs._path, rhs));
+    }
+    void operator/=(const path& rhs) { append(rhs); }
+
+    friend bool operator==(const path& lhs, const path& rhs) { return lhs._path == rhs._path; }
+    friend bool operator!=(const path& lhs, const path& rhs) { return !(lhs == rhs); }
+    friend bool operator<(const path& lhs, const path& rhs) { return lhs._path < rhs._path; }
+    friend bool operator>(const path& lhs, const path& rhs) { return lhs._path > rhs._path; }
+    friend bool operator>=(const path& lhs, const path& rhs) { return lhs._path >= rhs._path; }
+    friend bool operator<=(const path& lhs, const path& rhs) { return lhs._path <= rhs._path; }
+
+    friend void operator+=(path& lhs, const path& rhs) { lhs._path += rhs._path; }
+    friend void operator+=(path& lhs, const std::string& rhs) { lhs._path += _get_platform_path(rhs); }
+    friend void operator+=(path& lhs, const value_type* rhs) { lhs._path += _get_platform_path(rhs); }
+
+    [[nodiscard]] const char* c_str() const { return _path.c_str(); };
+    [[nodiscard]] std::string string() const { return _path; }
+    [[nodiscard]] bool is_absolute() const { return Glib::path_is_absolute(_path); }
+    [[nodiscard]] bool is_relative() const { return !is_absolute(); }
+    [[nodiscard]] bool empty() const noexcept { return _path.empty(); }
+    [[nodiscard]] path filename() const { return Glib::path_get_basename(_path); }
+    [[nodiscard]] path parent_path() const { return Glib::path_get_dirname(_path); }
+    [[nodiscard]] path extension() const;
+    [[nodiscard]] path stem() const;
+private:
+    string_type _path;
+
+    /// From Slash to Backslash when needed
+    static std::string _get_platform_path(std::string filepath);
+
+};
+
+class filesystem_error: public std::system_error {
+public:
+    filesystem_error(const std::string& what_arg, std::error_code ec) : std::system_error(ec, what_arg) {}
+    filesystem_error(const std::string& what_arg, const path& p1, std::error_code ec) : std::system_error(ec, what_arg), _p1(p1) {}
+    filesystem_error(const std::string& what_arg, const path& p1, const path& p2, std::error_code ec) : std::system_error(ec, what_arg), _p1(p1), _p2(p2) {}
+
+    const path& path1() const { return _p1; }
+    const path& path2() const { return _p2; }
+private:
+    path _p1;
+    path _p2;
+};
+
+} // namespace CtFileSystem
+
+namespace fs = CtFileSystem;
+
+template<>
+struct fmt::formatter<CtFileSystem::path> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template<typename FormatContext>
+    auto format(const CtFileSystem::path& path, FormatContext& ctx) {
+        return format_to(ctx.out(), "{}", path.string());
+    }
+};

--- a/future/src/ct/ct_image.cc
+++ b/future/src/ct/ct_image.cc
@@ -78,9 +78,9 @@ CtImage::~CtImage()
 {
 }
 
-void CtImage::save(const Glib::ustring& file_name, const Glib::ustring& type)
+void CtImage::save(const fs::path& file_name, const Glib::ustring& type)
 {
-    _rPixbuf->save(file_name, type);
+    _rPixbuf->save(file_name.string(), type);
 }
 
 
@@ -272,7 +272,7 @@ bool CtImageAnchor::_on_button_press_event(GdkEventButton* event)
 }
 
 CtImageEmbFile::CtImageEmbFile(CtMainWin* pCtMainWin,
-                               const Glib::ustring& fileName,
+                               const fs::path& fileName,
                                const std::string& rawBlob,
                                const double& timeSeconds,
                                const int charOffset,
@@ -292,7 +292,7 @@ void CtImageEmbFile::to_xml(xmlpp::Element* p_node_parent, const int offset_adju
     xmlpp::Element* p_image_node = p_node_parent->add_child("encoded_png");
     p_image_node->set_attribute("char_offset", std::to_string(_charOffset+offset_adjustment));
     p_image_node->set_attribute(CtConst::TAG_JUSTIFICATION, _justification);
-    p_image_node->set_attribute("filename", _fileName);
+    p_image_node->set_attribute("filename", _fileName.string());
     p_image_node->set_attribute("time", std::to_string(_timeSeconds));
     const std::string encodedBlob = Glib::Base64::encode(_rawBlob);
     p_image_node->add_child_text(encodedBlob);
@@ -309,7 +309,7 @@ bool CtImageEmbFile::to_sqlite(sqlite3* pDb, const gint64 node_id, const int off
     }
     else
     {
-        const std::string file_name = Glib::locale_from_utf8(_fileName);
+        const std::string file_name = Glib::locale_from_utf8(_fileName.string());
         sqlite3_bind_int64(p_stmt, 1, node_id);
         sqlite3_bind_int64(p_stmt, 2, _charOffset+offset_adjustment);
         sqlite3_bind_text(p_stmt, 3, _justification.c_str(), _justification.size(), SQLITE_STATIC);
@@ -337,7 +337,7 @@ void CtImageEmbFile::update_label_widget()
 {
     if (_pCtMainWin->get_ct_config()->embfileShowFileName)
     {
-        _labelWidget.set_markup("<b><small>"+_fileName+"</small></b>");
+        _labelWidget.set_markup("<b><small>"+_fileName.string()+"</small></b>");
         _labelWidget.show();
         _frame.set_label_widget(_labelWidget);
     }

--- a/future/src/ct/ct_image.h
+++ b/future/src/ct/ct_image.h
@@ -49,7 +49,7 @@ public:
     void apply_syntax_highlighting() override {}
     void set_modified_false() override {}
 
-    void save(const Glib::ustring& file_name, const Glib::ustring& type);
+    void save(const fs::path& file_name, const Glib::ustring& type);
     Glib::RefPtr<Gdk::Pixbuf> get_pixbuf() { return _rPixbuf; }
 
 protected:
@@ -118,7 +118,7 @@ class CtImageEmbFile : public CtImage
 {
 public:
     CtImageEmbFile(CtMainWin* pCtMainWin,
-                   const Glib::ustring& fileName,
+                   const fs::path& fileName,
                    const std::string& rawBlob,
                    const double& timeSeconds,
                    const int charOffset,
@@ -130,7 +130,7 @@ public:
     CtAnchWidgType get_type() override { return CtAnchWidgType::ImageEmbFile; }
     std::shared_ptr<CtAnchoredWidgetState> get_state() override;
 
-    const Glib::ustring& get_file_name() { return _fileName; }
+    const fs::path& get_file_name() { return _fileName; }
     const std::string&   get_raw_blob() { return _rawBlob; }
     void                 set_raw_blob(char* buffer, size_t size) { _rawBlob = std::string(buffer, size);}
     double               get_time() { return _timeSeconds; }
@@ -143,7 +143,7 @@ private:
     bool _on_button_press_event(GdkEventButton* event);
 
 protected:
-    Glib::ustring _fileName;
+    fs::path      _fileName;
     std::string   _rawBlob;      // raw data, not a string
     double        _timeSeconds;
 };

--- a/future/src/ct/ct_imports.cc
+++ b/future/src/ct/ct_imports.cc
@@ -166,12 +166,12 @@ std::vector<std::pair<int, int>> CtImports::get_web_links_offsets_from_plain_tex
     return web_links;
 }
 
-std::unique_ptr<ct_imported_node> CtImports::traverse_dir(const std::string& dir, CtImporterInterface* importer)
+std::unique_ptr<ct_imported_node> CtImports::traverse_dir(const fs::path& dir, CtImporterInterface* importer)
 {
-    auto dir_node = std::make_unique<ct_imported_node>(dir, Glib::path_get_basename(dir));
+    auto dir_node = std::make_unique<ct_imported_node>(dir, dir.filename().string());
     for (const auto& dir_item: CtFileSystem::get_dir_entries(dir))
     {
-        if (Glib::file_test(dir_item, Glib::FILE_TEST_IS_DIR))
+        if (fs::is_directory(dir_item))
         {
             if (auto node = traverse_dir(dir_item, importer))
               dir_node->children.emplace_back(std::move(node));
@@ -803,20 +803,20 @@ CtHtmlImport::CtHtmlImport(CtConfig* config) : _config(config)
 
 }
 
-std::unique_ptr<ct_imported_node> CtHtmlImport::import_file(const std::string& file)
+std::unique_ptr<ct_imported_node> CtHtmlImport::import_file(const fs::path& file)
 {
-    if (!str::endswith(file, ".html") && !str::endswith(file, ".htm"))
+    if (file.extension() != ".html" && file.extension() != ".htm")
         return nullptr;
 
     std::ifstream infile;
     infile.exceptions(std::ios_base::failbit);
-    infile.open(file);
+    infile.open(file.string());
     std::ostringstream ss;
     ss << infile.rdbuf();
 
-    auto imported_node = std::make_unique<ct_imported_node>(file, CtFileSystem::get_file_stem(file));
+    auto imported_node = std::make_unique<ct_imported_node>(file, file.stem().string());
     CtHtml2Xml html2xml(_config);
-    html2xml.set_local_dir(Glib::path_get_dirname(file));
+    html2xml.set_local_dir(file.parent_path().string());
     html2xml.set_outter_xml_doc(&imported_node->xml_content);
     html2xml.feed(ss.str());
 
@@ -831,10 +831,10 @@ CtTomboyImport::CtTomboyImport(CtConfig* config) : _config(config)
 
 }
 
-std::unique_ptr<ct_imported_node> CtTomboyImport::import_file(const std::string& file)
+std::unique_ptr<ct_imported_node> CtTomboyImport::import_file(const fs::path& file)
 {
     xmlpp::DomParser tomboy_doc;
-    try { tomboy_doc.parse_file(file);}
+    try { tomboy_doc.parse_file(file.string());}
     catch (std::exception& ex) {
         spdlog::error("CtTomboyImport: cannot parse xml file ({}): {}", ex.what(), file);
         return nullptr;
@@ -973,19 +973,18 @@ CtZimImport::CtZimImport(CtConfig* config): CtParser(config), CtTextParser(confi
 
 }
 
-std::unique_ptr<ct_imported_node> CtZimImport::import_file(const std::string& file)
+std::unique_ptr<ct_imported_node> CtZimImport::import_file(const fs::path& file)
 {
-    if (!str::endswith(file, ".txt"))
-        return nullptr;
+    if (file.extension() != ".txt") return nullptr;
 
-    _ensure_notebook_file_in_dir(Glib::path_get_dirname(file));
+    _ensure_notebook_file_in_dir(file.parent_path());
 
-    std::unique_ptr<ct_imported_node> node = std::make_unique<ct_imported_node>(file, CtFileSystem::get_file_stem(file));
+    std::unique_ptr<ct_imported_node> node = std::make_unique<ct_imported_node>(file, file.stem().string());
     _current_node = node.get();
     _current_element = node->xml_content.create_root_node("root")->add_child("slot");
     _current_element = _current_element->add_child("rich_text");
 
-    std::ifstream stream(file);
+    std::ifstream stream(file.string());
     feed(stream);
     return node;
 }
@@ -1144,11 +1143,11 @@ void CtZimImport::_parse_body_line(const std::string& line)
     _add_newline();
 }
 
-void CtZimImport::_ensure_notebook_file_in_dir(const std::string& dir)
+void CtZimImport::_ensure_notebook_file_in_dir(const fs::path& dir)
 {
     if (_has_notebook_file) return;
     for (auto dir_item: CtFileSystem::get_dir_entries(dir))
-        if (Glib::path_get_basename(dir_item) == "notebook.zim")
+        if (dir_item.filename() == "notebook.zim")
         {
             _has_notebook_file = true;
             break;
@@ -1161,20 +1160,20 @@ void CtZimImport::_ensure_notebook_file_in_dir(const std::string& dir)
 
 
 
-std::unique_ptr<ct_imported_node> CtPlainTextImport::import_file(const std::string& file)
+std::unique_ptr<ct_imported_node> CtPlainTextImport::import_file(const fs::path& file)
 {
-    if (!CtMiscUtil::mime_type_contains(file, "text/"))
+    if (!CtMiscUtil::mime_type_contains(file.string(), "text/"))
         return nullptr;
 
     try
     {
         std::ifstream infile;
         infile.exceptions(std::ios_base::failbit);
-        infile.open(file);
+        infile.open(file.string());
         std::ostringstream data;
         data << infile.rdbuf();
 
-        std::unique_ptr<ct_imported_node> node = std::make_unique<ct_imported_node>(file, CtFileSystem::get_file_stem(file));
+        std::unique_ptr<ct_imported_node> node = std::make_unique<ct_imported_node>(file, file.stem().string());
         node->xml_content.create_root_node("root")->add_child("slot")->add_child("rich_text")->add_child_text(data.str());
         node->node_syntax = CtConst::PLAIN_TEXT_ID;
         return node;
@@ -1193,17 +1192,17 @@ CtMDImport::CtMDImport(CtConfig* config) : _parser(config)
 
 }
 
-std::unique_ptr<ct_imported_node> CtMDImport::import_file(const std::string& file)
+std::unique_ptr<ct_imported_node> CtMDImport::import_file(const fs::path& file)
 {
-    if (!str::endswith(file, ".md"))
+    if (file.extension() != ".md")
         return nullptr;
 
-    std::ifstream infile(file);
+    std::ifstream infile(file.string());
     if (!infile) throw std::runtime_error(fmt::format("CtMDImport: cannot open file, what: {}, file: {}", strerror(errno), file));
     _parser.wipe();
     _parser.feed(infile);
 
-    std::unique_ptr<ct_imported_node> node = std::make_unique<ct_imported_node>(file, CtFileSystem::get_file_stem(file));
+    std::unique_ptr<ct_imported_node> node = std::make_unique<ct_imported_node>(file, file.stem().string());
     node->xml_content.create_root_node_by_import(_parser.get_root_node());
 
     return node;
@@ -1216,12 +1215,12 @@ CtPandocImport::CtPandocImport(CtConfig* config): _config(config)
 
 }
 
-std::unique_ptr<ct_imported_node> CtPandocImport::import_file(const std::string& file)
+std::unique_ptr<ct_imported_node> CtPandocImport::import_file(const fs::path& file)
 {
     std::stringstream html_buff;
     CtPandoc::to_html(file, html_buff);
 
-    std::unique_ptr<ct_imported_node> node = std::make_unique<ct_imported_node>(file, CtFileSystem::get_file_stem(file));
+    std::unique_ptr<ct_imported_node> node = std::make_unique<ct_imported_node>(file, file.stem().string());
 
     CtHtml2Xml parser(_config);
     parser.set_outter_xml_doc(&node->xml_content);

--- a/future/src/ct/ct_imports.cc
+++ b/future/src/ct/ct_imports.cc
@@ -88,7 +88,7 @@ xmlpp::Element *image_to_xml(xmlpp::Element *parent, const std::string &path, in
     
         // Download
         try {
-            std::string file_buffer = CtFileSystem::download_file(path);
+            std::string file_buffer = fs::download_file(path);
             if (!file_buffer.empty()) {
                 Glib::RefPtr<Gdk::PixbufLoader> pixbuf_loader = Gdk::PixbufLoader::create();
                 pixbuf_loader->write(reinterpret_cast<const guint8 *>(file_buffer.c_str()), file_buffer.size());
@@ -169,7 +169,7 @@ std::vector<std::pair<int, int>> CtImports::get_web_links_offsets_from_plain_tex
 std::unique_ptr<ct_imported_node> CtImports::traverse_dir(const fs::path& dir, CtImporterInterface* importer)
 {
     auto dir_node = std::make_unique<ct_imported_node>(dir, dir.filename().string());
-    for (const auto& dir_item: CtFileSystem::get_dir_entries(dir))
+    for (const auto& dir_item: fs::get_dir_entries(dir))
     {
         if (fs::is_directory(dir_item))
         {
@@ -643,7 +643,7 @@ void CtHtml2Xml::_insert_image(std::string img_path, std::string trailing_chars)
 
     // trying to download
     try {
-        std::string file_buffer = CtFileSystem::download_file(img_path);
+        std::string file_buffer = fs::download_file(img_path);
         if (!file_buffer.empty()) {
             Glib::RefPtr<Gdk::PixbufLoader> pixbuf_loader = Gdk::PixbufLoader::create();
             pixbuf_loader->write((const guint8*)file_buffer.c_str(), file_buffer.size());
@@ -1146,7 +1146,7 @@ void CtZimImport::_parse_body_line(const std::string& line)
 void CtZimImport::_ensure_notebook_file_in_dir(const fs::path& dir)
 {
     if (_has_notebook_file) return;
-    for (auto dir_item: CtFileSystem::get_dir_entries(dir))
+    for (auto dir_item: fs::get_dir_entries(dir))
         if (dir_item.filename() == "notebook.zim")
         {
             _has_notebook_file = true;

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -63,7 +63,7 @@ public:
 namespace CtImports {
 
     std::vector<std::pair<int, int>> get_web_links_offsets_from_plain_text(const Glib::ustring& plain_text);
-    std::unique_ptr<ct_imported_node> traverse_dir(const CtFileSystem::path& dir, CtImporterInterface* importer);
+    std::unique_ptr<ct_imported_node> traverse_dir(const fs::path& dir, CtImporterInterface* importer);
 
 }
 

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -23,11 +23,13 @@
 
 #include "ct_const.h"
 #include "ct_parser.h"
+#include "ct_filesystem.h"
 
 #include <glibmm/ustring.h>
 #include <libxml2/libxml/HTMLparser.h>
 #include <libxml++/libxml++.h>
 #include <queue>
+#include <utility>
 
 namespace {
 using TableMatrx = std::queue<std::queue<std::string>>;
@@ -35,7 +37,7 @@ using TableMatrx = std::queue<std::queue<std::string>>;
 
 struct ct_imported_node
 {
-    std::string                      path;
+    fs::path                         path;
     Glib::ustring                    node_name;
     gint64                           node_id {-1};     // generated at the end
     std::string                      node_syntax {CtConst::RICH_TEXT_ID};
@@ -43,7 +45,7 @@ struct ct_imported_node
     std::map<Glib::ustring, std::vector<xmlpp::Element*>> content_broken_links;
     std::list<std::unique_ptr<ct_imported_node>> children;
 
-    ct_imported_node(const std::string& _path, const Glib::ustring& _name) : path(_path), node_name(_name) {}
+    ct_imported_node(fs::path _path, const Glib::ustring& _name) : path(std::move(_path)), node_name(_name) {}
     void add_broken_link(const Glib::ustring& link, xmlpp::Element* el) { content_broken_links[link].push_back(el); }
     bool has_content() { return xml_content.get_root_node(); }
 };
@@ -52,7 +54,7 @@ struct ct_imported_node
 class CtImporterInterface
 {
 public:
-    virtual std::unique_ptr<ct_imported_node> import_file(const std::string& file) = 0;
+    virtual std::unique_ptr<ct_imported_node> import_file(const fs::path& file) = 0;
     virtual std::vector<std::string>          file_mimes() { return {}; }
     virtual std::vector<std::string>          file_patterns() { return {}; }
 };
@@ -61,7 +63,7 @@ public:
 namespace CtImports {
 
     std::vector<std::pair<int, int>> get_web_links_offsets_from_plain_text(const Glib::ustring& plain_text);
-    std::unique_ptr<ct_imported_node> traverse_dir(const std::string& dir, CtImporterInterface* importer);
+    std::unique_ptr<ct_imported_node> traverse_dir(const CtFileSystem::path& dir, CtImporterInterface* importer);
 
 }
 
@@ -182,7 +184,7 @@ public:
     CtHtmlImport(CtConfig* config);
 
     // virtuals of CtImporterInterface
-    std::unique_ptr<ct_imported_node> import_file(const std::string& file) override;
+    std::unique_ptr<ct_imported_node> import_file(const fs::path& file) override;
     std::vector<std::string>          file_mimes() override { return {"text/html"}; };
 
 private:
@@ -197,7 +199,7 @@ public:
 
 public:
     // virtuals of CtImporterInterface
-    std::unique_ptr<ct_imported_node> import_file(const std::string& file) override;
+    std::unique_ptr<ct_imported_node> import_file(const fs::path& file) override;
 
 private:
     void            _iterate_tomboy_note(xmlpp::Element* iter, std::unique_ptr<ct_imported_node>& node);
@@ -226,7 +228,7 @@ public:
 
 public:
     // virtuals of CtImporterInterface
-    std::unique_ptr<ct_imported_node> import_file(const std::string& file) override;
+    std::unique_ptr<ct_imported_node> import_file(const fs::path& file) override;
 
 protected:
     // virtuals of CtTextParser
@@ -235,7 +237,7 @@ protected:
 
 private:
     void _parse_body_line(const std::string& line);
-    void _ensure_notebook_file_in_dir(const std::string& dir);
+    void _ensure_notebook_file_in_dir(const fs::path& dir);
 
 private:
     bool              _has_notebook_file {false};
@@ -251,7 +253,7 @@ public:
 
 public:
     // virtuals of CtImporterInterface
-    std::unique_ptr<ct_imported_node> import_file(const std::string& file) override;
+    std::unique_ptr<ct_imported_node> import_file(const fs::path& file) override;
     std::vector<std::string>          file_mimes() override { return {"text/plain"}; };
 };
 
@@ -296,7 +298,7 @@ public:
 
 public:
     // virtuals of CtImporterInterface
-    std::unique_ptr<ct_imported_node> import_file(const std::string& file) override;
+    std::unique_ptr<ct_imported_node> import_file(const fs::path& file) override;
     std::vector<std::string>          file_mimes() override { return {"text/plain"}; };
     std::vector<std::string>          file_patterns() override { return {"*.md"}; };
 
@@ -312,7 +314,7 @@ public:
 
 public:
     // virtuals of CtImporterInterface
-    std::unique_ptr<ct_imported_node> import_file(const std::string& file) override;
+    std::unique_ptr<ct_imported_node> import_file(const fs::path& file) override;
 
 private:
     CtConfig* _config;

--- a/future/src/ct/ct_main.cc
+++ b/future/src/ct/ct_main.cc
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
     {
         if (Glib::setenv("LANGUAGE", ct_lang, true/*overwrite*/))
         {
-            g_message("Language overwrite = %s (localedir = %s)", ct_lang.c_str(), CtFileSystem::get_cherrytree_localedir().c_str());
+            g_message("Language overwrite = %s (localedir = %s)", ct_lang.c_str(), fs::get_cherrytree_localedir().c_str());
         }
         else
         {
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    bindtextdomain(GETTEXT_PACKAGE, CtFileSystem::get_cherrytree_localedir().c_str());
+    bindtextdomain(GETTEXT_PACKAGE, fs::get_cherrytree_localedir().c_str());
     bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
     textdomain(GETTEXT_PACKAGE);
 #endif

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -828,7 +828,7 @@ bool CtMainWin::file_open(const fs::path& filepath, const std::string& node_to_f
         CtDialogs::error_dialog("File does not exist", *this);
         return false;
     }
-    if (CtFileSystem::get_doc_type(filepath) == CtDocType::None) {
+    if (fs::get_doc_type(filepath) == CtDocType::None) {
         // can't open file but can insert content into a new node
         if (file_insert_plain_text(filepath)) {
             return false; // that's right
@@ -861,7 +861,7 @@ bool CtMainWin::file_open(const fs::path& filepath, const std::string& node_to_f
 
     _title_update(false/*saveNeeded*/);
     menu_set_bookmark_menu_items();
-    bool can_vacuum = CtFileSystem::get_doc_type(_uCtStorage->get_file_path()) == CtDocType::SQLite;
+    bool can_vacuum = fs::get_doc_type(_uCtStorage->get_file_path()) == CtDocType::SQLite;
     _uCtMenu->find_action("ct_vacuum")->signal_set_visible.emit(can_vacuum);
 
     const auto iterDocsRestore{_pCtConfig->recentDocsRestore.find(filepath.string())};
@@ -971,7 +971,7 @@ void CtMainWin::file_save_as(const std::string& new_filepath, const std::string&
 
     _uCtStorage.reset(new_storage);
 
-    bool can_vacuum = CtFileSystem::get_doc_type(_uCtStorage->get_file_path()) == CtDocType::SQLite;
+    bool can_vacuum = fs::get_doc_type(_uCtStorage->get_file_path()) == CtDocType::SQLite;
     _uCtMenu->find_action("ct_vacuum")->signal_set_visible.emit(can_vacuum);
 
     update_window_save_not_needed();

--- a/future/src/ct/ct_main_win.h
+++ b/future/src/ct/ct_main_win.h
@@ -94,12 +94,12 @@ public:
 
     void update_theme();
 
-    bool file_open(const std::string& filepath, const std::string& node_to_focus);
+    bool file_open(const fs::path& filepath, const std::string& node_to_focus);
     bool file_save_ask_user();
     void file_save(bool need_vacuum);
     void file_save_as(const std::string& new_filepath, const std::string& password);
     void file_autosave_restart();
-    bool file_insert_plain_text(const std::string& filepath);
+    bool file_insert_plain_text(const fs::path& filepath);
 
     void reset();
     void update_window_save_needed(const CtSaveNeededUpdType update_type = CtSaveNeededUpdType::None,

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -400,18 +400,18 @@ Gtk::Menu* CtMenu::build_recent_docs_menu(const CtRecentDocsFilepaths& recentDoc
                                           sigc::slot<void, const std::string&>& recent_doc_rm_action)
 {
     Gtk::Menu* pMenu = Gtk::manage(new Gtk::Menu());
-    for (const std::string& filepath : recentDocsFilepaths)
+    for (const fs::path& filepath : recentDocsFilepaths)
     {
         Gtk::MenuItem* pMenuItem = _add_menu_item(GTK_WIDGET(pMenu->gobj()), filepath.c_str(), "ct_open", nullptr, nullptr, filepath.c_str(), nullptr, nullptr, nullptr);
-        pMenuItem->signal_activate().connect(sigc::bind(recent_doc_open_action, filepath));
+        pMenuItem->signal_activate().connect(sigc::bind(recent_doc_open_action, filepath.string()));
     }
     Gtk::MenuItem* pMenuItemRm = _add_menu_item(GTK_WIDGET(pMenu->gobj()), _("Remove from list"), "ct_edit_delete", nullptr, nullptr, _("Remove from list"), nullptr, nullptr, nullptr);
     Gtk::Menu* pMenuRm = Gtk::manage(new Gtk::Menu());
     pMenuItemRm->set_submenu(*pMenuRm);
-    for (const std::string& filepath : recentDocsFilepaths)
+    for (const fs::path& filepath : recentDocsFilepaths)
     {
         Gtk::MenuItem* pMenuItem = _add_menu_item(GTK_WIDGET(pMenuRm->gobj()), filepath.c_str(), "ct_edit_delete", nullptr, nullptr, filepath.c_str(), nullptr, nullptr, nullptr);
-        pMenuItem->signal_activate().connect(sigc::bind(recent_doc_rm_action, filepath));
+        pMenuItem->signal_activate().connect(sigc::bind(recent_doc_rm_action, filepath.string()));
     }
     return pMenu;
 }

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -131,9 +131,9 @@ void table_to_csv(const CtStringTable& table, std::ostream& output) {
 std::string CtMiscUtil::get_ct_language()
 {
     std::string retLang{CtConst::LANG_DEFAULT};
-    if (Glib::file_test(CtFileSystem::get_cherrytree_lang_filepath(), Glib::FILE_TEST_IS_REGULAR))
+    if (fs::is_regular_file(CtFileSystem::get_cherrytree_lang_filepath()))
     {
-        const std::string langTxt = str::trim(Glib::file_get_contents(CtFileSystem::get_cherrytree_lang_filepath()));
+        const std::string langTxt = str::trim(Glib::file_get_contents(CtFileSystem::get_cherrytree_lang_filepath().string()));
         if (vec::exists(CtConst::AVAILABLE_LANGS, langTxt))
         {
             retLang = langTxt;
@@ -728,16 +728,6 @@ char* CtRgbUtil::set_rgb24str_from_str_any(const char* rgbStrAny, char* rgb24Str
     return rgb24StrOut;
 }
 
-std::vector<std::string> CtMiscUtil::split(const std::string& str, std::string_view sep) {
-    std::vector<std::string> strs;
-    size_t last_pos = 0;
-    size_t next_pos = 0;
-    while((next_pos = str.find(sep, last_pos)) != std::string::npos) {
-        strs.emplace_back(str.substr(last_pos, next_pos - last_pos));
-    }
-    strs.emplace_back(str.substr(last_pos));
-    return strs;
-}
 
 Glib::ustring CtRgbUtil::rgb_to_no_white(Glib::ustring in_rgb)
 {

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -40,7 +40,7 @@
 #endif
 
 
-namespace fs = CtFileSystem;
+namespace fs = fs;
 
 namespace CtCSV {
 CtStringTable table_from_csv(std::istream& input)
@@ -131,16 +131,16 @@ void table_to_csv(const CtStringTable& table, std::ostream& output) {
 std::string CtMiscUtil::get_ct_language()
 {
     std::string retLang{CtConst::LANG_DEFAULT};
-    if (fs::is_regular_file(CtFileSystem::get_cherrytree_lang_filepath()))
+    if (fs::is_regular_file(fs::get_cherrytree_lang_filepath()))
     {
-        const std::string langTxt = str::trim(Glib::file_get_contents(CtFileSystem::get_cherrytree_lang_filepath().string()));
+        const std::string langTxt = str::trim(Glib::file_get_contents(fs::get_cherrytree_lang_filepath().string()));
         if (vec::exists(CtConst::AVAILABLE_LANGS, langTxt))
         {
             retLang = langTxt;
         }
         else
         {
-            g_critical("Unexpected %s file content %s", CtFileSystem::get_cherrytree_lang_filepath().c_str(), langTxt.c_str());
+            g_critical("Unexpected %s file content %s", fs::get_cherrytree_lang_filepath().c_str(), langTxt.c_str());
         }
     }
     return retLang;

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -40,8 +40,6 @@
 #endif
 
 
-namespace fs = fs;
-
 namespace CtCSV {
 CtStringTable table_from_csv(std::istream& input)
 {

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -23,7 +23,7 @@
 
 #include <pangomm.h>
 #include <iostream>
-#include <string.h>
+#include <cstring>
 #include "ct_misc_utils.h"
 #include "ct_const.h"
 #include "ct_main_win.h"
@@ -31,7 +31,6 @@
 #include <ctime>
 #include <regex>
 #include <glib/gstdio.h> // to get stats
-#include <fstream>
 #include <curl/curl.h>
 #include <spdlog/fmt/bundled/printf.h>
 
@@ -147,64 +146,33 @@ std::string CtMiscUtil::get_ct_language()
     return retLang;
 }
 
-CtDocType CtMiscUtil::get_doc_type(const std::string& fileName)
-{
-    CtDocType retDocType{CtDocType::None};
-    if ( (Glib::str_has_suffix(fileName, CtConst::CTDOC_XML_NOENC)) or
-         (Glib::str_has_suffix(fileName, CtConst::CTDOC_XML_ENC)) )
-    {
-        retDocType = CtDocType::XML;
-    }
-    else if ( (Glib::str_has_suffix(fileName, CtConst::CTDOC_SQLITE_NOENC)) or
-              (Glib::str_has_suffix(fileName, CtConst::CTDOC_SQLITE_ENC)) )
-    {
-        retDocType = CtDocType::SQLite;
-    }
-    return retDocType;
-}
 
-CtDocEncrypt CtMiscUtil::get_doc_encrypt(const std::string& fileName)
+std::string CtMiscUtil::get_doc_extension(const CtDocType ctDocType, const CtDocEncrypt ctDocEncrypt)
 {
-    CtDocEncrypt retDocEncrypt{CtDocEncrypt::None};
-    if ( (Glib::str_has_suffix(fileName, CtConst::CTDOC_XML_NOENC)) or
-         (Glib::str_has_suffix(fileName, CtConst::CTDOC_SQLITE_NOENC)) )
-    {
-        retDocEncrypt = CtDocEncrypt::False;
-    }
-    else if ( (Glib::str_has_suffix(fileName, CtConst::CTDOC_XML_ENC)) or
-              (Glib::str_has_suffix(fileName, CtConst::CTDOC_SQLITE_ENC)) )
-    {
-        retDocEncrypt = CtDocEncrypt::True;
-    }
-    return retDocEncrypt;
-}
-
-const gchar* CtMiscUtil::get_doc_extension(const CtDocType ctDocType, const CtDocEncrypt ctDocEncrypt)
-{
-    const gchar* retVal{""};
+    std::string ret_val;
     if (CtDocType::XML == ctDocType)
     {
         if (CtDocEncrypt::False == ctDocEncrypt)
         {
-            retVal = CtConst::CTDOC_XML_NOENC;
+            ret_val = CtConst::CTDOC_XML_NOENC;
         }
         else if (CtDocEncrypt::True == ctDocEncrypt)
         {
-            retVal = CtConst::CTDOC_XML_ENC;
+            ret_val = CtConst::CTDOC_XML_ENC;
         }
     }
     else if (CtDocType::SQLite == ctDocType)
     {
         if (CtDocEncrypt::False == ctDocEncrypt)
         {
-            retVal = CtConst::CTDOC_SQLITE_NOENC;
+            ret_val = CtConst::CTDOC_SQLITE_NOENC;
         }
         else if (CtDocEncrypt::True == ctDocEncrypt)
         {
-            retVal = CtConst::CTDOC_SQLITE_ENC;
+            ret_val = CtConst::CTDOC_SQLITE_ENC;
         }
     }
-    return retVal;
+    return ret_val;
 }
 
 void CtMiscUtil::filepath_extension_fix(const CtDocType ctDocType, const CtDocEncrypt ctDocEncrypt, std::string& filepath)
@@ -760,6 +728,17 @@ char* CtRgbUtil::set_rgb24str_from_str_any(const char* rgbStrAny, char* rgb24Str
     return rgb24StrOut;
 }
 
+std::vector<std::string> CtMiscUtil::split(const std::string& str, std::string_view sep) {
+    std::vector<std::string> strs;
+    size_t last_pos = 0;
+    size_t next_pos = 0;
+    while((next_pos = str.find(sep, last_pos)) != std::string::npos) {
+        strs.emplace_back(str.substr(last_pos, next_pos - last_pos));
+    }
+    strs.emplace_back(str.substr(last_pos));
+    return strs;
+}
+
 Glib::ustring CtRgbUtil::rgb_to_no_white(Glib::ustring in_rgb)
 {
     char out_rgb[16] = {};
@@ -928,215 +907,6 @@ Glib::ustring str::repeat(const Glib::ustring& input, int num)
     return ret;
 }
 
-std::string CtFileSystem::get_proper_platform_filepath(std::string filepath)
-{
-#ifdef _WIN32
-    filepath = str::replace(filepath, CtConst::CHAR_SLASH, CtConst::CHAR_BSLASH);
-#else
-    filepath = str::replace(filepath, CtConst::CHAR_BSLASH, CtConst::CHAR_SLASH);
-#endif
-    return filepath;
-}
 
-bool CtFileSystem::copy_file(const std::string& from_file, const std::string& to_file)
-{
-    Glib::RefPtr<Gio::File> rFileFrom = Gio::File::create_for_path(from_file);
-    Glib::RefPtr<Gio::File> rFileTo = Gio::File::create_for_path(to_file);
-    return rFileFrom->copy(rFileTo, Gio::FILE_COPY_OVERWRITE);
-}
 
-bool CtFileSystem::is_directory(const fs::path& path) {
-    return Glib::file_test(path.string(), Glib::FILE_TEST_IS_DIR);
-}
 
-bool CtFileSystem::move_file(const std::string& from_file, const std::string& to_file)
-{
-    Glib::RefPtr<Gio::File> rFileFrom = Gio::File::create_for_path(from_file);
-    Glib::RefPtr<Gio::File> rFileTo = Gio::File::create_for_path(to_file);
-    return rFileFrom->move(rFileTo, Gio::FILE_COPY_OVERWRITE);
-}
-
-fs::path CtFileSystem::abspath(const fs::path& path)
-{
-    Glib::RefPtr<Gio::File> rFile = Gio::File::create_for_path(path.string());
-    return rFile->get_path();
-}
-
-time_t CtFileSystem::getmtime(const std::string& path)
-{
-    time_t time = 0;
-    GStatBuf st;
-    if (g_stat(path.c_str(), &st) == 0)
-        time = st.st_mtime;
-    return time;
-}
-
-int CtFileSystem::getsize(const std::string& path)
-{
-    GStatBuf st;
-    if (g_stat(path.c_str(), &st) == 0)
-        return st.st_size;
-    return 0;
-}
-
-std::list<std::string> CtFileSystem::get_dir_entries(const std::string& dir)
-{
-    Glib::Dir gdir(dir);
-    std::list<std::string> entries(gdir.begin(), gdir.end());
-    for (auto& entry: entries)
-        entry = Glib::build_filename(dir, entry);
-    return entries;
-}
-
-std::string CtFileSystem::get_file_stem(const std::string& path)
-{
-    if (path == "") return "";
-    std::string name = Glib::path_get_basename(path);
-    size_t dot_pos = name.find_last_of(".");
-    if (dot_pos == std::string::npos || dot_pos == 0)
-        return name;
-    return name.substr(0, dot_pos);
-}
-
-bool CtFileSystem::exists(const CtFileSystem::path& filepath) {
-    return Glib::file_test(filepath.string(), Glib::FILE_TEST_EXISTS);
-}
-
-// Open Filepath with External App
-void CtFileSystem::external_filepath_open(const fs::path& filepath, bool open_folder_if_file_not_exists, CtConfig* config)
-{
-    spdlog::debug("filepath to open: {}", filepath);
-    if (config->filelinkCustomOn) {
-        std::string cmd = fmt::sprintf(config->filelinkCustomAct, filepath.string());
-        std::system(cmd.c_str());
-    } else {
-        if (open_folder_if_file_not_exists && !fs::exists(filepath)) {
-            external_folderpath_open(filepath, config);
-        } else if (!fs::exists(filepath)) {
-            throw std::runtime_error(fmt::format("Filepath: {} does not exist and open_folder_if_not_exists is false", filepath.string()));
-        } else {
-#ifdef _WIN32
-            ShellExecute(GetActiveWindow(), "open", filepath.c_str(), NULL, NULL, SW_SHOWNORMAL);
-#else
-            fs::path f_path("file://");
-            f_path += filepath;
-            g_app_info_launch_default_for_uri(f_path.c_str(), nullptr, nullptr);
-#endif
-        }
-    }
-}
-
-// Open Folderpath with External App
-void CtFileSystem::external_folderpath_open(const fs::path& folderpath, CtConfig* config)
-{
-    spdlog::debug("dir to open: {}", folderpath.string());
-    if (config->folderlinkCustomOn) {
-        std::string cmd = fmt::sprintf(config->filelinkCustomAct, folderpath.string());
-        std::system(cmd.c_str());
-    } else {
-    
-        // https://stackoverflow.com/questions/42442189/how-to-open-spawn-a-file-with-glib-gtkmm-in-windows
-#ifdef _WIN32
-        ShellExecute(NULL, "open", folderpath.c_str(), NULL, NULL, SW_SHOWDEFAULT);
-#elif defined(__APPLE__)
-        std::vector<std::string> argv = { "open", folderpath.string() };
-    Glib::spawn_async("", argv, Glib::SpawnFlags::SPAWN_SEARCH_PATH);
-#else
-        fs::path path("file://");
-        path += folderpath;
-        g_app_info_launch_default_for_uri(folderpath.c_str(), nullptr, nullptr);
-#endif
-    }
-}
-
-std::string CtFileSystem::prepare_export_folder(const std::string& dir_place, std::string new_folder, bool overwrite_existing)
-{
-    if (Glib::file_test(Glib::build_filename(dir_place, new_folder), Glib::FILE_TEST_IS_DIR))
-    {
-        // todo:
-        if (overwrite_existing) {
-            std::cout << "removing dir: " << Glib::build_filename(dir_place, new_folder) << std::endl;
-            rmdir(Glib::build_filename(dir_place, new_folder));
-        }
-        else {
-            int n = 2;
-            while (Glib::file_test(Glib::build_filename(dir_place, new_folder + str::format("{:03d}", n)), Glib::FILE_TEST_IS_DIR))
-                n += 1;
-            new_folder += str::format("{:03d}", n);
-        }
-    }
-    return new_folder;
-}
-
-extern bool cherrytree_remove_dir_with_subs(const char* path);
-bool CtFileSystem::rmdir(const std::string& dir)
-{
-    return cherrytree_remove_dir_with_subs(dir.c_str());
-}
-
-std::string CtFileSystem::get_cherrytree_datadir()
-{
-    if (Glib::file_test(_CMAKE_BINARY_DIR, Glib::FILE_TEST_IS_DIR)) {
-        // we're running from the build sources
-        return _CMAKE_SOURCE_DIR;
-    }
-    return CHERRYTREE_DATADIR;
-}
-
-std::string CtFileSystem::get_cherrytree_localedir()
-{
-    const std::string sources_po_dir = Glib::canonicalize_filename(Glib::build_filename(_CMAKE_SOURCE_DIR, "po"));
-    if (Glib::file_test(sources_po_dir, Glib::FILE_TEST_IS_DIR)) {
-        // we're running from the build sources
-        return sources_po_dir;
-    }
-    return CHERRYTREE_LOCALEDIR;
-}
-
-std::string CtFileSystem::get_cherrytree_configdir()
-{
-    //TODO: define rule for local config.cfg/lang files at least for Windows portable
-    return Glib::build_filename(Glib::get_user_config_dir(), CtConst::APP_NAME);
-}
-
-std::string CtFileSystem::get_cherrytree_lang_filepath()
-{
-    return Glib::build_filename(get_cherrytree_configdir(), "lang");
-}
-
-std::string CtFileSystem::download_file(const std::string& filepath)
-{
-    struct local {
-        static size_t write_memory_callback(void *contents, size_t size, size_t nmemb, void *userp)
-        {
-            const size_t realsize = size*nmemb;
-            static_cast<std::string*>(userp)->append((char*)contents, realsize);
-            return realsize;
-        }
-    };
-
-    spdlog::debug("start downloading {}", filepath);
-
-    std::string buffer;
-    buffer.reserve(3 * 1024 * 1024); // preallocate 3mb
-
-    // from https://curl.haxx.se/libcurl/c/getinmemory.html
-    curl_global_init(CURL_GLOBAL_ALL);
-    CURL* pCurlHandle = curl_easy_init();
-
-    curl_easy_setopt(pCurlHandle, CURLOPT_URL, filepath.c_str());
-    curl_easy_setopt(pCurlHandle, CURLOPT_WRITEFUNCTION, local::write_memory_callback);
-    curl_easy_setopt(pCurlHandle, CURLOPT_WRITEDATA, (void*)&buffer);
-    curl_easy_setopt(pCurlHandle, CURLOPT_TIMEOUT, 3);
-    curl_easy_setopt(pCurlHandle, CURLOPT_USERAGENT, "libcurl-agent/1.0");
-    const CURLcode res = curl_easy_perform(pCurlHandle);
-    curl_easy_cleanup(pCurlHandle);
-    curl_global_cleanup();
-
-    if (res != CURLE_OK) {
-        spdlog::error("curl_easy_perform() failed: {}", curl_easy_strerror(res));
-        return "";
-    }
-
-    return buffer;
-}

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -47,14 +47,22 @@ namespace CtCSV {
 }
 
 namespace CtMiscUtil {
+template<class ITER_T>
+std::string join(ITER_T begin, ITER_T end, std::string_view sep) {
+    std::ostringstream out;
+    while (begin != end) {
+        out << *begin << sep;
+        ++begin;
+    }
+    return out.str();
+}
+
+std::vector<std::string> split(const std::string& str, std::string_view sep);
 
 std::string get_ct_language();
 
-CtDocType get_doc_type(const std::string& fileName);
 
-CtDocEncrypt get_doc_encrypt(const std::string& fileName);
-
-const gchar* get_doc_extension(const CtDocType ctDocType, const CtDocEncrypt ctDocEncrypt);
+std::string get_doc_extension(const CtDocType ctDocType, const CtDocEncrypt ctDocEncrypt);
 
 void filepath_extension_fix(const CtDocType ctDocType, const CtDocEncrypt ctDocEncrypt, std::string& filepath);
 
@@ -409,88 +417,5 @@ bool exists(const MAP& m, const KEY& key)
 
 } // namespace map
 
-namespace CtFileSystem {
-class path;
-// From Slash to Backslash when needed
-std::string get_proper_platform_filepath(std::string filepath);
 
-bool copy_file(const std::string& from_file, const std::string& to_file);
-
-bool move_file(const std::string& from_file, const std::string& to_file);
-
-path abspath(const path& path);
-
-bool exists(const path& filepath);
-
-bool is_directory(const path& path);
-
-time_t getmtime(const std::string& path);
-
-int getsize(const std::string& path);
-
-std::list<std::string> get_dir_entries(const std::string& dir);
-std::string get_file_stem(const std::string& path);
-
-void external_filepath_open(const path& filepath, bool open_folder_if_file_not_exists, CtConfig* config);
-void external_folderpath_open(const path& folderpath, CtConfig* config);
-
-std::string prepare_export_folder(const std::string& dir_place, std::string new_folder, bool overwrite_existing);
-
-bool rmdir(const std::string& dir);
-
-std::string get_cherrytree_datadir();
-std::string get_cherrytree_localedir();
-std::string get_cherrytree_configdir();
-std::string get_cherrytree_lang_filepath();
-
-std::string download_file(const std::string& filepath);
-
-/**
- * @class path
- * @brief An object representing a filepath
- */
-class path {
-    using path_type = std::string;
-public:
-    path(path_type path) : _path(std::move(path)) {}
-    path(const char* path) : _path(path) {}
-    
-    ~path() = default;
-    
-    void append(const path& other) {
-        _path = Glib::build_filename(_path, other._path);
-    }
-
-    path& operator=(std::string other) {
-        _path.swap(other);
-        return *this;
-    }
-
-
-    friend path operator/(const path& lhs, const path& rhs) {
-        return path(Glib::build_filename(lhs._path, rhs._path));
-    }
-
-    friend path operator/(const path& lhs, const std::string& rhs) {
-        return path(Glib::build_filename(lhs._path, rhs));
-    }
-
-    friend void operator+=(path& lhs, const path& rhs) { lhs._path += rhs._path; }
-    friend void operator+=(path& lhs, const std::string& rhs) { lhs._path += rhs; }
-    
-    const char* c_str() const { return string().c_str(); };
-    std::string string() const { return get_proper_platform_filepath(_path); }
-private:
-    path_type _path;
-};
-} // namespace CtFileSystem
-
-template<>
-struct fmt::formatter<CtFileSystem::path> {
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-    template<typename FormatContext>
-        auto format(const CtFileSystem::path& path, FormatContext& ctx) {
-            return format_to(ctx.out(), "{}", path.string());
-        }
-};
 

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -47,17 +47,6 @@ namespace CtCSV {
 }
 
 namespace CtMiscUtil {
-template<class ITER_T>
-std::string join(ITER_T begin, ITER_T end, std::string_view sep) {
-    std::ostringstream out;
-    while (begin != end) {
-        out << *begin << sep;
-        ++begin;
-    }
-    return out.str();
-}
-
-std::vector<std::string> split(const std::string& str, std::string_view sep);
 
 std::string get_ct_language();
 

--- a/future/src/ct/ct_pref_dlg.cc
+++ b/future/src/ct/ct_pref_dlg.cc
@@ -1496,7 +1496,7 @@ Gtk::Widget* CtPrefDlg::build_tab_misc()
     combobox_country_language->signal_changed().connect([this, combobox_country_language](){
         Glib::ustring new_lang = combobox_country_language->get_active_text();
         need_restart(RESTART_REASON::LANG, _("The New Language will be Available Only After Restarting CherryTree"));
-        g_file_set_contents(CtFileSystem::get_cherrytree_lang_filepath().c_str(),
+        g_file_set_contents(fs::get_cherrytree_lang_filepath().c_str(),
                             new_lang.c_str(), (gssize)new_lang.bytes(), nullptr);
     });
 #endif

--- a/future/src/ct/ct_state_machine.h
+++ b/future/src/ct/ct_state_machine.h
@@ -78,7 +78,7 @@ public:
     virtual CtAnchoredWidget* to_widget(CtMainWin* pCtMainWin);
 
 public:
-    Glib::ustring fileName;
+    fs::path      fileName;
     std::string   rawBlob;      // raw data, not a string
     double        timeSeconds;
 };

--- a/future/src/ct/ct_storage_control.cc
+++ b/future/src/ct/ct_storage_control.cc
@@ -44,26 +44,25 @@ std::unique_ptr<CtStorageEntity> get_entity_by_type(CtMainWin* pCtMainWin, CtDoc
     return doc;
 }
 
-/*static*/ CtStorageControl* CtStorageControl::load_from(CtMainWin* pCtMainWin, const Glib::ustring &file_path, Glib::ustring& error)
+/*static*/ CtStorageControl* CtStorageControl::load_from(CtMainWin* pCtMainWin, const fs::path& file_path, Glib::ustring& error)
 {
     std::unique_ptr<CtStorageEntity> storage;
-    Glib::ustring extracted_file_path = file_path;
+    fs::path extracted_file_path = file_path;
     try
     {
-        if (!Glib::file_test(file_path, Glib::FILE_TEST_IS_REGULAR))
-            throw std::runtime_error("no file");
+        if (!fs::is_regular_file(file_path)) throw std::runtime_error("no file");
 
         // unpack file if need
         std::string password;
-        if (CtMiscUtil::get_doc_encrypt(file_path) == CtDocEncrypt::True)
+        if (CtFileSystem::get_doc_encrypt(file_path) == CtDocEncrypt::True) {
             extracted_file_path = _extract_file(pCtMainWin, file_path, password);
+        }
 
         // choose storage type
-        storage = get_entity_by_type(pCtMainWin, CtMiscUtil::get_doc_type(file_path));
+        storage = get_entity_by_type(pCtMainWin, CtFileSystem::get_doc_type(file_path));
 
         // load from file
-        if (!storage->populate_treestore(extracted_file_path, error))
-            throw std::runtime_error(error);
+        if (!storage->populate_treestore(extracted_file_path, error)) throw std::runtime_error(error);
 
         // it's ready
         CtStorageControl* doc = new CtStorageControl();
@@ -78,7 +77,7 @@ std::unique_ptr<CtStorageEntity> get_entity_by_type(CtMainWin* pCtMainWin, CtDoc
     }
     catch (std::exception& e)
     {
-        if (extracted_file_path != file_path && Glib::file_test(extracted_file_path, Glib::FILE_TEST_IS_REGULAR))
+        if (extracted_file_path != file_path && fs::is_regular_file(extracted_file_path))
             g_remove(extracted_file_path.c_str());
 
         spdlog::error(e.what());
@@ -87,20 +86,23 @@ std::unique_ptr<CtStorageEntity> get_entity_by_type(CtMainWin* pCtMainWin, CtDoc
     }
 }
 
-/*static*/ CtStorageControl* CtStorageControl::save_as(CtMainWin* pCtMainWin, const Glib::ustring& file_path, const Glib::ustring& password, Glib::ustring& error)
+/*static*/ CtStorageControl* CtStorageControl::save_as(CtMainWin* pCtMainWin, const fs::path& file_path, const Glib::ustring& password, Glib::ustring& error)
 {
     std::unique_ptr<CtStorageEntity> storage;
-    Glib::ustring extracted_file_path = file_path;
+    fs::path extracted_file_path = file_path;
     try
     {
-        if (CtMiscUtil::get_doc_encrypt(file_path) == CtDocEncrypt::True)
+        if (CtFileSystem::get_doc_encrypt(file_path) == CtDocEncrypt::True) {
             extracted_file_path = pCtMainWin->get_ct_tmp()->getHiddenFilePath(file_path);
-        if (Glib::file_test(file_path, Glib::FILE_TEST_IS_REGULAR))
-            g_remove(file_path.c_str());
-        if (Glib::file_test(extracted_file_path, Glib::FILE_TEST_IS_REGULAR))
-            g_remove(extracted_file_path.c_str());
+        }
+        if (fs::is_regular_file(file_path)) {
+            fs::remove(file_path);
+        }
+        if (fs::is_regular_file(extracted_file_path)) {
+            fs::remove(extracted_file_path);
+        }
 
-        storage = get_entity_by_type(pCtMainWin, CtMiscUtil::get_doc_type(file_path));
+        storage = get_entity_by_type(pCtMainWin, CtFileSystem::get_doc_type(file_path));
         // will save all data because it's the first time
         CtStorageSyncPending fakePanding;
         if (!storage->save_treestore(extracted_file_path, fakePanding, error))
@@ -127,10 +129,8 @@ std::unique_ptr<CtStorageEntity> get_entity_by_type(CtMainWin* pCtMainWin, CtDoc
     }
     catch (std::exception& e)
     {
-        if (Glib::file_test(file_path, Glib::FILE_TEST_IS_REGULAR))
-            g_remove(file_path.c_str());
-        if (Glib::file_test(extracted_file_path, Glib::FILE_TEST_IS_REGULAR))
-            g_remove(extracted_file_path.c_str());
+        if (fs::is_regular_file(file_path)) fs::remove(file_path);
+        if (fs::is_regular_file(extracted_file_path)) fs::remove(extracted_file_path);
 
         spdlog::error(e.what());
         error = e.what();
@@ -145,7 +145,8 @@ bool CtStorageControl::save(bool need_vacuum, Glib::ustring &error)
     // then write changes (and encrypt) into the original. If it's OK, then put the main backup to backup rotate
     // if it's not, copy file.ext! back;
 
-    Glib::ustring main_backup = _file_path + "!";
+    fs::path main_backup = _file_path;
+    main_backup += "!";
     bool need_backup = _need_backup && _pCtMainWin->get_ct_config()->backupCopy and _pCtMainWin->get_ct_config()->backupNum > 0;
     try
     {
@@ -158,17 +159,17 @@ bool CtStorageControl::save(bool need_vacuum, Glib::ustring &error)
         if (need_backup)
         {
             // move is faster but the file is used by sqlite without encrypt
-            if (_file_path == _extracted_file_path && CtMiscUtil::get_doc_type(_file_path) == CtDocType::SQLite)
+            if (_file_path == _extracted_file_path && CtFileSystem::get_doc_type(_file_path) == CtDocType::SQLite)
             {
                 _storage->close_connect();    // temporary, because of sqlite keepig the file
                 if (!CtFileSystem::copy_file(_file_path, main_backup))
-                    throw std::runtime_error(str::format(_("You Have No Write Access to %s"), Glib::path_get_dirname(_file_path)));
+                    throw std::runtime_error(fmt::format(_("You Have No Write Access to {}"), _file_path.parent_path()));
                 _storage->reopen_connect();
             }
             else
             {
                 if (!CtFileSystem::move_file(_file_path, main_backup))
-                    throw std::runtime_error(str::format(_("You Have No Write Access to %s"), Glib::path_get_dirname(_file_path)));
+                    throw std::runtime_error(fmt::format(_("You Have No Write Access to {}"), _file_path.parent_path()));
             }
         }
         // save changes
@@ -200,8 +201,7 @@ bool CtStorageControl::save(bool need_vacuum, Glib::ustring &error)
         // recover from backup
         try {
             _storage->close_connect();
-            if (need_backup && Glib::file_test(main_backup, Glib::FILE_TEST_IS_REGULAR))
-                CtFileSystem::move_file(main_backup, _file_path);
+            if (need_backup && fs::is_regular_file(main_backup)) CtFileSystem::move_file(main_backup, _file_path);
             _storage->reopen_connect();
         }
         catch (std::exception& e2) { spdlog::error(e2.what()); }
@@ -223,11 +223,11 @@ Glib::RefPtr<Gsv::Buffer> CtStorageControl::get_delayed_text_buffer(const gint64
     return _storage->get_delayed_text_buffer(node_id, syntax, widgets);
 }
 
-/*static*/ std::string CtStorageControl::_extract_file(CtMainWin* pCtMainWin, const std::string& file_path, std::string& password)
+/*static*/ fs::path CtStorageControl::_extract_file(CtMainWin* pCtMainWin, const fs::path& file_path, std::string& password)
 {
-    Glib::ustring temp_dir = pCtMainWin->get_ct_tmp()->getHiddenDirPath(file_path);
-    Glib::ustring temp_file_path = pCtMainWin->get_ct_tmp()->getHiddenFilePath(file_path);
-    Glib::ustring title = str::format(_("Enter Password for %s"), Glib::path_get_basename(file_path));
+    fs::path temp_dir = pCtMainWin->get_ct_tmp()->getHiddenDirPath(file_path);
+    fs::path temp_file_path = pCtMainWin->get_ct_tmp()->getHiddenFilePath(file_path);
+    Glib::ustring title = fmt::format(_("Enter Password for {}"), file_path.filename());
     while (true)
     {
         CtDialogTextEntry dialogTextEntry(title, true/*forPassword*/, pCtMainWin);
@@ -241,24 +241,27 @@ Glib::RefPtr<Gsv::Buffer> CtStorageControl::get_delayed_text_buffer(const gint64
     }
 }
 
-/*static*/ bool CtStorageControl::_package_file(const Glib::ustring& file_from, const Glib::ustring& file_to, const Glib::ustring& password)
+/*static*/ bool CtStorageControl::_package_file(const fs::path& file_from, const fs::path& file_to, const Glib::ustring& password)
 {
     return 0 == CtP7zaIface::p7za_archive(file_from.c_str(), file_to.c_str(), password.c_str())
-            && Glib::file_test(file_to, Glib::FILE_TEST_IS_REGULAR);
+            && fs::is_regular_file(file_to);
 }
 
-void CtStorageControl::_put_in_backup(const Glib::ustring& main_backup)
+void CtStorageControl::_put_in_backup(const fs::path& main_backup)
 {
-    Glib::ustring tilda_filepath = _file_path + str::repeat(CtConst::CHAR_TILDE, _pCtMainWin->get_ct_config()->backupNum - 1);
-    while (str::endswith(tilda_filepath, CtConst::CHAR_TILDE))
+    fs::path tilda_filepath = _file_path;
+    tilda_filepath += std::string(_pCtMainWin->get_ct_config()->backupNum - 1, '~');
+    while (str::endswith(tilda_filepath.string(), CtConst::CHAR_TILDE))
     {
-        if (Glib::file_test(tilda_filepath, Glib::FILE_TEST_IS_REGULAR))
-            if (!CtFileSystem::move_file(tilda_filepath, tilda_filepath + CtConst::CHAR_TILDE))
-                throw std::runtime_error(str::format(_("You Have No Write Access to %s"), Glib::path_get_dirname(_file_path)));
-        tilda_filepath = tilda_filepath.substr(0, tilda_filepath.size()-1);
+        if (fs::is_regular_file(tilda_filepath)) {
+            if (!CtFileSystem::move_file(tilda_filepath, tilda_filepath.string() + CtConst::CHAR_TILDE))
+                throw std::runtime_error(
+                        fmt::format(_("You Have No Write Access to {}"), _file_path.parent_path()));
+        }
+        tilda_filepath = tilda_filepath.string().substr(0, tilda_filepath.string().size()-1);
     }
-    if (!CtFileSystem::move_file(main_backup, _file_path + CtConst::CHAR_TILDE))
-        throw std::runtime_error(str::format(_("You Have No Write Access to %s"), Glib::path_get_dirname(_file_path)));
+    if (!CtFileSystem::move_file(main_backup, _file_path.string() + CtConst::CHAR_TILDE))
+        throw std::runtime_error(fmt::format(_("You Have No Write Access to {}"), _file_path.parent_path()));
 }
 
 void CtStorageControl::pending_edit_db_node_prop(gint64 node_id)
@@ -334,17 +337,19 @@ void CtStorageControl::pending_edit_db_bookmarks()
     _syncPending.bookmarks_to_write = true;
 }
 
-void CtStorageControl::add_nodes_from_storage(const std::string& path) 
+void CtStorageControl::add_nodes_from_storage(const fs::path& path)
 {
-    if (!Glib::file_test(path, Glib::FILE_TEST_IS_REGULAR))
+    if (!fs::is_regular_file(path)) {
         throw std::runtime_error(fmt::format("File: {} - is not a regular file", path));
+    }
 
     std::string password;
-    std::string extracted_file_path = path;
-    if (CtMiscUtil::get_doc_encrypt(path) == CtDocEncrypt::True)
+    fs::path extracted_file_path = path;
+    if (CtFileSystem::get_doc_encrypt(path) == CtDocEncrypt::True) {
         extracted_file_path = _extract_file(_pCtMainWin, path, password);
+    }
 
-    std::unique_ptr<CtStorageEntity> storage = get_entity_by_type(_pCtMainWin, CtMiscUtil::get_doc_type(extracted_file_path));
+    std::unique_ptr<CtStorageEntity> storage = get_entity_by_type(_pCtMainWin, CtFileSystem::get_doc_type(extracted_file_path));
     storage->import_nodes(extracted_file_path);
 
     _pCtMainWin->get_tree_store().nodes_sequences_fix(Gtk::TreeIter(), false);

--- a/future/src/ct/ct_storage_control.h
+++ b/future/src/ct/ct_storage_control.h
@@ -27,8 +27,8 @@ class CtStorageControl
 {
 public:
     static CtStorageControl* create_dummy_storage(CtMainWin* pCtMainWin);
-    static CtStorageControl* load_from(CtMainWin* pCtMainWin, const Glib::ustring& file_path, Glib::ustring& error);
-    static CtStorageControl* save_as(CtMainWin* pCtMainWin, const Glib::ustring& file_path, const Glib::ustring& password, Glib::ustring& error);
+    static CtStorageControl* load_from(CtMainWin* pCtMainWin, const fs::path& file_path, Glib::ustring& error);
+    static CtStorageControl* save_as(CtMainWin* pCtMainWin, const fs::path& file_path, const Glib::ustring& password, Glib::ustring& error);
 
 public:
     bool save(bool need_vacuum, Glib::ustring& error);
@@ -36,19 +36,19 @@ public:
  private:
     CtStorageControl() = default;
 
-    static std::string _extract_file(CtMainWin* pCtMainWin, const std::string& file_path, std::string& password);
-    static bool        _package_file(const Glib::ustring& file_from, const Glib::ustring& file_to, const Glib::ustring& password);
+    static fs::path _extract_file(CtMainWin* pCtMainWin, const fs::path& file_path, std::string& password);
+    static bool        _package_file(const fs::path& file_from, const fs::path& file_to, const Glib::ustring& password);
 
-    void _put_in_backup(const Glib::ustring& main_backup);
+    void _put_in_backup(const fs::path& main_backup);
 
 public:
     Glib::RefPtr<Gsv::Buffer> get_delayed_text_buffer(const gint64& node_id,
                                                       const std::string& syntax,
                                                       std::list<CtAnchoredWidget*>& widgets) const;
 
-    Glib::ustring get_file_path() { return _file_path; }
-    Glib::ustring get_file_name() { return _file_path.empty() ? "" : Glib::path_get_basename(_file_path); }
-    Glib::ustring get_file_dir()  { return _file_path.empty() ? "" : Glib::path_get_dirname(_file_path); }
+    const fs::path& get_file_path() { return _file_path; }
+    fs::path get_file_name() { return _file_path.empty() ? "" : _file_path.filename(); }
+    fs::path get_file_dir()  { return _file_path.empty() ? "" : _file_path.parent_path(); }
 
     std::set<gint64> get_nodes_pending_rm() { return _syncPending.nodes_to_rm_set; }
 
@@ -65,13 +65,13 @@ public:
      * encrypted files 
      * @param path: The path to the external CT file
      */
-    void add_nodes_from_storage(const std::string& path);    
+    void add_nodes_from_storage(const fs::path& path);
 
 private:
     CtMainWin*                       _pCtMainWin{nullptr};
-    Glib::ustring                    _file_path;
+    fs::path                         _file_path;
     Glib::ustring                    _password;
-    Glib::ustring                    _extracted_file_path;
+    fs::path                         _extracted_file_path;
     bool                             _need_backup{true};   // create a backup once, on the first saving
     std::unique_ptr<CtStorageEntity> _storage;
     CtStorageSyncPending             _syncPending;

--- a/future/src/ct/ct_storage_sqlite.cc
+++ b/future/src/ct/ct_storage_sqlite.cc
@@ -173,7 +173,7 @@ void CtStorageSqlite::test_connection()
         throw std::runtime_error(str::format(_("%s write failed - is file blocked by a sync program?"), _file_path));
 }
 
-bool CtStorageSqlite::populate_treestore(const Glib::ustring& file_path, Glib::ustring& error)
+bool CtStorageSqlite::populate_treestore(const fs::path& file_path, Glib::ustring& error)
 {
     _close_db();
     try
@@ -214,7 +214,7 @@ bool CtStorageSqlite::populate_treestore(const Glib::ustring& file_path, Glib::u
     }
 }
 
-bool CtStorageSqlite::save_treestore(const Glib::ustring& file_path, const CtStorageSyncPending& syncPending, Glib::ustring& error)
+bool CtStorageSqlite::save_treestore(const fs::path& file_path, const CtStorageSyncPending& syncPending, Glib::ustring& error)
 {
     try
     {
@@ -291,7 +291,7 @@ void CtStorageSqlite::vacuum()
     _exec_no_callback("REINDEX");
 }
 
-void CtStorageSqlite::_open_db(const std::string &path)
+void CtStorageSqlite::_open_db(const fs::path& path)
 {
     if (_pDb) return;
     if (sqlite3_open(path.c_str(), &_pDb) != SQLITE_OK)
@@ -418,7 +418,7 @@ void CtStorageSqlite::_image_from_db(const gint64& nodeId, std::list<CtAnchoredW
         }
         else
         {
-            const Glib::ustring fileName = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 5));
+            fs::path fileName = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 5));
             const void* pBlob = sqlite3_column_blob(stmt, 4);
             const int blobSize = sqlite3_column_bytes(stmt, 4);
             const std::string rawBlob(reinterpret_cast<const char*>(pBlob), static_cast<size_t>(blobSize));
@@ -739,7 +739,7 @@ void CtStorageSqlite::_exec_bind_int64(const char* sqlCmd, const gint64 bind_int
         throw std::runtime_error(ERR_SQLITE_STEP + sqlite3_errmsg(_pDb));
 }
 
-void CtStorageSqlite::import_nodes(const std::string& path)
+void CtStorageSqlite::import_nodes(const fs::path& path)
 {
     _open_db(path); // storage is temp so can just open db
     // _fix_db_tables(); how to do it withough saving changes

--- a/future/src/ct/ct_storage_sqlite.h
+++ b/future/src/ct/ct_storage_sqlite.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "ct_types.h"
+#include "ct_filesystem.h"
 #include <sqlite3.h>
 #include <glibmm/refptr.h>
 #include <gtksourceviewmm/buffer.h>
@@ -42,16 +43,16 @@ public:
     void reopen_connect() override;
     void test_connection() override;
 
-    bool populate_treestore(const Glib::ustring& file_path, Glib::ustring& error) override;
-    bool save_treestore(const Glib::ustring& file_path, const CtStorageSyncPending& syncPending, Glib::ustring& error) override;
+    bool populate_treestore(const fs::path& file_path, Glib::ustring& error) override;
+    bool save_treestore(const fs::path& file_path, const CtStorageSyncPending& syncPending, Glib::ustring& error) override;
     void vacuum() override;
-    void import_nodes(const std::string& path) override;
+    void import_nodes(const fs::path& path) override;
 
     Glib::RefPtr<Gsv::Buffer> get_delayed_text_buffer(const gint64& node_id,
                                                       const std::string& syntax,
                                                       std::list<CtAnchoredWidget*>& widgets) const override;
 private:
-    void _open_db(const std::string &path);
+    void _open_db(const fs::path& path);
     void _close_db();
 
 
@@ -116,5 +117,5 @@ public:
 private:
     CtMainWin*    _pCtMainWin;
     sqlite3*      _pDb{nullptr};
-    Glib::ustring _file_path;
+    fs::path      _file_path;
 };

--- a/future/src/ct/ct_storage_xml.cc
+++ b/future/src/ct/ct_storage_xml.cc
@@ -50,10 +50,10 @@ void CtStorageXml::test_connection()
 
 }
 
-std::unique_ptr<xmlpp::DomParser> get_parser(const Glib::ustring& file_path) {
+std::unique_ptr<xmlpp::DomParser> get_parser(const fs::path& file_path) {
     // open file
     auto parser = std::make_unique<xmlpp::DomParser>();
-    parser->parse_file(file_path);
+    parser->parse_file(file_path.string());
     if (!parser->get_document())
         throw std::runtime_error("document is null");
     if (parser->get_document()->get_root_node()->get_name() != CtConst::APP_NAME)
@@ -62,7 +62,7 @@ std::unique_ptr<xmlpp::DomParser> get_parser(const Glib::ustring& file_path) {
 }
 
 
-bool CtStorageXml::populate_treestore(const Glib::ustring& file_path, Glib::ustring& error)
+bool CtStorageXml::populate_treestore(const fs::path& file_path, Glib::ustring& error)
 {
     try
     {
@@ -97,7 +97,7 @@ bool CtStorageXml::populate_treestore(const Glib::ustring& file_path, Glib::ustr
     }
  }
 
-bool CtStorageXml::save_treestore(const Glib::ustring& file_path, const CtStorageSyncPending&, Glib::ustring& error)
+bool CtStorageXml::save_treestore(const fs::path& file_path, const CtStorageSyncPending&, Glib::ustring& error)
 {
     try
     {
@@ -119,7 +119,7 @@ bool CtStorageXml::save_treestore(const Glib::ustring& file_path, const CtStorag
         }
 
         // write file
-        xml_doc.write_to_file(file_path);
+        xml_doc.write_to_file(file_path.string());
 
         return true;
     }
@@ -135,7 +135,7 @@ void CtStorageXml::vacuum()
 
 }
 
-void CtStorageXml::import_nodes(const std::string& path)
+void CtStorageXml::import_nodes(const fs::path& path)
 {
     auto parser = get_parser(path);
 
@@ -381,7 +381,7 @@ CtAnchoredWidget* CtStorageXmlHelper::_create_image_from_xml(xmlpp::Element* xml
     if (!anchorName.empty())
         return new CtImageAnchor(_pCtMainWin, anchorName, charOffset, justification);
 
-    const Glib::ustring file_name = xml_element->get_attribute_value("filename");
+    fs::path file_name = static_cast<std::string>(xml_element->get_attribute_value("filename"));
     xmlpp::TextNode* pTextNode = xml_element->get_child_text();
     const std::string encodedBlob = pTextNode ? pTextNode->get_content() : "";
     const std::string rawBlob = Glib::Base64::decode(encodedBlob);

--- a/future/src/ct/ct_storage_xml.h
+++ b/future/src/ct/ct_storage_xml.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "ct_types.h"
+#include "ct_filesystem.h"
 #include <glibmm/refptr.h>
 #include <gtksourceviewmm/buffer.h>
 #include <gtkmm/treeiter.h>
@@ -47,10 +48,10 @@ public:
     void reopen_connect() override;
     void test_connection() override;
 
-    bool populate_treestore(const Glib::ustring& file_path, Glib::ustring& error) override;
-    bool save_treestore(const Glib::ustring& file_path, const CtStorageSyncPending& syncPending, Glib::ustring& error) override;
+    bool populate_treestore(const fs::path& file_path, Glib::ustring& error) override;
+    bool save_treestore(const fs::path& file_path, const CtStorageSyncPending& syncPending, Glib::ustring& error) override;
     void vacuum() override;
-    void import_nodes(const std::string& path) override;
+    void import_nodes(const fs::path& path) override;
 
     Glib::RefPtr<Gsv::Buffer> get_delayed_text_buffer(const gint64& node_id,
                                                       const std::string& syntax,

--- a/future/src/ct/ct_types.h
+++ b/future/src/ct/ct_types.h
@@ -30,6 +30,11 @@
 #include <glibmm/ustring.h>
 #include <gtksourceviewmm/buffer.h>
 
+
+namespace CtFileSystem {
+class path;
+}
+
 enum class CtYesNoCancel { Yes, No, Cancel };
 
 enum class CtDocType { None, XML, SQLite };
@@ -104,9 +109,9 @@ private:
     }
 };
 
-struct CtRecentDocsFilepaths : public CtMaxSizedList<std::string>
+struct CtRecentDocsFilepaths : public CtMaxSizedList<CtFileSystem::path>
 {
-    CtRecentDocsFilepaths() : CtMaxSizedList<std::string>{10} {}
+    CtRecentDocsFilepaths() : CtMaxSizedList<CtFileSystem::path>{10} {}
 };
 
 
@@ -137,10 +142,10 @@ public:
     virtual void reopen_connect() = 0;
     virtual void test_connection() = 0;
 
-    virtual bool populate_treestore(const Glib::ustring& file_path, Glib::ustring& error) = 0;
-    virtual bool save_treestore(const Glib::ustring& file_path, const CtStorageSyncPending& syncPending, Glib::ustring& error) = 0;
+    virtual bool populate_treestore(const CtFileSystem::path& file_path, Glib::ustring& error) = 0;
+    virtual bool save_treestore(const CtFileSystem::path& file_path, const CtStorageSyncPending& syncPending, Glib::ustring& error) = 0;
     virtual void vacuum() = 0;
-    virtual void import_nodes(const std::string& path) = 0;
+    virtual void import_nodes(const CtFileSystem::path& path) = 0;
 
     virtual Glib::RefPtr<Gsv::Buffer> get_delayed_text_buffer(const gint64& node_id,
                                                               const std::string& syntax,

--- a/future/src/ct/ct_types.h
+++ b/future/src/ct/ct_types.h
@@ -31,7 +31,7 @@
 #include <gtksourceviewmm/buffer.h>
 
 
-namespace CtFileSystem {
+namespace fs {
 class path;
 }
 
@@ -109,9 +109,9 @@ private:
     }
 };
 
-struct CtRecentDocsFilepaths : public CtMaxSizedList<CtFileSystem::path>
+struct CtRecentDocsFilepaths : public CtMaxSizedList<fs::path>
 {
-    CtRecentDocsFilepaths() : CtMaxSizedList<CtFileSystem::path>{10} {}
+    CtRecentDocsFilepaths() : CtMaxSizedList<fs::path>{10} {}
 };
 
 
@@ -142,10 +142,10 @@ public:
     virtual void reopen_connect() = 0;
     virtual void test_connection() = 0;
 
-    virtual bool populate_treestore(const CtFileSystem::path& file_path, Glib::ustring& error) = 0;
-    virtual bool save_treestore(const CtFileSystem::path& file_path, const CtStorageSyncPending& syncPending, Glib::ustring& error) = 0;
+    virtual bool populate_treestore(const fs::path& file_path, Glib::ustring& error) = 0;
+    virtual bool save_treestore(const fs::path& file_path, const CtStorageSyncPending& syncPending, Glib::ustring& error) = 0;
     virtual void vacuum() = 0;
-    virtual void import_nodes(const CtFileSystem::path& path) = 0;
+    virtual void import_nodes(const fs::path& path) = 0;
 
     virtual Glib::RefPtr<Gsv::Buffer> get_delayed_text_buffer(const gint64& node_id,
                                                               const std::string& syntax,

--- a/future/src/ct/ct_widgets.cc
+++ b/future/src/ct/ct_widgets.cc
@@ -77,12 +77,12 @@ fs::path CtTmp::getHiddenFilePath(const fs::path& visiblePath)
         if (basename.extension() == ".ctx")
         {
             basename = basename.stem();
-            basename += ".ctd";
+            basename += ".ctb";
         }
         else if (basename.extension() == ".ctz")
         {
             basename = basename.stem();
-            basename += ".ctb";
+            basename += ".ctd";
         }
         _mapHiddenFiles[visiblePath.string()] = g_build_filename(tempDir.c_str(), basename.c_str(), nullptr);
     }

--- a/future/src/ct/ct_widgets.cc
+++ b/future/src/ct/ct_widgets.cc
@@ -59,32 +59,34 @@ CtTmp::~CtTmp()
     }
 }
 
-const gchar* CtTmp::getHiddenDirPath(const std::string& visiblePath)
+fs::path CtTmp::getHiddenDirPath(const fs::path& visiblePath)
 {
-    if (not _mapHiddenDirs.count(visiblePath))
+    if (not _mapHiddenDirs.count(visiblePath.string()))
     {
-        _mapHiddenDirs[visiblePath] = g_dir_make_tmp(nullptr, nullptr);
+        _mapHiddenDirs[visiblePath.string()] = g_dir_make_tmp(nullptr, nullptr);
     }
-    return _mapHiddenDirs.at(visiblePath);
+    return _mapHiddenDirs.at(visiblePath.string());
 }
 
-const gchar* CtTmp::getHiddenFilePath(const std::string& visiblePath)
+fs::path CtTmp::getHiddenFilePath(const fs::path& visiblePath)
 {
-    if (not _mapHiddenFiles.count(visiblePath))
+    if (not _mapHiddenFiles.count(visiblePath.string()))
     {
-        const gchar* tempDir{getHiddenDirPath(visiblePath)};
-        std::string basename{Glib::path_get_basename(visiblePath)};
-        if (Glib::str_has_suffix(basename, ".ctx"))
+        fs::path tempDir = getHiddenDirPath(visiblePath);
+        fs::path basename = visiblePath.filename();
+        if (basename.extension() == ".ctx")
         {
-            basename.replace(basename.end()-1, basename.end(), "b");
+            basename = basename.stem();
+            basename += ".ctd";
         }
-        else if (Glib::str_has_suffix(basename, ".ctz"))
+        else if (basename.extension() == ".ctz")
         {
-            basename.replace(basename.end()-1, basename.end(), "d");
+            basename = basename.stem();
+            basename += ".ctb";
         }
-        _mapHiddenFiles[visiblePath] = g_build_filename(tempDir, basename.c_str(), NULL);
+        _mapHiddenFiles[visiblePath.string()] = g_build_filename(tempDir.c_str(), basename.c_str(), nullptr);
     }
-    return _mapHiddenFiles.at(visiblePath);
+    return _mapHiddenFiles.at(visiblePath.string());
 }
 
 

--- a/future/src/ct/ct_widgets.h
+++ b/future/src/ct/ct_widgets.h
@@ -31,6 +31,7 @@
 #include <gspell/gspell.h>
 #include <map>
 #include "ct_types.h"
+#include "ct_filesystem.h"
 
 
 class CtMDParser;
@@ -40,8 +41,8 @@ class CtTmp
 public:
     CtTmp();
     virtual ~CtTmp();
-    const gchar* getHiddenDirPath(const std::string& visiblePath);
-    const gchar* getHiddenFilePath(const std::string& visiblePath);
+    fs::path getHiddenDirPath(const CtFileSystem::path& visiblePath);
+    fs::path getHiddenFilePath(const fs::path& visiblePath);
 
 protected:
     std::unordered_map<std::string,gchar*> _mapHiddenDirs;

--- a/future/src/ct/ct_widgets.h
+++ b/future/src/ct/ct_widgets.h
@@ -41,7 +41,7 @@ class CtTmp
 public:
     CtTmp();
     virtual ~CtTmp();
-    fs::path getHiddenDirPath(const CtFileSystem::path& visiblePath);
+    fs::path getHiddenDirPath(const fs::path& visiblePath);
     fs::path getHiddenFilePath(const fs::path& visiblePath);
 
 protected:

--- a/future/tests/CMakeLists.txt
+++ b/future/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CT_TEST_FILES
     tests_tmp_n_p7zip.cpp
     tests_types.cpp
     tests_clipboard.cpp
+    tests_filesystem.cpp
 )
 
 # some tests doesn't work in TRAVIS, so turn off them

--- a/future/tests/tests_filesystem.cpp
+++ b/future/tests/tests_filesystem.cpp
@@ -116,7 +116,7 @@ TEST(FileSystemGroup, path_concat)
     STRCMP_EQUAL("/home/foo/bar.txt", p1.c_str());
 }
 
-TEST(FileSystemGroup, path_string)
+TEST(FileSystemGroup, path_native)
 {
 #ifndef _WIN32
     std::string first = "/foo";
@@ -127,10 +127,10 @@ TEST(FileSystemGroup, path_string)
 #endif
     CtFileSystem::path path("/foo");
 
-    STRCMP_EQUAL(path.c_str(), first.c_str());
+    STRCMP_EQUAL(path.native().c_str(), first.c_str());
 
     path /= "bar.txt";
-    STRCMP_EQUAL(path.c_str(), second.c_str());
+    STRCMP_EQUAL(path.native().c_str(), second.c_str());
 }
 
 TEST(FileSystemGroup, remove) {

--- a/future/tests/tests_filesystem.cpp
+++ b/future/tests/tests_filesystem.cpp
@@ -95,6 +95,9 @@ TEST(FileSystemGroup, get_doc_type)
     CHECK(CtDocType::SQLite == fs::get_doc_type(unitTestsDataDir + "/test.ctb"));
     CHECK(CtDocType::XML == fs::get_doc_type(unitTestsDataDir + "/test.ctd"));
     CHECK(CtDocType::None == fs::get_doc_type(unitTestsDataDir + "/md_testfile.md"));
+    CHECK(CtDocType::SQLite == fs::get_doc_type(unitTestsDataDir + "/mimetype_ctb.ctb"));
+    CHECK(CtDocType::XML == fs::get_doc_type(unitTestsDataDir + "/7zr.ctz"));
+    CHECK(CtDocType::SQLite == fs::get_doc_type("test.ctx")); // Doesnt actually exist
 }
 
 TEST(FileSystemGroup, get_doc_encrypt)

--- a/future/tests/tests_filesystem.cpp
+++ b/future/tests/tests_filesystem.cpp
@@ -102,9 +102,10 @@ TEST(FileSystemGroup, path_is_absolute)
 
 TEST(FileSystemGroup, path_parent_path)
 {
-    STRCMP_EQUAL("/home", CtFileSystem::path("/home/foo").parent_path().c_str());
-    STRCMP_EQUAL("/home/foo", CtFileSystem::path("/home/foo/bar.txt").parent_path().c_str());
-    STRCMP_EQUAL("home/foo", CtFileSystem::path("home/foo/bar.txt").parent_path().c_str());
+
+    STRCMP_EQUAL(CtFileSystem::path("/home").c_str(), CtFileSystem::path("/home/foo").parent_path().c_str());
+    STRCMP_EQUAL(CtFileSystem::path("/home/foo").c_str(), CtFileSystem::path("/home/foo/bar.txt").parent_path().c_str());
+    STRCMP_EQUAL(CtFileSystem::path("home/foo").c_str(), CtFileSystem::path("home/foo/bar.txt").parent_path().c_str());
 }
 
 TEST(FileSystemGroup, path_concat)
@@ -124,9 +125,9 @@ TEST(FileSystemGroup, path_string)
     std::string first = "\\foo";
     std::string second = "\\foo\\bar.txt";
 #endif
-    CtFileSystem::path path(first.c_str());
+    CtFileSystem::path path("/foo");
 
-    STRCMP_EQUAL(path.c_str(), "/foo");
+    STRCMP_EQUAL(path.c_str(), first.c_str());
 
     path /= "bar.txt";
     STRCMP_EQUAL(path.c_str(), second.c_str());

--- a/future/tests/tests_filesystem.cpp
+++ b/future/tests/tests_filesystem.cpp
@@ -35,83 +35,95 @@ TEST_GROUP(FileSystemGroup)
 TEST(FileSystemGroup, path_stem)
 {
 #ifndef _WIN32
-    STRCMP_EQUAL("", CtFileSystem::path("").stem().c_str());
-    STRCMP_EQUAL("file", CtFileSystem::path("/root/file").stem().c_str());
-    STRCMP_EQUAL("file", CtFileSystem::path("/root/file.txt").stem().c_str());
-    STRCMP_EQUAL("file.2", CtFileSystem::path("/root/file.2.txt").stem().c_str());
-    STRCMP_EQUAL(".txt", CtFileSystem::path("/root/.txt").stem().c_str());
+    STRCMP_EQUAL("", fs::path("").stem().c_str());
+    STRCMP_EQUAL("file", fs::path("/root/file").stem().c_str());
+    STRCMP_EQUAL("file", fs::path("/root/file.txt").stem().c_str());
+    STRCMP_EQUAL("file.2", fs::path("/root/file.2.txt").stem().c_str());
+    STRCMP_EQUAL(".txt", fs::path("/root/.txt").stem().c_str());
 #endif
 }
 
 TEST(FileSystemGroup, path_extension)
 {
-    STRCMP_EQUAL("", CtFileSystem::path("").extension().c_str());
-    STRCMP_EQUAL(".", CtFileSystem::path(".").extension().c_str());
-    STRCMP_EQUAL(".txt", CtFileSystem::path("file.txt").extension().c_str());
-    STRCMP_EQUAL("", CtFileSystem::path("file").extension().c_str());
-    STRCMP_EQUAL(".txt", CtFileSystem::path("root/file.txt").extension().c_str());
-    STRCMP_EQUAL(".txt", CtFileSystem::path("/root/file.txt").extension().c_str());
+    STRCMP_EQUAL("", fs::path("").extension().c_str());
+    STRCMP_EQUAL("", fs::path(".").extension().c_str());
+    STRCMP_EQUAL(".txt", fs::path("file.txt").extension().c_str());
+    STRCMP_EQUAL("", fs::path("file").extension().c_str());
+    STRCMP_EQUAL(".txt", fs::path("root/file.txt").extension().c_str());
+    STRCMP_EQUAL(".txt", fs::path("/root/file.txt").extension().c_str());
+    STRCMP_EQUAL(".txt", fs::path(".local/file.txt").extension().c_str());
+    STRCMP_EQUAL(".my_bar", fs::path(".local/file.txt/.....my_bar").extension().c_str());
+    STRCMP_EQUAL(".txt", fs::path("/home/foo/.local/file.txt/.....my_bar/txt.txt").extension().c_str());
+    STRCMP_EQUAL("", fs::path("/home/foo/.local/file.txt/.....my_bar/txt.").extension().c_str());
+    STRCMP_EQUAL(".txt", fs::path("foo..txt").extension().c_str());
+    STRCMP_EQUAL("", fs::path("/home/foo/.local").extension().c_str());
+    STRCMP_EQUAL("", fs::path("/home/foo/.config").extension().c_str());
 }
 
 TEST(FileSystemGroup, get_cherrytree_datadir)
 {
     // we expect the unit test to be run from the built sources
-    STRCMP_EQUAL(_CMAKE_SOURCE_DIR, CtFileSystem::get_cherrytree_datadir().c_str());
+    STRCMP_EQUAL(_CMAKE_SOURCE_DIR, fs::get_cherrytree_datadir().c_str());
 }
 
 TEST(FileSystemGroup, get_cherrytree_localedir)
 {
     // we expect the unit test to be run from the built sources
-    STRCMP_EQUAL(CtFileSystem::canonical(Glib::build_filename(_CMAKE_SOURCE_DIR, "po")).c_str(), CtFileSystem::get_cherrytree_localedir().c_str());
+    STRCMP_EQUAL(fs::canonical(Glib::build_filename(_CMAKE_SOURCE_DIR, "po")).c_str(), fs::get_cherrytree_localedir().c_str());
 }
 
 TEST(FileSystemGroup, is_regular_file)
 {
-    CHECK_EQUAL(true, CtFileSystem::is_regular_file(unitTestsDataDir + "/test.ctd"));
-    CHECK_EQUAL(true, CtFileSystem::is_regular_file(unitTestsDataDir + "/test.ctb"));
-    CHECK_EQUAL(true, CtFileSystem::is_regular_file(unitTestsDataDir + "/md_testfile.md"));
+    CHECK_EQUAL(true, fs::is_regular_file(unitTestsDataDir + "/test.ctd"));
+    CHECK_EQUAL(true, fs::is_regular_file(unitTestsDataDir + "/test.ctb"));
+    CHECK_EQUAL(true, fs::is_regular_file(unitTestsDataDir + "/md_testfile.md"));
+    CHECK_EQUAL(false, fs::is_regular_file(unitTestsDataDir));
+    CHECK_EQUAL(false, fs::is_regular_file(fs::absolute(unitTestsDataDir)));
+    CHECK_EQUAL(false, fs::is_regular_file(fs::absolute(unitTestsDataDir).parent_path()));
 }
 
 TEST(FileSystemGroup, is_directory)
 {
-    CHECK_EQUAL(true, CtFileSystem::is_directory(unitTestsDataDir));
-    CHECK_EQUAL(true, CtFileSystem::is_directory(CtFileSystem::path(unitTestsDataDir).parent_path()));
+    CHECK_EQUAL(true, fs::is_directory(unitTestsDataDir));
+    CHECK_EQUAL(false, fs::is_directory(unitTestsDataDir + "/test.ctd"));
+    CHECK_EQUAL(true, fs::is_directory(fs::path(unitTestsDataDir).parent_path()));
+    CHECK_EQUAL(false, fs::is_directory(fs::path(unitTestsDataDir).parent_path() / "test_consts.h"));
 }
 
 TEST(FileSystemGroup, get_doc_type)
 {
-    CHECK(CtDocType::SQLite == CtFileSystem::get_doc_type(unitTestsDataDir + "/test.ctb"));
-    CHECK(CtDocType::XML == CtFileSystem::get_doc_type(unitTestsDataDir + "/test.ctd"));
-    CHECK(CtDocType::None == CtFileSystem::get_doc_type(unitTestsDataDir + "/md_testfile.md"));
+    CHECK(CtDocType::SQLite == fs::get_doc_type(unitTestsDataDir + "/test.ctb"));
+    CHECK(CtDocType::XML == fs::get_doc_type(unitTestsDataDir + "/test.ctd"));
+    CHECK(CtDocType::None == fs::get_doc_type(unitTestsDataDir + "/md_testfile.md"));
 }
 
 TEST(FileSystemGroup, get_doc_encrypt)
 {
-    CHECK(CtFileSystem::get_doc_encrypt(unitTestsDataDir + "/test.ctb") == CtDocEncrypt::False);
-    CHECK(CtFileSystem::get_doc_encrypt(unitTestsDataDir + "/test.ctz") == CtDocEncrypt::True);
-    CHECK(CtFileSystem::get_doc_encrypt(unitTestsDataDir + "/mimetype_txt.txt") == CtDocEncrypt::None);
+    CHECK(fs::get_doc_encrypt(unitTestsDataDir + "/test.ctb") == CtDocEncrypt::False);
+    CHECK(fs::get_doc_encrypt(unitTestsDataDir + "/test.ctz") == CtDocEncrypt::True);
+    CHECK(fs::get_doc_encrypt(unitTestsDataDir + "/mimetype_txt.txt") == CtDocEncrypt::None);
 }
 
 TEST(FileSystemGroup, path_is_absolute)
 {
-    CHECK_EQUAL(true, CtFileSystem::path("/home/foo").is_absolute());
-    CHECK_EQUAL(false, CtFileSystem::path("/home/foo").is_relative());
-    CHECK_EQUAL(true, CtFileSystem::path("home/foo").is_relative());
-    CHECK_EQUAL(false, CtFileSystem::path("home/foo").is_absolute());
+    CHECK_EQUAL(true, fs::path("/home/foo").is_absolute());
+    CHECK_EQUAL(false, fs::path("/home/foo").is_relative());
+    CHECK_EQUAL(true, fs::path("home/foo").is_relative());
+    CHECK_EQUAL(false, fs::path("home/foo").is_absolute());
 }
 
 TEST(FileSystemGroup, path_parent_path)
 {
 
-    STRCMP_EQUAL(CtFileSystem::path("/home").c_str(), CtFileSystem::path("/home/foo").parent_path().c_str());
-    STRCMP_EQUAL(CtFileSystem::path("/home/foo").c_str(), CtFileSystem::path("/home/foo/bar.txt").parent_path().c_str());
-    STRCMP_EQUAL(CtFileSystem::path("home/foo").c_str(), CtFileSystem::path("home/foo/bar.txt").parent_path().c_str());
+    STRCMP_EQUAL(fs::path("/home").c_str(), fs::path("/home/foo").parent_path().c_str());
+    STRCMP_EQUAL(fs::path("/home/foo").c_str(), fs::path("/home/foo/bar.txt").parent_path().c_str());
+    STRCMP_EQUAL(fs::path("home/foo").c_str(), fs::path("home/foo/bar.txt").parent_path().c_str());
 }
 
 TEST(FileSystemGroup, path_concat)
 {
-    CtFileSystem::path p1("/home/foo/bar");
-    CtFileSystem::path p2(".txt");
+    fs::path p1("/home/foo/bar");
+    fs::path p2(".txt");
     p1 += p2;
     STRCMP_EQUAL("/home/foo/bar.txt", p1.c_str());
 }
@@ -125,7 +137,7 @@ TEST(FileSystemGroup, path_native)
     std::string first = "\\foo";
     std::string second = "\\foo\\bar.txt";
 #endif
-    CtFileSystem::path path("/foo");
+    fs::path path("/foo");
 
     STRCMP_EQUAL(path.native().c_str(), first.c_str());
 
@@ -134,13 +146,13 @@ TEST(FileSystemGroup, path_native)
 }
 
 TEST(FileSystemGroup, remove) {
-    CtFileSystem::path test_dir(unitTestsDataDir + "/test_dir");
+    fs::path test_dir(unitTestsDataDir + "/test_dir");
     CHECK_EQUAL(0, g_mkdir_with_parents(test_dir.c_str(), 0777));
-    CHECK(CtFileSystem::exists(test_dir));
-    CtFileSystem::remove(test_dir);
-    CHECK(!CtFileSystem::exists(test_dir));
+    CHECK(fs::exists(test_dir));
+    fs::remove(test_dir);
+    CHECK(!fs::exists(test_dir));
 
     CHECK_EQUAL( 0, g_mkdir_with_parents(test_dir.c_str(), 0777));
-    CHECK_EQUAL( 1, CtFileSystem::remove_all(test_dir));
-    CHECK(!CtFileSystem::exists(test_dir));
+    CHECK_EQUAL(1, fs::remove_all(test_dir));
+    CHECK(!fs::exists(test_dir));
 }

--- a/future/tests/tests_filesystem.cpp
+++ b/future/tests/tests_filesystem.cpp
@@ -135,17 +135,12 @@ TEST(FileSystemGroup, path_native)
 {
 #ifndef _WIN32
     std::string first = "/foo";
-    std::string second = "/foo/bar.txt";
 #else
     std::string first = "\\foo";
-    std::string second = "\\foo\\bar.txt";
 #endif
     fs::path path("/foo");
 
     STRCMP_EQUAL(path.native().c_str(), first.c_str());
-
-    path /= "bar.txt";
-    STRCMP_EQUAL(path.native().c_str(), second.c_str());
 }
 
 TEST(FileSystemGroup, remove) {

--- a/future/tests/tests_filesystem.cpp
+++ b/future/tests/tests_filesystem.cpp
@@ -1,0 +1,145 @@
+/*
+ * tests_filesystem.cpp
+ *
+ * Copyright 2009-2020
+ * Giuseppe Penone <giuspen@gmail.com>
+ * Evgenii Gurianov <https://github.com/txe>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "ct_filesystem.h"
+#include "CppUTest/CommandLineTestRunner.h"
+#include "test_consts.h"
+
+
+
+TEST_GROUP(FileSystemGroup)
+{
+};
+
+
+TEST(FileSystemGroup, path_stem)
+{
+#ifndef _WIN32
+    STRCMP_EQUAL("", CtFileSystem::path("").stem().c_str());
+    STRCMP_EQUAL("file", CtFileSystem::path("/root/file").stem().c_str());
+    STRCMP_EQUAL("file", CtFileSystem::path("/root/file.txt").stem().c_str());
+    STRCMP_EQUAL("file.2", CtFileSystem::path("/root/file.2.txt").stem().c_str());
+    STRCMP_EQUAL(".txt", CtFileSystem::path("/root/.txt").stem().c_str());
+#endif
+}
+
+TEST(FileSystemGroup, path_extension)
+{
+    STRCMP_EQUAL("", CtFileSystem::path("").extension().c_str());
+    STRCMP_EQUAL(".", CtFileSystem::path(".").extension().c_str());
+    STRCMP_EQUAL(".txt", CtFileSystem::path("file.txt").extension().c_str());
+    STRCMP_EQUAL("", CtFileSystem::path("file").extension().c_str());
+    STRCMP_EQUAL(".txt", CtFileSystem::path("root/file.txt").extension().c_str());
+    STRCMP_EQUAL(".txt", CtFileSystem::path("/root/file.txt").extension().c_str());
+}
+
+TEST(FileSystemGroup, get_cherrytree_datadir)
+{
+    // we expect the unit test to be run from the built sources
+    STRCMP_EQUAL(_CMAKE_SOURCE_DIR, CtFileSystem::get_cherrytree_datadir().c_str());
+}
+
+TEST(FileSystemGroup, get_cherrytree_localedir)
+{
+    // we expect the unit test to be run from the built sources
+    STRCMP_EQUAL(CtFileSystem::canonical(Glib::build_filename(_CMAKE_SOURCE_DIR, "po")).c_str(), CtFileSystem::get_cherrytree_localedir().c_str());
+}
+
+TEST(FileSystemGroup, is_regular_file)
+{
+    CHECK_EQUAL(true, CtFileSystem::is_regular_file(unitTestsDataDir + "/test.ctd"));
+    CHECK_EQUAL(true, CtFileSystem::is_regular_file(unitTestsDataDir + "/test.ctb"));
+    CHECK_EQUAL(true, CtFileSystem::is_regular_file(unitTestsDataDir + "/md_testfile.md"));
+}
+
+TEST(FileSystemGroup, is_directory)
+{
+    CHECK_EQUAL(true, CtFileSystem::is_directory(unitTestsDataDir));
+    CHECK_EQUAL(true, CtFileSystem::is_directory(CtFileSystem::path(unitTestsDataDir).parent_path()));
+}
+
+TEST(FileSystemGroup, get_doc_type)
+{
+    CHECK(CtDocType::SQLite == CtFileSystem::get_doc_type(unitTestsDataDir + "/test.ctb"));
+    CHECK(CtDocType::XML == CtFileSystem::get_doc_type(unitTestsDataDir + "/test.ctd"));
+    CHECK(CtDocType::None == CtFileSystem::get_doc_type(unitTestsDataDir + "/md_testfile.md"));
+}
+
+TEST(FileSystemGroup, get_doc_encrypt)
+{
+    CHECK(CtFileSystem::get_doc_encrypt(unitTestsDataDir + "/test.ctb") == CtDocEncrypt::False);
+    CHECK(CtFileSystem::get_doc_encrypt(unitTestsDataDir + "/test.ctz") == CtDocEncrypt::True);
+    CHECK(CtFileSystem::get_doc_encrypt(unitTestsDataDir + "/mimetype_txt.txt") == CtDocEncrypt::None);
+}
+
+TEST(FileSystemGroup, path_is_absolute)
+{
+    CHECK_EQUAL(true, CtFileSystem::path("/home/foo").is_absolute());
+    CHECK_EQUAL(false, CtFileSystem::path("/home/foo").is_relative());
+    CHECK_EQUAL(true, CtFileSystem::path("home/foo").is_relative());
+    CHECK_EQUAL(false, CtFileSystem::path("home/foo").is_absolute());
+}
+
+TEST(FileSystemGroup, path_parent_path)
+{
+    STRCMP_EQUAL("/home", CtFileSystem::path("/home/foo").parent_path().c_str());
+    STRCMP_EQUAL("/home/foo", CtFileSystem::path("/home/foo/bar.txt").parent_path().c_str());
+    STRCMP_EQUAL("home/foo", CtFileSystem::path("home/foo/bar.txt").parent_path().c_str());
+}
+
+TEST(FileSystemGroup, path_concat)
+{
+    CtFileSystem::path p1("/home/foo/bar");
+    CtFileSystem::path p2(".txt");
+    p1 += p2;
+    STRCMP_EQUAL("/home/foo/bar.txt", p1.c_str());
+}
+
+TEST(FileSystemGroup, path_string)
+{
+#ifndef _WIN32
+    std::string first = "/foo";
+    std::string second = "/foo/bar.txt";
+#else
+    std::string first = "\\foo";
+    std::string second = "\\foo\\bar.txt";
+#endif
+    CtFileSystem::path path(first.c_str());
+
+    STRCMP_EQUAL(path.c_str(), "/foo");
+
+    path /= "bar.txt";
+    STRCMP_EQUAL(path.c_str(), second.c_str());
+}
+
+TEST(FileSystemGroup, remove) {
+    CtFileSystem::path test_dir(unitTestsDataDir + "/test_dir");
+    CHECK_EQUAL(0, g_mkdir_with_parents(test_dir.c_str(), 0777));
+    CHECK(CtFileSystem::exists(test_dir));
+    CtFileSystem::remove(test_dir);
+    CHECK(!CtFileSystem::exists(test_dir));
+
+    CHECK_EQUAL( 0, g_mkdir_with_parents(test_dir.c_str(), 0777));
+    CHECK_EQUAL( 1, CtFileSystem::remove_all(test_dir));
+    CHECK(!CtFileSystem::exists(test_dir));
+}

--- a/future/tests/tests_misc_utils.cpp
+++ b/future/tests/tests_misc_utils.cpp
@@ -342,5 +342,7 @@ int main(int ac, char** av)
     // libp7za has memory leaks
     MemoryLeakWarningPlugin::turnOffNewDeleteOverloads();
 
+    Gio::init();
+
     return CommandLineTestRunner::RunAllTests(ac, av);
 }

--- a/future/tests/tests_misc_utils.cpp
+++ b/future/tests/tests_misc_utils.cpp
@@ -26,7 +26,7 @@
 #include "CppUTest/CommandLineTestRunner.h"
 #include "gtkmm/textbuffer.h"
 #include "test_consts.h"
-
+#include "ct_filesystem.h"
 
 
 TEST_GROUP(MiscUtilsGroup)
@@ -301,17 +301,7 @@ TEST(MiscUtilsGroup, vec_remove)
     CHECK(v_3.size() == 2);
 }
 
-TEST(MiscUtilsGroup, get_cherrytree_datadir)
-{
-    // we expect the unit test to be run from the built sources
-    STRCMP_EQUAL(_CMAKE_SOURCE_DIR, CtFileSystem::get_cherrytree_datadir().c_str());
-}
 
-TEST(MiscUtilsGroup, get_cherrytree_localedir)
-{
-    // we expect the unit test to be run from the built sources
-    STRCMP_EQUAL(Glib::canonicalize_filename(Glib::build_filename(_CMAKE_SOURCE_DIR, "po")).c_str(), CtFileSystem::get_cherrytree_localedir().c_str());
-}
 
 TEST(MiscUtilsGroup, get__uri_type)
 {
@@ -345,21 +335,6 @@ TEST(MiscUtilsGroup, mime__type_contains)
 
 
 
-TEST_GROUP(FileSystemGroup)
-{
-};
-
-
-TEST(FileSystemGroup, get_file_stem)
-{
-#ifndef _WIN32
-    STRCMP_EQUAL("", CtFileSystem::get_file_stem("").c_str());
-    STRCMP_EQUAL("file", CtFileSystem::get_file_stem("/root/file").c_str());
-    STRCMP_EQUAL("file", CtFileSystem::get_file_stem("/root/file.txt").c_str());
-    STRCMP_EQUAL("file.2", CtFileSystem::get_file_stem("/root/file.2.txt").c_str());
-    STRCMP_EQUAL(".txt", CtFileSystem::get_file_stem("/root/.txt").c_str());
-#endif
-}
 
 
 int main(int ac, char** av)

--- a/future/tests/tests_tmp_n_p7zip.cpp
+++ b/future/tests/tests_tmp_n_p7zip.cpp
@@ -24,6 +24,7 @@
 #include "ct_app.h"
 #include "ct_p7za_iface.h"
 #include "config.h"
+#include "ct_filesystem.h"
 #include "test_consts.h"
 
 #include <glib/gstdio.h>
@@ -40,10 +41,10 @@ TEST(TmpP7zipGroup, CTTmp_misc)
     CtTmp* pCTmp = new CtTmp();
 
     // temporary directories are created when their path is first queried
-    std::string tempDirCtz{pCTmp->getHiddenDirPath(ctzInputPath)};
-    std::string tempDirCtx{pCTmp->getHiddenDirPath(ctxInputPath)};
-    std::string tempFileCtz{pCTmp->getHiddenFilePath(ctzInputPath)};
-    std::string tempFileCtx{pCTmp->getHiddenFilePath(ctxInputPath)};
+    std::string tempDirCtz{pCTmp->getHiddenDirPath(ctzInputPath).string()};
+    std::string tempDirCtx{pCTmp->getHiddenDirPath(ctxInputPath).string()};
+    std::string tempFileCtz{pCTmp->getHiddenFilePath(ctzInputPath).string()};
+    std::string tempFileCtx{pCTmp->getHiddenFilePath(ctxInputPath).string()};
 
     CHECK(Glib::file_test(tempDirCtz, Glib::FILE_TEST_IS_DIR));
     CHECK(Glib::file_test(tempDirCtx, Glib::FILE_TEST_IS_DIR));
@@ -68,11 +69,11 @@ TEST(TmpP7zipGroup, P7zaIfaceMisc)
 {
     // extract our test archive
     CtTmp ctTmp;
-    CHECK_EQUAL(0, CtP7zaIface::p7za_extract(ctzInputPath.c_str(), ctTmp.getHiddenDirPath(ctzInputPath), testPassword));
-    CHECK(Glib::file_test(ctTmp.getHiddenFilePath(ctzInputPath), Glib::FILE_TEST_EXISTS));
+    CHECK_EQUAL(0, CtP7zaIface::p7za_extract(ctzInputPath.c_str(), ctTmp.getHiddenDirPath(ctzInputPath).c_str(), testPassword));
+    CHECK(Glib::file_test(ctTmp.getHiddenFilePath(ctzInputPath).string(), Glib::FILE_TEST_EXISTS));
 
     // read and parse xml of extracted archive
-    std::string xml_txt = Glib::file_get_contents(ctTmp.getHiddenFilePath(ctzInputPath));
+    std::string xml_txt = Glib::file_get_contents(ctTmp.getHiddenFilePath(ctzInputPath).string());
     xmlpp::DomParser dom_parser;
     dom_parser.parse_memory(xml_txt);
     xmlpp::Document* p_document = dom_parser.get_document();
@@ -82,19 +83,19 @@ TEST(TmpP7zipGroup, P7zaIfaceMisc)
     STRCMP_EQUAL("NodeContent", static_cast<xmlpp::Element*>(p_element->find("node/rich_text")[0])->get_child_text()->get_content().c_str());
 
     // try and archive again the extracted xml
-    const std::string ctzTmpPathBis{Glib::build_filename(ctTmp.getHiddenDirPath(ctzInputPath), "7zr2.ctz")};
-    CHECK_EQUAL(0, CtP7zaIface::p7za_archive(ctTmp.getHiddenFilePath(ctzInputPath), ctzTmpPathBis.c_str(), testPasswordBis));
+    const std::string ctzTmpPathBis{Glib::build_filename(ctTmp.getHiddenDirPath(ctzInputPath).string(), "7zr2.ctz")};
+    CHECK_EQUAL(0, CtP7zaIface::p7za_archive(ctTmp.getHiddenFilePath(ctzInputPath).c_str(), ctzTmpPathBis.c_str(), testPasswordBis));
 
     CHECK(Glib::file_test(ctzTmpPathBis, Glib::FILE_TEST_EXISTS));
 
     // remove originally extracted
-    CHECK_EQUAL(0, g_remove(ctTmp.getHiddenFilePath(ctzInputPath)));
-    CHECK_FALSE(Glib::file_test(ctTmp.getHiddenFilePath(ctzInputPath), Glib::FILE_TEST_EXISTS));
+    CHECK_EQUAL(0, g_remove(ctTmp.getHiddenFilePath(ctzInputPath).c_str()));
+    CHECK_FALSE(Glib::file_test(ctTmp.getHiddenFilePath(ctzInputPath).string(), Glib::FILE_TEST_EXISTS));
 
     // extract again from the archive that we created
-    CHECK_EQUAL(0, CtP7zaIface::p7za_extract(ctzTmpPathBis.c_str(), ctTmp.getHiddenDirPath(ctzInputPath), testPasswordBis));
-    CHECK(Glib::file_test(ctTmp.getHiddenFilePath(ctzInputPath), Glib::FILE_TEST_EXISTS));
-    std::string xml_txt_bis = Glib::file_get_contents(ctTmp.getHiddenFilePath(ctzInputPath));
+    CHECK_EQUAL(0, CtP7zaIface::p7za_extract(ctzTmpPathBis.c_str(), ctTmp.getHiddenDirPath(ctzInputPath).c_str(), testPasswordBis));
+    CHECK(Glib::file_test(ctTmp.getHiddenFilePath(ctzInputPath).string(), Glib::FILE_TEST_EXISTS));
+    std::string xml_txt_bis = Glib::file_get_contents(ctTmp.getHiddenFilePath(ctzInputPath).string());
     STRCMP_EQUAL(xml_txt.c_str(), xml_txt_bis.c_str());
 
     // remove alien/unexpected files in temp directory
@@ -111,13 +112,13 @@ TEST(TmpP7zipGroup, P7zaIfaceMisc)
 TEST(TmpP7zipGroup, P7zaExtravtWrongPasswd)
 {
     CtTmp ctTmp;
-    const std::string ctdTmpPath{Glib::build_filename(ctTmp.getHiddenDirPath(ctzInputPath), "7zr.ctd")};
+    const std::string ctdTmpPath{(ctTmp.getHiddenDirPath(ctzInputPath) /"7zr.ctd").string()};
 
     // wrong password
-    CHECK(0 != CtP7zaIface::p7za_extract(ctzInputPath.c_str(), ctTmp.getHiddenDirPath(ctzInputPath), "wrongpassword"));
+    CHECK(0 != CtP7zaIface::p7za_extract(ctzInputPath.c_str(), ctTmp.getHiddenDirPath(ctzInputPath).c_str(), "wrongpassword"));
     CHECK_FALSE(Glib::file_test(ctdTmpPath, Glib::FILE_TEST_EXISTS));
 
     // correct password
-    CHECK_EQUAL(0, CtP7zaIface::p7za_extract(ctzInputPath.c_str(), ctTmp.getHiddenDirPath(ctzInputPath), testPassword));
+    CHECK_EQUAL(0, CtP7zaIface::p7za_extract(ctzInputPath.c_str(), ctTmp.getHiddenDirPath(ctzInputPath).c_str(), testPassword));
     CHECK_TRUE(Glib::file_test(ctdTmpPath, Glib::FILE_TEST_EXISTS));
 }

--- a/future/tests/tests_tmp_n_p7zip.cpp
+++ b/future/tests/tests_tmp_n_p7zip.cpp
@@ -121,4 +121,5 @@ TEST(TmpP7zipGroup, P7zaExtravtWrongPasswd)
     // correct password
     CHECK_EQUAL(0, CtP7zaIface::p7za_extract(ctzInputPath.c_str(), ctTmp.getHiddenDirPath(ctzInputPath).c_str(), testPassword));
     CHECK_TRUE(Glib::file_test(ctdTmpPath, Glib::FILE_TEST_EXISTS));
+    g_remove(ctTmp.getHiddenFilePath(ctzInputPath).string().c_str());
 }

--- a/future/tests/tests_types.cpp
+++ b/future/tests/tests_types.cpp
@@ -21,7 +21,7 @@
 
 #include "ct_types.h"
 #include "CppUTest/CommandLineTestRunner.h"
-
+#include "ct_filesystem.h"
 
 TEST_GROUP(TestTypesGroup)
 {


### PR DESCRIPTION
This is a refractor of CtFileSystem and changing everything to use `CtFileSystem::path`, afaik there are no more `Glib::ustring`'s being used for paths (hazzah!). 

I have added unit tests in `tests_filesystem.cpp` and currently everything is passing on linux at least

(Also yes I misclicked when writing this, oops)