### PR TITLE
uses Gtk::FileChooserNative

### DIFF
--- a/future/src/ct/ct_actions_import.cc
+++ b/future/src/ct/ct_actions_import.cc
@@ -133,7 +133,6 @@ void CtActions::_import_from_file(CtImporterInterface* importer)
 {
     CtDialogs::file_select_args args(_pCtMainWin);
     args.curr_folder = _pCtMainWin->get_ct_config()->pickDirImport;
-    args.filter_mime = importer->file_mimes();
     args.filter_name = importer->file_pattern_name();
     args.filter_pattern = importer->file_patterns();
     auto filepath = CtDialogs::file_select_dialog(args);

--- a/future/src/ct/ct_actions_import.cc
+++ b/future/src/ct/ct_actions_import.cc
@@ -49,7 +49,8 @@ void CtActions::import_nodes_from_ct_file() noexcept
     {
         CtDialogs::file_select_args args(_pCtMainWin);
         args.curr_folder = _pCtMainWin->get_ct_config()->pickDirImport;
-        args.filter_pattern = CtConst::CT_FILE_EXTENSIONS_FILTER;
+        args.filter_name = _("CherryTree Document");
+        args.filter_pattern.push_back("*.ct*");
 
         auto fpath = CtDialogs::file_select_dialog(args);
         if (fpath.empty()) return; // No file selected
@@ -133,6 +134,7 @@ void CtActions::_import_from_file(CtImporterInterface* importer)
     CtDialogs::file_select_args args(_pCtMainWin);
     args.curr_folder = _pCtMainWin->get_ct_config()->pickDirImport;
     args.filter_mime = importer->file_mimes();
+    args.filter_name = importer->file_pattern_name();
     args.filter_pattern = importer->file_patterns();
     auto filepath = CtDialogs::file_select_dialog(args);
     if (filepath.empty()) return;

--- a/future/src/ct/ct_dialogs.cc
+++ b/future/src/ct/ct_dialogs.cc
@@ -1082,17 +1082,13 @@ std::string CtDialogs::file_select_dialog(const file_select_args& args)
     {
         chooser->set_current_folder(args.curr_folder.string());
     }
-    if (!args.filter_pattern.empty() || !args.filter_mime.empty())
+    if (!args.filter_pattern.empty())
     {
         Glib::RefPtr<Gtk::FileFilter> rFileFilter = Gtk::FileFilter::create();
         rFileFilter->set_name(args.filter_name);
         for (const std::string& element : args.filter_pattern)
         {
             rFileFilter->add_pattern(element);
-        }
-        for (const std::string& element : args.filter_mime)
-        {
-            rFileFilter->add_mime_type(element);
         }
         chooser->add_filter(rFileFilter);
     }
@@ -1138,10 +1134,6 @@ std::string CtDialogs::file_save_as_dialog(const file_select_args& args)
         for (const std::string& element : args.filter_pattern)
         {
             rFileFilter->add_pattern(element);
-        }
-        for (const std::string& element : args.filter_mime)
-        {
-            rFileFilter->add_mime_type(element);
         }
         chooser->add_filter(rFileFilter);
     }

--- a/future/src/ct/ct_dialogs.cc
+++ b/future/src/ct/ct_dialogs.cc
@@ -1073,28 +1073,14 @@ bool CtDialogs::link_handle_dialog(CtMainWin& ctMainWin,
 // The Select file dialog, Returns the retrieved filepath or None
 std::string CtDialogs::file_select_dialog(const file_select_args& args)
 {
-    Gtk::FileChooserDialog chooser(_("Select File"),
-                                   Gtk::FILE_CHOOSER_ACTION_OPEN);
-    chooser.add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-    chooser.add_button(Gtk::Stock::OPEN, Gtk::RESPONSE_ACCEPT);
-    if (args.pParentWin)
-    {
-        chooser.set_transient_for(*args.pParentWin);
-        chooser.property_modal() = true;
-        chooser.property_destroy_with_parent() = true;
-        chooser.set_position(Gtk::WIN_POS_CENTER_ON_PARENT);
-    }
-    else
-    {
-        chooser.set_position(Gtk::WIN_POS_CENTER);
-    }
+    auto chooser = Gtk::FileChooserNative::create(_("Select File"), *args.pParentWin, Gtk::FILE_CHOOSER_ACTION_OPEN);
     if (args.curr_folder.empty() || !fs::is_directory(args.curr_folder))
     {
-        chooser.set_current_folder(g_get_home_dir());
+        chooser->set_current_folder(g_get_home_dir());
     }
     else
     {
-        chooser.set_current_folder(args.curr_folder.string());
+        chooser->set_current_folder(args.curr_folder.string());
     }
     if (!args.filter_pattern.empty() || !args.filter_mime.empty())
     {
@@ -1108,71 +1094,42 @@ std::string CtDialogs::file_select_dialog(const file_select_args& args)
         {
             rFileFilter->add_mime_type(element);
         }
-        chooser.add_filter(rFileFilter);
+        chooser->add_filter(rFileFilter);
     }
-    return (chooser.run() == Gtk::RESPONSE_ACCEPT ? chooser.get_filename() : "");
+    return (chooser->run() == Gtk::RESPONSE_ACCEPT ? chooser->get_filename() : "");
 }
 
 // The Select folder dialog, returns the retrieved folderpath or None
-std::string CtDialogs::folder_select_dialog(const std::string& curr_folder,
-                                            Gtk::Window* pParentWin /*= nullptr*/)
+std::string CtDialogs::folder_select_dialog(const std::string& curr_folder, Gtk::Window* pParentWin)
 {
-    Gtk::FileChooserDialog chooser(_("Select Folder"),
-                                   Gtk::FILE_CHOOSER_ACTION_SELECT_FOLDER);
-    chooser.add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-    chooser.add_button(Gtk::Stock::OPEN, Gtk::RESPONSE_ACCEPT);
-    if (pParentWin)
-    {
-        chooser.set_transient_for(*pParentWin);
-        chooser.property_modal() = true;
-        chooser.property_destroy_with_parent() = true;
-        chooser.set_position(Gtk::WIN_POS_CENTER_ON_PARENT);
-    }
-    else
-    {
-        chooser.set_position(Gtk::WIN_POS_CENTER);
-    }
+    auto chooser = Gtk::FileChooserNative::create(_("Select Folder"), *pParentWin, Gtk::FILE_CHOOSER_ACTION_SELECT_FOLDER);
     if (curr_folder.empty() || !Glib::file_test(curr_folder, Glib::FILE_TEST_IS_DIR))
     {
-        chooser.set_current_folder(g_get_home_dir());
+        chooser->set_current_folder(g_get_home_dir());
     }
     else
     {
-        chooser.set_current_folder(curr_folder);
+        chooser->set_current_folder(curr_folder);
     }
-    return (chooser.run() == Gtk::RESPONSE_ACCEPT ? chooser.get_filename() : "");
+    return (chooser->run() == Gtk::RESPONSE_ACCEPT ? chooser->get_filename() : "");
 }
 
 // The Save file as dialog, Returns the retrieved filepath or None
 std::string CtDialogs::file_save_as_dialog(const file_select_args& args)
 {
-    Gtk::FileChooserDialog chooser(_("Save File as"),
-                                   Gtk::FILE_CHOOSER_ACTION_SAVE);
-    chooser.add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-    chooser.add_button(Gtk::Stock::SAVE, Gtk::RESPONSE_ACCEPT);
-    chooser.set_do_overwrite_confirmation(true);
-    if (args.pParentWin)
-    {
-        chooser.set_transient_for(*args.pParentWin);
-        chooser.property_modal() = true;
-        chooser.property_destroy_with_parent() = true;
-        chooser.set_position(Gtk::WIN_POS_CENTER_ON_PARENT);
-    }
-    else
-    {
-        chooser.set_position(Gtk::WIN_POS_CENTER);
-    }
+    auto chooser = Gtk::FileChooserNative::create(_("Save File as"), *args.pParentWin, Gtk::FILE_CHOOSER_ACTION_SAVE);
+    chooser->set_do_overwrite_confirmation(true);
     if (args.curr_folder.empty() || !fs::is_directory(args.curr_folder))
     {
-        chooser.set_current_folder(g_get_home_dir());
+        chooser->set_current_folder(g_get_home_dir());
     }
     else
     {
-        chooser.set_current_folder(args.curr_folder.string());
+        chooser->set_current_folder(args.curr_folder.string());
     }
     if (!args.curr_file_name.empty())
     {
-        chooser.set_current_name(args.curr_file_name.string());
+        chooser->set_current_name(args.curr_file_name.string());
     }
     if (!args.filter_pattern.empty())
     {
@@ -1186,9 +1143,9 @@ std::string CtDialogs::file_save_as_dialog(const file_select_args& args)
         {
             rFileFilter->add_mime_type(element);
         }
-        chooser.add_filter(rFileFilter);
+        chooser->add_filter(rFileFilter);
     }
-    return (chooser.run() == Gtk::RESPONSE_ACCEPT ? chooser.get_filename() : "");
+    return (chooser->run() == Gtk::RESPONSE_ACCEPT ? chooser->get_filename() : "");
 }
 
 // Insert/Edit Image

--- a/future/src/ct/ct_dialogs.cc
+++ b/future/src/ct/ct_dialogs.cc
@@ -1494,6 +1494,10 @@ bool CtDialogs::choose_data_storage_dialog(storage_select_args& args)
             radiobutton_xml_pass_protected.set_active(true);
         }
     }
