### PR TITLE
fixes paste on win32

### DIFF
--- a/future/src/ct/ct_imports.cc
+++ b/future/src/ct/ct_imports.cc
@@ -129,7 +129,7 @@ xmlpp::Element *image_to_xml(xmlpp::Element *parent, const std::string &path, in
     xmlpp::Element* image_element = parent->add_child("encoded_png");
     image_element->set_attribute("char_offset", std::to_string(char_offset));
     image_element->set_attribute(CtConst::TAG_JUSTIFICATION, justification);
-    image_element->set_attribute("link", path);
+    image_element->set_attribute("link", std::string(CtConst::LINK_TYPE_WEBS) + " " + path);
     image_element->add_child_text(encodedBlob);
     
     if (status_bar) status_bar->update_status("");
@@ -638,7 +638,7 @@ void CtHtml2Xml::_insert_image(std::string img_path, std::string trailing_chars)
         xmlpp::Element* p_image_node = _slot_root->add_child("encoded_png");
         p_image_node->set_attribute("char_offset", std::to_string(_char_offset));
         p_image_node->set_attribute(CtConst::TAG_JUSTIFICATION, CtConst::TAG_PROP_VAL_LEFT);
-        p_image_node->set_attribute("link", img_path);
+        p_image_node->set_attribute("link", std::string(CtConst::LINK_TYPE_WEBS) + " " + img_path);
         p_image_node->add_child_text(encodedBlob);
     };
 

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -356,8 +356,12 @@ Glib::ustring CtMainWin::sourceview_hovering_link_get_tooltip(const Glib::ustrin
 {
     Glib::ustring tooltip;
     auto vec = str::split(link, " ");
-    if (vec[0] == CtConst::LINK_TYPE_FILE or vec[0] == CtConst::LINK_TYPE_FOLD)
+    if (vec.size() == 1) { // case when link has wrong format
+        tooltip = str::replace(link, "amp;", "");
+    } 
+    else if (vec[0] == CtConst::LINK_TYPE_FILE or vec[0] == CtConst::LINK_TYPE_FOLD) {
         tooltip = Glib::Base64::decode(vec[1]);
+    }
     else
     {
         if (vec[0] == CtConst::LINK_TYPE_NODE)


### PR DESCRIPTION
- paste didn't work on win32 because of the wrong target "text/html", should "HTML Format"
- paste an image caused crash, the issue is in a wrong tooltip for the image.

Fixes #958