### PR TITLE
fixes behaviour systray icon

### DIFF
--- a/future/src/ct/ct_app.cc
+++ b/future/src/ct/ct_app.cc
@@ -196,7 +196,8 @@ CtMainWin* CtApp::_create_window(const bool no_gui)
     add_window(*pCtMainWin);
 
     pCtMainWin->signal_app_new_instance.connect([this]() {
-        _create_window();
+        auto win = _create_window();
+        win->present(); // explicitly show it because it can be hidden by start in systray
     });
     pCtMainWin->signal_app_apply_for_each_window.connect([this](std::function<void(CtMainWin*)> callback) {
         for (Gtk::Window* pWin : get_windows())

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -368,6 +368,14 @@ Gtk::MenuItem* CtMenu::find_menu_item(Gtk::MenuBar* menuBar, std::string name)
     return nullptr;
 }
 
+Gtk::AccelLabel* CtMenu::get_accel_label(Gtk::MenuItem* item)
+{
+    if (auto box = dynamic_cast<Gtk::Box*>(item->get_child()))
+        if (auto label = dynamic_cast<Gtk::AccelLabel*>(box->get_children().back()))
+            return label;
+    return nullptr;
+}
+
 Gtk::Toolbar* CtMenu::build_toolbar(Gtk::MenuToolButton*& pRecentDocsMenuToolButton)
 {
     Gtk::Toolbar* pToolbar{nullptr};

--- a/future/src/ct/ct_menu.h
+++ b/future/src/ct/ct_menu.h
@@ -72,8 +72,9 @@ public:
 
     GtkAccelGroup* default_accel_group();
 
-    static ACCEL_TYPE     get_accel_type(const std::string& action_name);
-    static Gtk::MenuItem* find_menu_item(Gtk::MenuBar* menuBar, std::string name);
+    static ACCEL_TYPE       get_accel_type(const std::string& action_name);
+    static Gtk::MenuItem*   find_menu_item(Gtk::MenuBar* menuBar, std::string name);
+    static Gtk::AccelLabel* get_accel_label(Gtk::MenuItem* item);
 
     Gtk::Toolbar* build_toolbar(Gtk::MenuToolButton*& pRecentDocsMenuToolButton);
     Gtk::MenuBar* build_menubar();


### PR DESCRIPTION
- `is_embedded` doesn't work because it should be called in main event loop
- fixed an issue when New Instance could create a hidden window
- changed "Quit" label into "Hide" when it works as hide

Didn't check it on Ubuntu, but I think it should work