### PR TITLE
fixes collapsing/expanding nodes on double-click

### DIFF
--- a/future/src/ct/ct_main_win.h
+++ b/future/src/ct/ct_main_win.h
@@ -184,6 +184,8 @@ private:
     void                _on_treeview_cursor_changed(); // pygtk: on_node_changed
     bool                _on_treeview_button_release_event(GdkEventButton* event);
     void                _on_treeview_event_after(GdkEvent* event); // pygtk: on_event_after_tree
+    void                _on_treeview_row_activated(const Gtk::TreeModel::Path&, Gtk::TreeViewColumn*);
+    bool                _on_treeview_test_collapse_row(const Gtk::TreeModel::iterator&,const Gtk::TreeModel::Path&);
     bool                _on_treeview_key_press_event(GdkEventKey* event);
     bool                _on_treeview_popup_menu();
     bool                _on_treeview_scroll_event(GdkEventScroll* event);
@@ -250,6 +252,7 @@ private:
     int                 _savedXpos{-1};
     int                 _savedYpos{-1};
     sigc::connection    _autosave_timout_connection;
+    bool                _tree_just_auto_expanded{false};
 
 public:
     sigc::signal<void>             signal_app_new_instance = sigc::signal<void>();


### PR DESCRIPTION
Resolves #987

Issues:
- From #987: double click in any empty place (or an expand icon) of the tree panel causes expanding/collapsing of the selected row. So, double click on an expand icon of some row, doesn't expand that row, but expand the selected row. To fix it, I check if selected row is under cursor.
- double click sometimes doesn't work and this looks like click skipping. To fix it, I use `row activated` signal, in this case, double click works smoothly.
-  `row activated` signal doesn't work right when the `one click` option is on. In this case, I use old double-click, although it can have the mentioned issue.
 
Fixes are both for pygtk and gtkmm3

