### PR TITLE
Fixes node sequences after moving nodes.

### DIFF
--- a/future/src/ct/ct_actions_import.cc
+++ b/future/src/ct/ct_actions_import.cc
@@ -234,6 +234,7 @@ void CtActions::_create_imported_nodes(ct_imported_node* imported_nodes)
         node_data.syntax = imported_node->node_syntax;
         node_data.tsCreation = std::time(nullptr);
         node_data.tsLastSave = node_data.tsCreation;
+        node_data.sequence = -1;
         if (imported_node->has_content())
         {
             Glib::RefPtr<Gsv::Buffer> buffer = _pCtMainWin->get_new_text_buffer();

--- a/future/src/ct/ct_pref_dlg.cc
+++ b/future/src/ct/ct_pref_dlg.cc
@@ -366,6 +366,8 @@ Gtk::Widget* CtPrefDlg::build_tab_rich_text()
     Gtk::RadioButton* radiobutton_rt_col_dark = Gtk::manage(new Gtk::RadioButton(_("Dark Background, Light Text")));
     radiobutton_rt_col_dark->join_group(*radiobutton_rt_col_light);
     Gtk::RadioButton* radiobutton_rt_col_custom = Gtk::manage(new Gtk::RadioButton(_("Custom Background")));
+    radiobutton_rt_col_custom->set_sensitive(false);
+    radiobutton_rt_col_custom->set_tooltip_text(_("Disabled in Development Version"));
     radiobutton_rt_col_custom->join_group(*radiobutton_rt_col_light);
     Gtk::HBox* hbox_rt_col_custom = Gtk::manage(new Gtk::HBox());
     hbox_rt_col_custom->set_spacing(4);
@@ -914,6 +916,8 @@ Gtk::Widget* CtPrefDlg::build_tab_tree_2()
     Gtk::Label* label_tree_nodes_names_width = Gtk::manage(new Gtk::Label(_("Tree Nodes Names Wrapping Width")));
     Glib::RefPtr<Gtk::Adjustment> adj_tree_nodes_names_width = Gtk::Adjustment::create(pConfig->cherryWrapWidth, 10, 10000, 1);
     Gtk::SpinButton* spinbutton_tree_nodes_names_width = Gtk::manage(new Gtk::SpinButton(adj_tree_nodes_names_width));
+    spinbutton_tree_nodes_names_width->set_sensitive(false);
+    spinbutton_tree_nodes_names_width->set_tooltip_text(_("Disabled in Development Version"));
     spinbutton_tree_nodes_names_width->set_value(pConfig->cherryWrapWidth);
     hbox_tree_nodes_names_width->pack_start(*label_tree_nodes_names_width, false, false);
     hbox_tree_nodes_names_width->pack_start(*spinbutton_tree_nodes_names_width, false, false);
@@ -1416,6 +1420,9 @@ Gtk::Widget* CtPrefDlg::build_tab_misc()
     checkbutton_reload_doc_last->set_active(pConfig->reloadDocLast);
     checkbutton_mod_time_sentinel->set_active(pConfig->modTimeSentinel);
 
+    checkbutton_mod_time_sentinel->set_sensitive(false);
+    checkbutton_mod_time_sentinel->set_tooltip_text(_("Disabled in Development Version"));
+
     Gtk::Frame* frame_misc_misc = Gtk::manage(new Gtk::Frame(std::string("<b>")+_("Miscellaneous")+"</b>"));
     ((Gtk::Label*)frame_misc_misc->get_label_widget())->set_use_markup(true);
     frame_misc_misc->set_shadow_type(Gtk::SHADOW_NONE);
@@ -1488,11 +1495,15 @@ Gtk::Widget* CtPrefDlg::build_tab_misc()
         pConfig->autosaveVal = spinbutton_autosave->get_value_as_int();
         _pCtMainWin->file_autosave_restart();
     });
