### PR TITLE
Fix issues with md formatting

### DIFF
--- a/future/src/ct/ct_parser_md.cc
+++ b/future/src/ct/ct_parser_md.cc
@@ -62,6 +62,10 @@ void CtMDParser::_init_tokens()
                     _add_weight_tag(CtConst::TAG_PROP_VAL_HEAVY, data);
                 }},
                 // Italic
+                {"_", true, true, [this](const std::string& data){
+                    _add_italic_tag(data);
+                }},
+                // Italic
                 {"*", true, true, [this](const std::string& data){
                     _add_italic_tag(data);
                 }},

--- a/future/src/ct/ct_parser_text.cc
+++ b/future/src/ct/ct_parser_text.cc
@@ -216,14 +216,16 @@ std::vector<std::pair<const CtParser::token_schema *, std::string>> CtTextParser
 }
 
 
+
 std::pair<Gtk::TextIter, Gtk::TextIter> CtTextParser::find_formatting_boundaries(Gtk::TextIter start_bounds, Gtk::TextIter word_end)
 {
     _build_token_maps();
     
     Glib::ustring token_str(start_bounds, word_end);
+   
     auto tokens = _tokenize(token_str);
     auto& close_tags = close_tokens_map();
-    
+
     // Forward match
     auto token = tokens.cbegin();
     auto& open_tags = open_tokens_map();
@@ -254,14 +256,7 @@ std::pair<Gtk::TextIter, Gtk::TextIter> CtTextParser::find_formatting_boundaries
         // Didn't find anything
         throw CtParseError(fmt::format("Could not find any valid tags in: {}", token_str.c_str()));
     }
-    
-    Glib::ustring token_test(start_bounds, word_end);
-    if ((ftoken_iter == open_tags.cend() && rtoken_iter != close_tags.cend()) || (token_test == rtoken_iter->second->open_tag)) {
-        // Found only a close tag, parse error
-        throw CtParseError(fmt::format("Close tag without open tag while parsing: {}", token_str.c_str()));
-    }
-    
-    
+        
     return {start_bounds, word_end};
 }
 

--- a/future/src/ct/ct_widgets.cc
+++ b/future/src/ct/ct_widgets.cc
@@ -458,10 +458,11 @@ void CtTextView::for_event_after_key_press(GdkEvent* event, const Glib::ustring&
                 start_iter.backward_line();
                 try {
                     _markdown_check_and_replace(text_buffer, start_iter, iter_insert);
-                    text_buffer->insert_at_cursor(CtConst::CHAR_NEWLINE);
                     iter_start  = text_buffer->get_insert()->get_iter();
                     iter_insert = iter_start;
-                } catch(CtParseError&) {}
+                } catch(const CtParseError& e) {
+                    spdlog::error("Exception caught while parsing markdown formatting: {}", e.what());
+                }
             }
             
             int cursor_key_press = iter_insert.get_offset();
@@ -616,19 +617,6 @@ void CtTextView::for_event_after_key_press(GdkEvent* event, const Glib::ustring&
                     if (iter_start.get_line_offset() == 0 and iter_start.get_char() == g_utf8_get_char(CtConst::CHAR_COLON))
                         // ":: " becoming "▪ " at line start
                         _special_char_replace(CtConst::CHARS_LISTBUL_DEFAULT[2], iter_start, iter_insert);
-                } else if (_pCtMainWin->get_ct_config()->enableMdFormatting && syntaxHighlighting == CtConst::RICH_TEXT_ID) {
-                    auto word_start = iter_insert;
-                    if (word_start.backward_chars(2)) {
-                        if (!word_start.inside_word() && !word_start.ends_word() && !word_start.starts_line()) {
-                            if (Glib::ustring(1, word_start.get_char()) != " ") {
-                                word_start.backward_sentence_start();
-                                try {
-                                    _markdown_check_and_replace(text_buffer, word_start, iter_insert);
-                                    text_buffer->insert_at_cursor(" ");
-                                } catch(CtParseError&) {}
-                            }
-                        }
-                    }
                 }
             }
         }
@@ -651,16 +639,12 @@ void CtTextView::_markdown_check_and_replace(Glib::RefPtr<Gtk::TextBuffer> text_
         _md_parser->feed(txt);
     
         text_buffer->erase(iter_pair.first, iter_pair.second);
-        auto cursor = text_buffer->get_insert()->get_iter();
-        if (cursor.backward_char()) {
-            text_buffer->place_cursor(cursor);
-        }
+        
     
         if (!_clipboard) _clipboard = std::make_unique<CtClipboard>(_pCtMainWin);
         _clipboard->from_xml_string_to_buffer(std::move(text_buffer), _md_parser->to_string());
-    } catch(CtParseError&) {
-        // todo: log this in debug
-        throw;
+    } catch(CtParseError& e) {
+        spdlog::error("Parse exception during markdown check: {}", e.what());
     }
 }
 


### PR DESCRIPTION
This fixes an issue raised [here](https://github.com/giuspen/cherrytree/issues/444#issuecomment-647577303). Basically the parser was overzealous with erroring out.

To note, the formatter is still not perfect (case in point: tables are problematic since it is done line by line, but since that's more advanced I don't think it should be expected to work). This also removes formatting on space, replacing it with only on enter since one space is pretty restrictive. Perhaps there should be a config option for when to do formatting?

Also this adds `_` as italics (forgot that part of the syntax, oops)