### PR TITLE
Implement links in exported PDFs

### DIFF
--- a/future/src/ct/ct_export2pdf.h
+++ b/future/src/ct/ct_export2pdf.h
@@ -80,8 +80,9 @@ public:
     [[nodiscard]] std::size_t lines() const;
     [[nodiscard]] const Glib::RefPtr<Pango::Layout>& layout() const { return _layout; }
     [[nodiscard]] constexpr bool is_newline() const { return _is_newline; }
+    [[nodiscard]] const Glib::ustring& text() const { return _text; }
 
-
+    virtual ~CtTextPrintable() = default;
 private:
     Glib::ustring _text;
     Glib::RefPtr<Pango::Layout> _layout;
@@ -90,6 +91,38 @@ private:
 
     /// Calculate the heights of all the destinct lines 
     double _calc_lines_heights() const;
+};
+
+/**
+ * @brief 
+ * 
+ */
+
+class CtLinkPrintable: public CtTextPrintable 
+{
+public:
+    CtLinkPrintable(Glib::ustring title, std::string url);
+
+
+    PrintPosition print(const PrintingContext& context) override;
+
+private:
+    std::string _url;
+    bool _is_internal = false;
+};
+
+class CtDestPrintable: public CtTextPrintable 
+{
+public:
+    CtDestPrintable(Glib::ustring txt, std::string id) : CtTextPrintable(std::move(txt)), _id(std::move(id)) {}
+    CtDestPrintable(CtImageAnchor* anchor, int node_id);
+
+    PrintPosition print(const PrintingContext& context) override;
+
+    ~CtDestPrintable() = default;
+
+private:
+    std::string _id;
 };
 
 class CtPageBreakPrintable: public CtPrintable {
@@ -118,9 +151,6 @@ protected:
     mutable std::size_t _last_height = 0;
 };
 
-std::unique_ptr<CtPrintable> printable_from_widget(CtAnchoredWidget* widget);
-
-
 using CtPrintableVector = std::vector<std::shared_ptr<CtPrintable>>;
 
 class CtExport2Pdf
@@ -135,7 +165,6 @@ public:
 private:
     void _nodes_all_export_print_iter(const CtTreeIter& tree_iter, const CtExportOptions& options,
                                       CtPrintableVector& tree_printables, Glib::ustring& text_font);
-    std::unique_ptr<CtTextPrintable> _add_node_name(Glib::ustring node_name);
 
 private:
     CtMainWin* _pCtMainWin;

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -721,6 +721,25 @@ std::string CtStrUtil::get_internal_link_from_http_url(std::string link_url)
     else                                            return "webs http://" + link_url;
 }
 
+std::string CtStrUtil::external_uri_from_internal(std::string internal_uri) {
+    constexpr std::array<std::string_view, 2> internal_ids = {"webs ", "file "};
+    auto internal_id_iter = std::find_if(internal_ids.cbegin(), internal_ids.cend(), [internal_uri](std::string_view comp){
+        return str::startswith(internal_uri, std::string(comp.begin(), comp.end()));
+    });
+    if (internal_id_iter != internal_ids.cend()) {
+        // Valid
+        internal_uri.erase(internal_uri.cbegin(), internal_uri.cbegin() + internal_id_iter->size());
+        if (*internal_id_iter == "file ") {
+            // Decode a file url
+            internal_uri = Glib::Base64::decode(internal_uri);
+        }
+    } else {
+        throw std::logic_error(fmt::format("CtStrUtil::get_external_uri_from_internal passed string ({}) which does not contain an internal uri", internal_uri));
+    }
+    return internal_uri;
+
+}
+
 std::string CtFontUtil::get_font_family(const std::string& fontStr)
 {
     return Pango::FontDescription(fontStr).get_family();

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -194,6 +194,9 @@ Glib::ustring get_accelerator_label(const std::string& accelerator);
 
 std::string get_internal_link_from_http_url(std::string link_url);
 
+/// reverse get_internal_link_from_http_url and strips internal identifiers
+std::string external_uri_from_internal(std::string internal_uri);
+
 } // namespace CtStrUtil
 
 namespace CtFontUtil {

--- a/future/tests/tests_misc_utils.cpp
+++ b/future/tests/tests_misc_utils.cpp
@@ -366,3 +366,12 @@ TEST(MiscUtilsGroup, parallel_for)
             CHECK(check_range_in_vec(vec, first, last));
         }
 }
+
+TEST(MiscUtilsGroup, external_uri_from_internal) 
+{
+    STRCMP_EQUAL("https://example.com", CtStrUtil::external_uri_from_internal("webs https://example.com").c_str());
+    STRCMP_EQUAL("/home/foo/bar\n", CtStrUtil::external_uri_from_internal("file L2hvbWUvZm9vL2Jhcgo=").c_str());
+    CHECK_THROWS(std::logic_error, CtStrUtil::external_uri_from_internal("https://example.com"));
+    CHECK_THROWS(std::logic_error, CtStrUtil::external_uri_from_internal("/home/foo/bar"));
+}
+

--- a/future/tests/tests_misc_utils.cpp
+++ b/future/tests/tests_misc_utils.cpp
@@ -27,6 +27,8 @@
 #include "tests_common.h"
 #include "CppUTest/CommandLineTestRunner.h"
 
+#include <stdexcept>
+
 TEST_GROUP(MiscUtilsGroup)
 {
 };


### PR DESCRIPTION
This is the second part to #942

Image anchors are now processed, anchors are inserted as the unicode anchor emoji (⚓) instead of the image because it was simpler, since it takes a `CtImageAnchor` in the relevant ctor however, this is easy to change. 

This adds two new classes, `CtDestPrintable` and `CtLinkPrintable` where `CtDestPrintable` is what processes `CtImageAnchor`'s, and `CtLinkPrintable` just applies the cairo link tag and makes its text blue.

Internal destinations are represented in the form `n.<node id>.[section (e.g h1-1)]`, the section part is optional. External destinations are processed by `CtStrUtil::external_uri_from_internal()` which converts an internal uri (e.g `webs https://example.com`) to an external one (and decodes file paths).