### PR TITLE
fixes encoding issues on win32

### DIFF
--- a/future/src/ct/ct_codebox.cc
+++ b/future/src/ct/ct_codebox.cc
@@ -204,7 +204,7 @@ bool CtCodebox::to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_a
     }
     else
     {
-        const std::string codebox_txt = Glib::locale_from_utf8(get_text_content());
+        const std::string codebox_txt = get_text_content();
         sqlite3_bind_int64(p_stmt, 1, node_id);
         sqlite3_bind_int64(p_stmt, 2, _charOffset+offset_adjustment);
         sqlite3_bind_text(p_stmt, 3, _justification.c_str(), _justification.size(), SQLITE_STATIC);

--- a/future/src/ct/ct_filesystem.h
+++ b/future/src/ct/ct_filesystem.h
@@ -25,7 +25,7 @@
 #include <vector>
 #include "ct_types.h"
 #include "ct_splittable.h"
-#include <spdlog/fmt/fmt.h>
+#include "ct_logging.h"
 #include <glibmm/miscutils.h>
 
 class CtConfig;

--- a/future/src/ct/ct_image.cc
+++ b/future/src/ct/ct_image.cc
@@ -146,7 +146,7 @@ bool CtImagePng::to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_
         std::string rawBlob;
         if (!storage_cache || !storage_cache->get_cached_image(this, rawBlob))
            rawBlob = get_raw_blob();
-        const std::string link = Glib::locale_from_utf8(_link);
+        const std::string link = _link;
 
         sqlite3_bind_int64(p_stmt, 1, node_id);
         sqlite3_bind_int64(p_stmt, 2, _charOffset+offset_adjustment);
@@ -235,7 +235,7 @@ bool CtImageAnchor::to_sqlite(sqlite3* pDb, const gint64 node_id, const int offs
     }
     else
     {
-        const std::string anchor_name = Glib::locale_from_utf8(_anchorName);
+        const std::string anchor_name = _anchorName;
         sqlite3_bind_int64(p_stmt, 1, node_id);
         sqlite3_bind_int64(p_stmt, 2, _charOffset+offset_adjustment);
         sqlite3_bind_text(p_stmt, 3, _justification.c_str(), _justification.size(), SQLITE_STATIC);
@@ -315,7 +315,7 @@ bool CtImageEmbFile::to_sqlite(sqlite3* pDb, const gint64 node_id, const int off
     }
     else
     {
-        const std::string file_name = Glib::locale_from_utf8(_fileName.string());
+        const std::string file_name = _fileName.string();
         sqlite3_bind_int64(p_stmt, 1, node_id);
         sqlite3_bind_int64(p_stmt, 2, _charOffset+offset_adjustment);
         sqlite3_bind_text(p_stmt, 3, _justification.c_str(), _justification.size(), SQLITE_STATIC);

--- a/future/src/ct/ct_logging.h
+++ b/future/src/ct/ct_logging.h
@@ -27,7 +27,18 @@
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/fmt.h>
-#include <spdlog/fmt/ostr.h>
+#include <glibmm/ustring.h>
+
+// ostream works badly on Win32 due to locale encoding
+template <>
+struct fmt::formatter<Glib::ustring>: formatter<string_view> {
+  // parse is inherited from formatter<string_view>.
+  template <typename FormatContext>
+  auto format(Glib::ustring c, FormatContext& ctx) {
+    return formatter<string_view>::format(c.c_str(), ctx);
+  }
+};
+
 
 
 

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -29,9 +29,10 @@
 #include <unordered_set>
 #include "ct_treestore.h"
 #include "ct_types.h"
-#include <spdlog/fmt/fmt.h>
-#include <spdlog/fmt/ostr.h> // to support Glib::ustring formatting
+#include "ct_logging.h"
 #include <type_traits>
+
+
 
 class CtConfig;
 

--- a/future/src/ct/ct_storage_sqlite.cc
+++ b/future/src/ct/ct_storage_sqlite.cc
@@ -661,11 +661,11 @@ void CtStorageSqlite::_write_node_to_db(CtTreeIter* ct_tree_iter,
             xmlpp::Document xml_doc;
             xml_doc.create_root_node("node");
             CtStorageXmlHelper::save_buffer_no_widgets_to_xml(xml_doc.get_root_node(), ct_tree_iter->get_node_text_buffer(), start_offset, end_offset, 'n');
-            node_txt = Glib::locale_from_utf8(xml_doc.write_to_string());
+            node_txt = xml_doc.write_to_string();
         }
         else
         {
-            node_txt = Glib::locale_from_utf8(ct_tree_iter->get_node_text_buffer()->get_text());
+            node_txt = ct_tree_iter->get_node_text_buffer()->get_text();
         }
 
         // full node rewrite
@@ -675,9 +675,9 @@ void CtStorageSqlite::_write_node_to_db(CtTreeIter* ct_tree_iter,
             if (stmt.is_bad())
                 throw std::runtime_error(ERR_SQLITE_PREPV2 + sqlite3_errmsg(_pDb));
 
-            const std::string node_name = Glib::locale_from_utf8(ct_tree_iter->get_node_name());
+            const std::string node_name = ct_tree_iter->get_node_name();
             const std::string node_syntax = ct_tree_iter->get_node_syntax_highlighting();
-            const std::string node_tags = Glib::locale_from_utf8(ct_tree_iter->get_node_tags());
+            const std::string node_tags = ct_tree_iter->get_node_tags();
             sqlite3_bind_int64(stmt, 1, node_id);
             sqlite3_bind_text(stmt, 2, node_name.c_str(), node_name.size(), SQLITE_STATIC);
             sqlite3_bind_text(stmt, 3, node_txt.c_str(), node_txt.size(), SQLITE_STATIC);
@@ -720,9 +720,9 @@ void CtStorageSqlite::_write_node_to_db(CtTreeIter* ct_tree_iter,
             if (stmt.is_bad())
                 throw std::runtime_error(ERR_SQLITE_PREPV2 + sqlite3_errmsg(_pDb));
 
-            const std::string node_name = Glib::locale_from_utf8(ct_tree_iter->get_node_name());
+            const std::string node_name = ct_tree_iter->get_node_name();
             const std::string node_syntax = ct_tree_iter->get_node_syntax_highlighting();
-            const std::string node_tags = Glib::locale_from_utf8(ct_tree_iter->get_node_tags());
+            const std::string node_tags = ct_tree_iter->get_node_tags();
             sqlite3_bind_text(stmt, 1, node_name.c_str(), node_name.size(), SQLITE_STATIC);
             sqlite3_bind_text(stmt, 2, node_syntax.c_str(), node_syntax.size(), SQLITE_STATIC);
             sqlite3_bind_text(stmt, 3, node_tags.c_str(), node_tags.size(), SQLITE_STATIC);

--- a/future/src/ct/ct_table.cc
+++ b/future/src/ct/ct_table.cc
@@ -161,7 +161,7 @@ bool CtTable::to_sqlite(sqlite3* pDb, const gint64 node_id, const int offset_adj
         xmlpp::Document xml_doc;
         xml_doc.create_root_node("table");
         _populate_xml_rows_cells(xml_doc.get_root_node());
-        const std::string table_txt = Glib::locale_from_utf8(xml_doc.write_to_string());
+        const std::string table_txt = xml_doc.write_to_string();
         sqlite3_bind_int64(p_stmt, 1, node_id);
         sqlite3_bind_int64(p_stmt, 2, _charOffset+offset_adjustment);
         sqlite3_bind_text(p_stmt, 3, _justification.c_str(), _justification.size(), SQLITE_STATIC);

--- a/future/tests/CMakeLists.txt
+++ b/future/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CT_TEST_FILES
     tests_types.cpp
     tests_clipboard.cpp
     tests_filesystem.cpp
+    tests_encoding.cpp
 )
 
 # some tests doesn't work in TRAVIS, so turn off them

--- a/future/tests/test_consts.h
+++ b/future/tests/test_consts.h
@@ -27,6 +27,7 @@
 
 #include <string>
 #include <glib/gstdio.h>
+#include <glibmm/miscutils.h>
 
 const std::string unitTestsDataDir{Glib::build_filename(_CMAKE_SOURCE_DIR, "tests", "data")};
 const std::string ctzInputPath{Glib::build_filename(unitTestsDataDir, "7zr.ctz")};

--- a/future/tests/tests_encoding.cpp
+++ b/future/tests/tests_encoding.cpp
@@ -1,0 +1,38 @@
+/*
+ * tests_encoding.cpp
+ *
+ * Copyright 2009-2020
+ * Giuseppe Penone <giuspen@gmail.com>
+ * Evgenii Gurianov <https://github.com/txe>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+#include "ct_logging.h"
+#include "test_consts.h"
+#include "CppUTest/CommandLineTestRunner.h"
+
+
+TEST_GROUP(EncodingGroup)
+{
+};
+
+TEST(EncodingGroup, ustring_format)
+{
+    // on win32 this could throw an exception due to locale
+    Glib::ustring str = "привет こんにちは";
+    STRCMP_EQUAL(str.c_str(), fmt::format("{}", str).c_str());
+}


### PR DESCRIPTION
- fixes `fmt::format` crash with Glib::ustring because `std::ostream` couldn't work with win32 locale
- adds test for `fmt::format` 
- fixes crash during saving in sqlite due to `Glib::locale_from_utf8`
