### PR TITLE
fixes CT cannot open links on KDE

### DIFF
--- a/future/src/ct/ct_actions_export.cc
+++ b/future/src/ct/ct_actions_export.cc
@@ -186,7 +186,7 @@ void CtActions::_export_to_html(const fs::path& auto_path, bool auto_overwrite)
             export2html.node_export_to_html(_pCtMainWin->curr_tree_iter(), _export_options, "", iter_start.get_offset(), iter_end.get_offset());
     }
     if (!ret_html_path.empty()) {
-       fs::external_folderpath_open(ret_html_path, _pCtMainWin->get_ct_config());
+       fs::open_folderpath(ret_html_path, _pCtMainWin->get_ct_config());
     }
 }
 

--- a/future/src/ct/ct_actions_help.cc
+++ b/future/src/ct/ct_actions_help.cc
@@ -26,7 +26,7 @@
 
 void CtActions::online_help()
 {
-    fs::external_weblink_open("https://giuspen.com/cherrytreemanual/");
+    fs::open_weblink("https://giuspen.com/cherrytreemanual/");
 }
 
 void CtActions::dialog_about()
@@ -36,7 +36,7 @@ void CtActions::dialog_about()
 
 void CtActions::folder_cfg_open()
 {
-    fs::external_folderpath_open(Glib::get_user_config_dir() / fs::path(CtConst::APP_NAME), _pCtMainWin->get_ct_config());
+    fs::open_folderpath(Glib::get_user_config_dir() / fs::path(CtConst::APP_NAME), _pCtMainWin->get_ct_config());
 }
 
 void CtActions::check_for_newer_version()

--- a/future/src/ct/ct_actions_help.cc
+++ b/future/src/ct/ct_actions_help.cc
@@ -26,7 +26,7 @@
 
 void CtActions::online_help()
 {
-    g_app_info_launch_default_for_uri("https://giuspen.com/cherrytreemanual/", nullptr, nullptr);
+    fs::external_weblink_open("https://giuspen.com/cherrytreemanual/");
 }
 
 void CtActions::dialog_about()

--- a/future/src/ct/ct_actions_others.cc
+++ b/future/src/ct/ct_actions_others.cc
@@ -164,7 +164,7 @@ void CtActions::embfile_open()
 
     spdlog::debug("embfile_open {}", filepath);
 
-    fs::external_filepath_open(filepath.c_str(), false, _pCtMainWin->get_ct_config());
+    fs::open_filepath(filepath.c_str(), false, _pCtMainWin->get_ct_config());
     _embfiles_opened[filepath] = fs::getmtime(filepath);
 
     if (not _embfiles_timeout_connection)
@@ -278,7 +278,7 @@ void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_
                  return;
              }
          }
-         else fs::external_weblink_open(clean_weblink);
+         else fs::open_weblink(clean_weblink);
      }
      else if (vec[0] == CtConst::LINK_TYPE_FILE) // link to file
      {
@@ -290,7 +290,7 @@ void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_
          }
          if (from_wheel)
              filepath = fs::absolute(filepath).parent_path();
-         fs::external_filepath_open(filepath, true, _pCtMainWin->get_ct_config());
+         fs::open_filepath(filepath, true, _pCtMainWin->get_ct_config());
      }
      else if (vec[0] == CtConst::LINK_TYPE_FOLD) // link to folder
      {
@@ -302,7 +302,7 @@ void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_
          }
          if (from_wheel)
              folderpath = Glib::path_get_dirname(fs::absolute(folderpath).string());
-         fs::external_folderpath_open(folderpath, _pCtMainWin->get_ct_config());
+         fs::open_folderpath(folderpath, _pCtMainWin->get_ct_config());
      }
      else if (vec[0] == CtConst::LINK_TYPE_NODE) // link to a tree node
      {

--- a/future/src/ct/ct_actions_others.cc
+++ b/future/src/ct/ct_actions_others.cc
@@ -278,7 +278,7 @@ void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_
                  return;
              }
          }
-         else g_app_info_launch_default_for_uri(clean_weblink.c_str(), nullptr, nullptr); // todo: ?
+         else fs::external_weblink_open(clean_weblink);
      }
      else if (vec[0] == CtConst::LINK_TYPE_FILE) // link to file
      {

--- a/future/src/ct/ct_filesystem.cc
+++ b/future/src/ct/ct_filesystem.cc
@@ -124,7 +124,7 @@ bool exists(const path& filepath)
     return Glib::file_test(filepath.string(), Glib::FILE_TEST_EXISTS);
 }
 
-void external_weblink_open(const std::string& link)
+void open_weblink(const std::string& link)
 {
 #if defined(_WIN32) || defined(__APPLE__)
     g_app_info_launch_default_for_uri(link.c_str(), nullptr, nullptr);
@@ -136,9 +136,9 @@ void external_weblink_open(const std::string& link)
 }
 
 // Open Filepath with External App
