### PR TITLE
Fixes hidden app in a missing systray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
         ;;
       osx)
         brew update
-        brew install python3 cmake pkg-config gtksourceviewmm3 gnome-icon-theme gspell libxml++ cpputest
+        brew install python3 pip3 cmake pkg-config gtksourceviewmm3 gnome-icon-theme gspell libxml++ cpputest
         pip3 install lxml
         ;;
     esac

--- a/future/src/ct/ct_app.cc
+++ b/future/src/ct/ct_app.cc
@@ -93,6 +93,7 @@ Glib::RefPtr<CtApp> CtApp::create()
 
 void CtApp::on_activate()
 {
+    // start of main instance
     if (get_windows().size() == 0)
     {
         CtMainWin* pAppWindow = _create_window();
@@ -113,6 +114,24 @@ void CtApp::on_activate()
                 pAppWindow->menu_set_items_recent_documents();
             }
         }
+    }
+    else // start of the second instance
+    {
+        Gtk::Window* any_shown_win = nullptr;
+        for (Gtk::Window* pWin : get_windows())
+            if (pWin->get_visible())
+                any_shown_win = pWin;
+        if (any_shown_win)
+        {
+            any_shown_win->present();
+        }
+        else
+        {
+            // all windows are hidden, show them
+            // also it fixes an issue with a missing systray
+            _systray_show_hide_windows();
+        }
+
     }
 }
 


### PR DESCRIPTION
The second start of cherrytree brings up the main window of the first instance (quite intuitive behavior for users ). Also, if all windows are hidden in a system tray, it makes them all visible. 