### PR TITLE
Redesign pdf exporting code

### DIFF
--- a/future/src/ct/ct_export2pdf.cc
+++ b/future/src/ct/ct_export2pdf.cc
@@ -197,7 +197,6 @@ void CtPrint::_on_begin_print_text(const Glib::RefPtr<Gtk::PrintContext>& contex
 
 
     double total_height = 0;
-    std::size_t forced_breaks = 0;   
     for (const auto& printable : print_data->printables)
     {
 
@@ -205,7 +204,6 @@ void CtPrint::_on_begin_print_text(const Glib::RefPtr<Gtk::PrintContext>& contex
         auto add_height = printable->height();
         if (add_height < 0) {
             // Forced page break
-            ++forced_breaks;
             add_height = _print_info.page_height - fmod(total_height, _print_info.page_height);
         } 
         total_height += add_height;
@@ -267,7 +265,7 @@ void CtPrint::_on_draw_page_text(const Glib::RefPtr<Gtk::PrintContext>& context,
         }
 
     }
-    spdlog::debug("Finished, page num: {}/{}", page_nr, print_data->nb_pages);
+    spdlog::debug("Finished, page num: {}/{}", page_nr + 1, print_data->nb_pages);
 }
 
 // Returns Width and Height of a layout line

--- a/future/src/ct/ct_export2pdf.h
+++ b/future/src/ct/ct_export2pdf.h
@@ -24,7 +24,6 @@
 #include "ct_main_win.h"
 #include "ct_dialogs.h"
 #include <iterator>
-#include <queue>
 
 
 struct CtPrintData;

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -304,6 +304,17 @@ std::vector<STRING> split(const STRING& strToSplit, const char* delimiter)
     return vecOfStrings;
 }
 
+template<class STRING_T, class ITER_T, typename DELIM_T>
+STRING_T join(ITER_T begin, ITER_T end, DELIM_T delim) {
+    STRING_T out;
+    while(begin != end) {
+        out += *begin;
+        if ((begin + 1) != end) out += delim;
+        ++begin;
+    }
+    return out;
+}
+
 template<class STRING>
 std::string join(const std::vector<STRING>& cnt, const std::string& delimer)
 {

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -304,16 +304,6 @@ std::vector<STRING> split(const STRING& strToSplit, const char* delimiter)
     return vecOfStrings;
 }
 
-template<class STRING_T, class ITER_T, typename DELIM_T>
-STRING_T join(ITER_T begin, ITER_T end, DELIM_T delim) {
-    STRING_T out;
-    while(begin != end) {
-        out += *begin;
-        if ((begin + 1) != end) out += delim;
-        ++begin;
-    }
-    return out;
-}
 
 template<class STRING>
 std::string join(const std::vector<STRING>& cnt, const std::string& delimer)


### PR DESCRIPTION
This is the first part to implementing: #942 

I ended up going for the redesign in the end because the custom formatting worked up to a point but was incredibly hacky and trying to get it to align properly and format correctly was a nightmare. 

The new design works as follows:
- `CtPrintData` has a list of `CtPrintable`'s which are everything which can be drawn to the pdf  (i.e text and widgets). 
- Page count is calculated based on the sum heights of all the `CtPrintable`'s in the print data divided by the size of each page (rounded up, +1 if there is any remainder)
- `CtPrintable` exposes `height()`, `width()`, `setup()`, `print()` and `done()`. `setup()` needs to be called before the printable can be used and `print()` displays the printable in the given context and returns the final position of the "cursor" after drawing the printable. `done()` is used to check if the printable is done (e.g the text printable will not be "done" until it has printed all of its line but it may print them over several pages).
- Page breaks are done via `CtPageBreakPrintable` which returns `-1` for the height (< 0 is interpreted as a page break) and moves the position of the cursor out of bounds on `print()`.
- Widget printables inherit from the template `CtWidgetPrintable`, which inherits from `CtPrintable`, based on their widget (e.g `CtWidgetTablePrintable` inherits from `CtWidgetPrintable<CtPrintTableProxy>`), the dynamic casts have been moved to `printable_from_widget()`. It may be possible to avoid the proxy classes all together here but I did not think it was really necessary. 

`_on_begin_print_text` now simply calls `setup()` on all the printables and calculates the number of pages (as described above). 

`_on_draw_page_text` now calls `print()` on the current printable and updates the next position based on the return value, if the printable is done it increments the current printable, if the new position after printing is larger than the height of the page it returns.

The pango serialization methods now all return either `std::vector<std::shared_ptr<CtPrintable>>` (`CtPrintableVector`) or `std::shared_ptr<CtPrintable>`.

Based on this structure it should be simple to implement links and anchors since `print()` gets the current position and a cairo context to use and each `CtPrintable` is completely independent.