### PR TITLE
main.py : don't try libc.prctl on MacOS

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -167,7 +167,7 @@ def initializations():
     if hasattr(sys, 'frozen'):
         import warnings
         warnings.filterwarnings(cons.STR_IGNORE)
-    if not cons.IS_WIN_OS:
+    if not (cons.IS_WIN_OS or cons.IS_MAC_OS):
         try:
             # change process name
             import ctypes, ctypes.util


### PR DESCRIPTION
It's not available on macOS, and so generates a warning every launch.

I'm not a python guy, but this looked right and seems to stop the warning on my systems.