### PR TITLE
Add integrity check to SQLite storage

### DIFF
--- a/future/src/ct/ct_storage_sqlite.h
+++ b/future/src/ct/ct_storage_sqlite.h
@@ -55,7 +55,7 @@ public:
 private:
     void _open_db(const fs::path& path);
     void _close_db();
-
+    bool _check_database_integrity();
 
     Gtk::TreeIter       _node_from_db(gint64 node_id, Gtk::TreeIter parent_iter, gint64 new_id);
 


### PR DESCRIPTION
The SQLite storage manager will now check corruption on 
- `test_connection()`
- `populate_treestore()`
- `import_nodes()`

It prints a warning to the terminal with the issues reported by SQLite and displays a warning to the user. I think handling it all in `_check_database_integrity()` and not throwing is ok?