-void external_filepath_open(const fs::path& filepath, bool open_folder_if_file_not_exists, CtConfig* config)
+void open_filepath(const fs::path& filepath, bool open_folder_if_file_not_exists, CtConfig* config)
 {
-    spdlog::debug("fs::external_filepath_open {}", filepath);
+    spdlog::debug("fs::open_filepath {}", filepath);
     if (config->filelinkCustomOn) {
         std::string cmd = fmt::sprintf(config->filelinkCustomAct, filepath.string());
         const int retVal = std::system(cmd.c_str());
@@ -147,9 +147,9 @@ void external_filepath_open(const fs::path& filepath, bool open_folder_if_file_n
         }
     } else {
         if (open_folder_if_file_not_exists && !fs::exists(filepath)) {
-            external_folderpath_open(filepath, config);
+            open_folderpath(filepath, config);
         } else if (!fs::exists(filepath)) {
-            spdlog::error("fs::external_filepath_open: file doesn't exist, {}", filepath.string());
+            spdlog::error("fs::open_filepath: file doesn't exist, {}", filepath.string());
             return;
         } else {
 #ifdef _WIN32
@@ -164,9 +164,9 @@ void external_filepath_open(const fs::path& filepath, bool open_folder_if_file_n
 }
 
 // Open Folderpath with External App
-void external_folderpath_open(const fs::path& folderpath, CtConfig* config)
+void open_folderpath(const fs::path& folderpath, CtConfig* config)
 {
-    spdlog::debug("fs::external_folderpath_open {}", folderpath);
+    spdlog::debug("fs::open_folderpath {}", folderpath);
     if (config->folderlinkCustomOn) {
         std::string cmd = fmt::sprintf(config->folderlinkCustomAct, folderpath.string());
         const int retVal = std::system(cmd.c_str());

--- a/future/src/ct/ct_filesystem.cc
+++ b/future/src/ct/ct_filesystem.cc
@@ -124,6 +124,17 @@ bool exists(const path& filepath)
     return Glib::file_test(filepath.string(), Glib::FILE_TEST_EXISTS);
 }
 
+void external_weblink_open(const std::string& link)
+{
+#if defined(_WIN32) || defined(__APPLE__)
+    g_app_info_launch_default_for_uri(link.c_str(), nullptr, nullptr);
+#else
+    std::vector<std::string> argv = { "xdg-open", link};
+    Glib::spawn_async("", argv, Glib::SpawnFlags::SPAWN_SEARCH_PATH);
+    // g_app_info_launch_default_for_uri(link.c_str(), nullptr, nullptr); // doesn't work on KDE
+#endif
+}
+
 // Open Filepath with External App
 void external_filepath_open(const fs::path& filepath, bool open_folder_if_file_not_exists, CtConfig* config)
 {
@@ -144,8 +155,9 @@ void external_filepath_open(const fs::path& filepath, bool open_folder_if_file_n
 #ifdef _WIN32
             ShellExecute(GetActiveWindow(), "open", filepath.c_str(), NULL, NULL, SW_SHOWNORMAL);
 #else
-            std::string f_path = "file://" + filepath.string();
-            g_app_info_launch_default_for_uri(f_path.c_str(), nullptr, nullptr);
+            std::vector<std::string> argv = { "xdg-open", "file://" + filepath.string() };
+            Glib::spawn_async("", argv, Glib::SpawnFlags::SPAWN_SEARCH_PATH);
+            // g_app_info_launch_default_for_uri(f_path.c_str(), nullptr, nullptr); // doesn't work on KDE
 #endif
         }
     }
@@ -169,8 +181,9 @@ void external_folderpath_open(const fs::path& folderpath, CtConfig* config)
         std::vector<std::string> argv = { "open", folderpath.string() };
         Glib::spawn_async("", argv, Glib::SpawnFlags::SPAWN_SEARCH_PATH);
 #else
-        std::string f_path = "file://" + folderpath.string();
-        g_app_info_launch_default_for_uri(f_path.c_str(), nullptr, nullptr);
+        std::vector<std::string> argv = { "xdg-open", "file://" + folderpath.string() };
+        Glib::spawn_async("", argv, Glib::SpawnFlags::SPAWN_SEARCH_PATH);
+        // g_app_info_launch_default_for_uri(f_path.c_str(), nullptr, nullptr); // doesn't work on KDE
 #endif
     }
 }

--- a/future/src/ct/ct_filesystem.h
+++ b/future/src/ct/ct_filesystem.h
@@ -58,9 +58,9 @@ std::uintmax_t file_size(const path& path);
 
 std::list<path> get_dir_entries(const path& dir);
 
-void external_weblink_open(const std::string& link);
-void external_filepath_open(const path& filepath, bool open_folder_if_file_not_exists, CtConfig* config);
-void external_folderpath_open(const path& folderpath, CtConfig* config);
+void open_weblink(const std::string& link);
+void open_filepath(const path& filepath, bool open_folder_if_file_not_exists, CtConfig* config);
+void open_folderpath(const path& folderpath, CtConfig* config);
 
 path prepare_export_folder(const path& dir_place, path new_folder, bool overwrite_existing);
 

--- a/future/src/ct/ct_filesystem.h
+++ b/future/src/ct/ct_filesystem.h
@@ -58,6 +58,7 @@ std::uintmax_t file_size(const path& path);
 
 std::list<path> get_dir_entries(const path& dir);
 
+void external_weblink_open(const std::string& link);
 void external_filepath_open(const path& filepath, bool open_folder_if_file_not_exists, CtConfig* config);
 void external_folderpath_open(const path& folderpath, CtConfig* config);
 


### PR DESCRIPTION
Fixes #1004. 
- use `xdg-open` to open files/directories/links on linux (fiy, inkscape do the same). 
- renames related functions.