+    else {
+        radiobutton_sqlite_not_protected.set_active(true);
+        passw_frame.set_sensitive(false);
+    }
 
     Gtk::Box* pContentArea = dialog.get_content_area();
     pContentArea->set_spacing(5);

--- a/future/src/ct/ct_dialogs.h
+++ b/future/src/ct/ct_dialogs.h
@@ -242,8 +242,7 @@ struct file_select_args
 std::string file_select_dialog(const file_select_args& args);
 
 // The Select folder dialog, returns the retrieved folderpath or None
-std::string folder_select_dialog(const std::string& curr_folder,
-                                 Gtk::Window* pParentWin = nullptr);
+std::string folder_select_dialog(const std::string& curr_folder, Gtk::Window* pParentWin);
 
 // The Save file as dialog, Returns the retrieved filepath or None
 std::string file_save_as_dialog(const file_select_args& args);

--- a/future/src/ct/ct_dialogs.h
+++ b/future/src/ct/ct_dialogs.h
@@ -233,7 +233,7 @@ struct file_select_args
     fs::path                    curr_file_name;
     Glib::ustring               filter_name;
     std::vector<std::string>    filter_pattern;
-    std::vector<std::string>    filter_mime;
+    // std::vector<std::string>    filter_mime; doesn't work with native dialog
 
     file_select_args(Gtk::Window* win) : pParentWin(win) {}
 };

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -30,6 +30,7 @@
 #include <libxml++/libxml++.h>
 #include <queue>
 #include <utility>