-    spinbutton_num_backups->signal_value_changed().connect([pConfig, spinbutton_num_backups](){
-        pConfig->backupNum = spinbutton_num_backups->get_value_as_int();
-    });
     checkbutton_autosave_on_quit->signal_toggled().connect([pConfig, checkbutton_autosave_on_quit](){
         pConfig->autosaveOnQuit = checkbutton_autosave_on_quit->get_active();
+    });
+    checkbutton_backup_before_saving->signal_toggled().connect([pConfig, checkbutton_backup_before_saving, spinbutton_num_backups](){
+        pConfig->backupCopy = checkbutton_backup_before_saving->get_active();
+        spinbutton_num_backups->set_sensitive(pConfig->backupCopy);
+    });
+    spinbutton_num_backups->signal_value_changed().connect([pConfig, spinbutton_num_backups](){
+        pConfig->backupNum = spinbutton_num_backups->get_value_as_int();
     });
     checkbutton_reload_doc_last->signal_toggled().connect([pConfig, checkbutton_reload_doc_last](){
         pConfig->reloadDocLast = checkbutton_reload_doc_last->get_active();

--- a/future/src/ct/ct_storage_sqlite.h
+++ b/future/src/ct/ct_storage_sqlite.h
@@ -57,7 +57,7 @@ private:
     void _close_db();
     bool _check_database_integrity();
 
-    Gtk::TreeIter       _node_from_db(gint64 node_id, Gtk::TreeIter parent_iter, gint64 new_id);
+    Gtk::TreeIter       _node_from_db(gint64 node_id, gint64 sequence, Gtk::TreeIter parent_iter, gint64 new_id);
 
     
     /**

--- a/future/src/ct/ct_storage_xml.h
+++ b/future/src/ct/ct_storage_xml.h
@@ -58,7 +58,7 @@ public:
                                                       const std::string& syntax,
                                                       std::list<CtAnchoredWidget*>& widgets) const override;
 private:
-    Gtk::TreeIter  _node_from_xml(xmlpp::Element* xml_element, Gtk::TreeIter parent_iter, gint64 new_id);
+    Gtk::TreeIter  _node_from_xml(xmlpp::Element* xml_element, gint64 sequence, Gtk::TreeIter parent_iter, gint64 new_id);
     void           _nodes_to_xml(CtTreeIter* ct_tree_iter, xmlpp::Element* p_node_parent, CtStorageCache* storage_cache);
     std::unique_ptr<xmlpp::DomParser> _get_parser(const fs::path& file_path);
 

--- a/future/src/ct/ct_treestore.cc
+++ b/future/src/ct/ct_treestore.cc
@@ -583,7 +583,7 @@ void CtTreeStore::get_node_data(const Gtk::TreeIter& treeIter, CtNodeData& nodeD
     nodeData.rTextBuffer = row[_columns.rColTextBuffer];
     nodeData.nodeId = row[_columns.colNodeUniqueId];
     nodeData.syntax = row[_columns.colSyntaxHighlighting];
-    //row[_columns.colNodeSequence] = ;
+    nodeData.sequence = row[_columns.colNodeSequence];
     nodeData.tags = row[_columns.colNodeTags];
     nodeData.isRO = row[_columns.colNodeRO];
     //row[_columns.rColPixbufAux] = ;
@@ -605,7 +605,7 @@ void CtTreeStore::update_node_data(const Gtk::TreeIter& treeIter, const CtNodeDa
     row[_columns.rColTextBuffer] = nodeData.rTextBuffer;
     row[_columns.colNodeUniqueId] = nodeData.nodeId;
     row[_columns.colSyntaxHighlighting] = nodeData.syntax;
-    //row[_columns.colNodeSequence] = ; // either not changed or updated somewhere
+    row[_columns.colNodeSequence] = nodeData.sequence;
     row[_columns.colNodeTags] = nodeData.tags;
     row[_columns.colNodeRO] = nodeData.isRO;
     //row[_columns.rColPixbufAux] = ;  // will be updated by update_node_aux_icon

--- a/future/src/ct/ct_treestore.h
+++ b/future/src/ct/ct_treestore.h
@@ -44,6 +44,7 @@ struct CtNodeData
     std::string    foregroundRgb24;
     gint64         tsCreation{0};
     gint64         tsLastSave{0};
+    gint64         sequence{-1};
     Glib::RefPtr<Gsv::Buffer>  rTextBuffer{nullptr};
     std::list<CtAnchoredWidget*> anchoredWidgets;
 };


### PR DESCRIPTION
Resolves #979

- Node order wasn't right after using commands "Node Up" and "Node Down", though moving nodes by drag-drop was OK. The reason is that node sequence swapping didn't work because node sequence was never loaded. It was usually OK because we recreated node sequences every time and it only caused extensive db writing. Fixed it by loading node sequences. 
- Users complained on some options in PrefDlg that should not work, so I disabled them.
- Switching off "Create a Backup Copy Before Saving" didn't work. Fixed it
