### PR TITLE
fixes gtk not sending paired released Ctrl for pressed Ctrl (broken zoom)

### DIFF
--- a/modules/cons.py
+++ b/modules/cons.py
@@ -218,6 +218,7 @@ STR_KEY_RIGHT = "Right"
 STR_KEY_DQUOTE = "quotedbl"
 STR_KEY_SQUOTE = "apostrophe"
 STR_KEYS_CONTROL = ["Control_L", "Control_R"]
+STR_KEYS_LAYOUT_GROUP = ["ISO_Prev_Group", "ISO_Next_Group"]
 STR_PYGTK_222_REQUIRED = "PyGTK 2.22 required"
 
 CHERRY_RED = 'cherry_red'

--- a/modules/core.py
+++ b/modules/core.py
@@ -2680,6 +2680,8 @@ iter_end, exclude_iter_sel_end=True)
                 keyname = gtk.gdk.keyval_name(event.keyval)
                 if keyname in cons.STR_KEYS_CONTROL:
                     self.ctrl_down = False
+                if keyname in cons.STR_KEYS_LAYOUT_GROUP:
+                    self.ctrl_down = False               
         elif event.type == gtk.gdk.SCROLL:
             if self.ctrl_down:
                 if event.direction == gtk.gdk.SCROLL_UP:

--- a/modules/support.py
+++ b/modules/support.py
@@ -335,6 +335,8 @@ def on_sourceview_event_after_key_release(dad, text_view, event):
     if dad.ctrl_down:
         if keyname in cons.STR_KEYS_CONTROL:
             dad.ctrl_down = False
+        if keyname in cons.STR_KEYS_LAYOUT_GROUP:
+            dad.ctrl_down = False     
     elif keyname in [cons.STR_KEY_RETURN, cons.STR_KEY_SPACE]:
         if dad.word_count:
             dad.update_selected_node_statusbar_info()


### PR DESCRIPTION
Resolves #889
Fixes situation when you press Control button, we get Control signal; when you release this Control button, we get ISO_Prev_Group instead of Control (LMDE 4, Debian 10)

It only affects pygtk, C++ version uses different approach.