+#include <glibmm/i18n.h>
 
 namespace {
 using TableMatrx = std::queue<std::queue<std::string>>;
@@ -56,6 +57,7 @@ class CtImporterInterface
 public:
     virtual std::unique_ptr<ct_imported_node> import_file(const fs::path& file) = 0;
     virtual std::vector<std::string>          file_mimes() { return {}; }
+    virtual std::string                       file_pattern_name() { return ""; }
     virtual std::vector<std::string>          file_patterns() { return {}; }
 };
 
@@ -186,6 +188,7 @@ public:
     // virtuals of CtImporterInterface
     std::unique_ptr<ct_imported_node> import_file(const fs::path& file) override;
     std::vector<std::string>          file_mimes() override { return {"text/html"}; };
+    std::string                       file_pattern_name() override { return _("Html Document"); }
 
 private:
     CtConfig* _config;
@@ -255,6 +258,7 @@ public:
     // virtuals of CtImporterInterface
     std::unique_ptr<ct_imported_node> import_file(const fs::path& file) override;
     std::vector<std::string>          file_mimes() override { return {"text/plain"}; };
+    std::string                       file_pattern_name() override { return _("Plain Text Document"); }
 };
 
 
@@ -299,9 +303,8 @@ public:
 public:
     // virtuals of CtImporterInterface
     std::unique_ptr<ct_imported_node> import_file(const fs::path& file) override;
-    std::vector<std::string>          file_mimes() override { return {"text/plain"}; };
     std::vector<std::string>          file_patterns() override { return {"*.md"}; };
-
+    std::string                       file_pattern_name() override { return _("Markdown Document"); }
 private:
     CtMDParser _parser;
 };

--- a/future/src/ct/ct_imports.h
+++ b/future/src/ct/ct_imports.h
@@ -56,7 +56,6 @@ class CtImporterInterface
 {
 public:
     virtual std::unique_ptr<ct_imported_node> import_file(const fs::path& file) = 0;
-    virtual std::vector<std::string>          file_mimes() { return {}; }
     virtual std::string                       file_pattern_name() { return ""; }
     virtual std::vector<std::string>          file_patterns() { return {}; }
 };
@@ -187,8 +186,8 @@ public:
 
     // virtuals of CtImporterInterface
     std::unique_ptr<ct_imported_node> import_file(const fs::path& file) override;
-    std::vector<std::string>          file_mimes() override { return {"text/html"}; };
     std::string                       file_pattern_name() override { return _("Html Document"); }
+    std::vector<std::string>          file_patterns() override { return {"*.html", "*.htm"}; };
 
 private:
     CtConfig* _config;
@@ -257,8 +256,8 @@ public:
 public:
     // virtuals of CtImporterInterface
     std::unique_ptr<ct_imported_node> import_file(const fs::path& file) override;
-    std::vector<std::string>          file_mimes() override { return {"text/plain"}; };
     std::string                       file_pattern_name() override { return _("Plain Text Document"); }
+    std::vector<std::string>          file_patterns() override { return {"*.txt"}; };
 };
 
 


### PR DESCRIPTION
Resolves #1000 (such a nice issue number)

Adds support for native dialogs, to use it, start the app with `GTK_USE_PORTAL=1` on kde systems. On win32 there is no need for any flags. Small drawback is mime filtering is not supported there, there is only pattern filtering.

