### PR TITLE
addes abitlity to create several toolbars

### DIFF
--- a/future/src/ct/ct_actions.h
+++ b/future/src/ct/ct_actions.h
@@ -235,7 +235,7 @@ private:
 public:
     // view actions
     void toggle_show_hide_tree();
-    void toggle_show_hide_toolbar();
+    void toggle_show_hide_toolbars();
     void toggle_show_hide_node_name_header();
     void toggle_tree_text();
     void nodes_expand_all();

--- a/future/src/ct/ct_actions_view.cc
+++ b/future/src/ct/ct_actions_view.cc
@@ -40,10 +40,10 @@ void CtActions::toggle_show_hide_tree()
 }
 
 // Toggle Show/Hide the Toolbar
-void CtActions::toggle_show_hide_toolbar()
+void CtActions::toggle_show_hide_toolbars()
 {
     _pCtMainWin->get_ct_config()->toolbarVisible = !_pCtMainWin->get_ct_config()->toolbarVisible;
-    _pCtMainWin->show_hide_toolbar(_pCtMainWin->get_ct_config()->toolbarVisible);
+    _pCtMainWin->show_hide_toolbars(_pCtMainWin->get_ct_config()->toolbarVisible);
 }
 
 void CtActions::toggle_show_hide_node_name_header()
@@ -81,7 +81,7 @@ void CtActions::toolbar_icons_size_increase()
         return;
     }
     _pCtMainWin->get_ct_config()->toolbarIconSize += 1;
-    _pCtMainWin->set_toolbar_icon_size(_pCtMainWin->get_ct_config()->toolbarIconSize);
+    _pCtMainWin->set_toolbars_icon_size(_pCtMainWin->get_ct_config()->toolbarIconSize);
 }
 
 // Decrease the Size of the Toolbar Icons
@@ -92,7 +92,7 @@ void CtActions::toolbar_icons_size_decrease()
         return;
     }
     _pCtMainWin->get_ct_config()->toolbarIconSize -= 1;
-    _pCtMainWin->set_toolbar_icon_size(_pCtMainWin->get_ct_config()->toolbarIconSize);
+    _pCtMainWin->set_toolbars_icon_size(_pCtMainWin->get_ct_config()->toolbarIconSize);
 }
 
 // Toggle Fullscreen State

--- a/future/src/ct/ct_const.h
+++ b/future/src/ct/ct_const.h
@@ -207,6 +207,7 @@ const inline static std::array<const gchar*, 4> TAG_ALIGNMENTS {
     TAG_PROP_VAL_FILL
 };
 
+const inline static gchar* TOOLBAR_SPLIT {"toolbar_split"};
 const inline static gchar* TOOLBAR_VEC_DEFAULT {
     "tree_add_node,tree_add_subnode,separator,go_node_prev,go_node_next,"
     "separator,*,ct_save,export_pdf,separator,"

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -87,10 +87,11 @@ CtMainWin::CtMainWin(bool             no_gui,
     _pSpecialCharsSubmenu = CtMenu::find_menu_item(_pMenuBar, "SpecialCharsMenu");
     _pMenuBar->show_all();
     gtk_window_add_accel_group(GTK_WINDOW(gobj()), _uCtMenu->default_accel_group());
-    _pToolbar = _uCtMenu->build_toolbar(_pRecentDocsMenuToolButton);
+    _pToolbars = _uCtMenu->build_toolbars(_pRecentDocsMenuToolButton);
 
     _vboxMain.pack_start(*_pMenuBar, false, false);
-    _vboxMain.pack_start(*_pToolbar, false, false);
+    for (auto pToolbar: _pToolbars)
+        _vboxMain.pack_start(*pToolbar, false, false);
     _vboxMain.pack_start(_hPaned);
     _vboxMain.pack_start(_init_status_bar(), false, false);
     _vboxMain.show_all();
@@ -521,7 +522,7 @@ void CtMainWin::config_apply()
     _ctWinHeader.lockIcon.hide();
     _ctWinHeader.bookmarkIcon.hide();
 
-    menu_rebuild_toolbar(false);
+    menu_rebuild_toolbars(false);
 
     _ctStatusBar.progressBar.hide();
     _ctStatusBar.stopButton.hide();
@@ -801,21 +802,27 @@ void CtMainWin::menu_set_visible_exit_app(bool visible)
     CtMenu::find_menu_item(_pMenuBar, "exit_app")->set_visible(visible);
 }
 
-void CtMainWin::menu_rebuild_toolbar(bool new_toolbar)
+void CtMainWin::menu_rebuild_toolbars(bool new_toolbar)
 {
     if (new_toolbar)
     {
-        _vboxMain.remove(*_pToolbar);
-        _pToolbar = _uCtMenu->build_toolbar(_pRecentDocsMenuToolButton);
-        _vboxMain.pack_start(*_pToolbar, false, false);
-        _vboxMain.reorder_child(*_pToolbar, 1);
+        for (auto pToolbar: _pToolbars)
+            _vboxMain.remove(*pToolbar);
+        _pToolbars = _uCtMenu->build_toolbars(_pRecentDocsMenuToolButton);
+        for (auto toolbar = _pToolbars.rbegin(); toolbar != _pToolbars.rend(); ++toolbar)
+        {
+            _vboxMain.pack_start(*(*toolbar), false, false);
+            _vboxMain.reorder_child(*(*toolbar), 1);
+        }
         menu_set_items_recent_documents();
-        _pToolbar->show_all();
+        for (auto pToolbar: _pToolbars)
+            pToolbar->show_all();
     }
 
-    show_hide_toolbar(_pCtConfig->toolbarVisible);
-    _pToolbar->set_toolbar_style(Gtk::ToolbarStyle::TOOLBAR_ICONS);
-    set_toolbar_icon_size(_pCtConfig->toolbarIconSize);
+    show_hide_toolbars(_pCtConfig->toolbarVisible);
+    for (auto pToolbar: _pToolbars)
+        pToolbar->set_toolbar_style(Gtk::ToolbarStyle::TOOLBAR_ICONS);
+    set_toolbars_icon_size(_pCtConfig->toolbarIconSize);
 }
 
 

--- a/future/src/ct/ct_main_win.h
+++ b/future/src/ct/ct_main_win.h
@@ -164,14 +164,14 @@ public:
     void menu_set_items_recent_documents();
     void menu_set_items_special_chars();
     void menu_set_visible_exit_app(bool visible);
-    void menu_rebuild_toolbar(bool new_toolbar);
+    void menu_rebuild_toolbars(bool new_toolbar);
 
     void config_switch_tree_side();
 
-    void show_hide_toolbar(bool visible)    { _pToolbar->property_visible() = visible; }
+    void show_hide_toolbars(bool visible)   { for (auto pToolbar: _pToolbars) pToolbar->property_visible() = visible; }
+    void set_toolbars_icon_size(int size)   { for (auto pToolbar: _pToolbars) pToolbar->property_icon_size() = CtMiscUtil::getIconSize(size); }
     void show_hide_tree_view(bool visible)  { _scrolledwindowTree.property_visible() = visible; }
     void show_hide_win_header(bool visible) { _ctWinHeader.headerBox.property_visible() = visible; }
-    void set_toolbar_icon_size(int size)    { _pToolbar->property_icon_size() = CtMiscUtil::getIconSize(size); }
 
     void resetPrevTreeIter()                { _prevTreeIter = CtTreeIter(); }
 
@@ -223,7 +223,7 @@ private:
     Gtk::VBox                    _vboxText;
     Gtk::HPaned                  _hPaned;
     Gtk::MenuBar*                _pMenuBar{nullptr};
-    Gtk::Toolbar*                _pToolbar{nullptr};
+    std::vector<Gtk::Toolbar*>   _pToolbars;
     CtStatusBar                  _ctStatusBar;
     CtWinHeader                  _ctWinHeader;
     Gtk::MenuItem*               _pBookmarksSubmenu{nullptr};

--- a/future/src/ct/ct_menu.h
+++ b/future/src/ct/ct_menu.h
@@ -76,18 +76,18 @@ public:
     static Gtk::MenuItem*   find_menu_item(Gtk::MenuBar* menuBar, std::string name);
     static Gtk::AccelLabel* get_accel_label(Gtk::MenuItem* item);
 
-    Gtk::Toolbar* build_toolbar(Gtk::MenuToolButton*& pRecentDocsMenuToolButton);
-    Gtk::MenuBar* build_menubar();
-    Gtk::Menu*    build_bookmarks_menu(std::list<std::pair<gint64, std::string>>& bookmarks,
-                                       sigc::slot<void, gint64>& bookmark_action);
-    Gtk::Menu*    build_recent_docs_menu(const CtRecentDocsFilepaths& recentDocsFilepaths,
-                                         sigc::slot<void, const std::string&>& recent_doc_open_action,
-                                         sigc::slot<void, const std::string&>& recent_doc_rm_action);
-    Gtk::Menu*    build_special_chars_menu(const Glib::ustring& specialChars,
-                                           sigc::slot<void, gunichar>& spec_char_action);
+    std::vector<Gtk::Toolbar*> build_toolbars(Gtk::MenuToolButton*& pRecentDocsMenuToolButton);
+    Gtk::MenuBar*              build_menubar();
+    Gtk::Menu*                 build_bookmarks_menu(std::list<std::pair<gint64, std::string>>& bookmarks,
+                                                    sigc::slot<void, gint64>& bookmark_action);
+    Gtk::Menu*                 build_recent_docs_menu(const CtRecentDocsFilepaths& recentDocsFilepaths,
+                                                      sigc::slot<void, const std::string&>& recent_doc_open_action,
+                                                      sigc::slot<void, const std::string&>& recent_doc_rm_action);
+    Gtk::Menu*                 build_special_chars_menu(const Glib::ustring& specialChars,
+                                                        sigc::slot<void, gunichar>& spec_char_action);
 
-    Gtk::Menu*    get_popup_menu(POPUP_MENU_TYPE popupMenuType);
-    Gtk::Menu*    build_popup_menu(GtkWidget* pMenu, POPUP_MENU_TYPE popupMenuType);
+    Gtk::Menu*                 get_popup_menu(POPUP_MENU_TYPE popupMenuType);
+    Gtk::Menu*                 build_popup_menu(GtkWidget* pMenu, POPUP_MENU_TYPE popupMenuType);
 
 private:
     GtkWidget*     _walk_menu_xml(GtkWidget* pMenu, const char* document, const char* xpath);
@@ -103,13 +103,13 @@ private:
     static void    _add_menu_item_image_or_label(Gtk::Widget* pMenuItem, const char* image, GtkWidget* pLabel);
     GtkWidget*     _add_separator(GtkWidget* pMenu);
 
-    std::string _get_ui_str_toolbar();
-    const char* _get_ui_str_menu();
-    const char* _get_popup_menu_ui_str_text();
-    const char* _get_popup_menu_ui_str_code();
-    const char* _get_popup_menu_ui_str_image();
-    const char* _get_popup_menu_ui_str_anchor();
-    const char* _get_popup_menu_ui_str_embfile();
+    std::vector<std::string> _get_ui_str_toolbars();
+    const char*              _get_ui_str_menu();
+    const char*              _get_popup_menu_ui_str_text();
+    const char*              _get_popup_menu_ui_str_code();
+    const char*              _get_popup_menu_ui_str_image();
+    const char*              _get_popup_menu_ui_str_anchor();
+    const char*              _get_popup_menu_ui_str_embfile();
 
 private:
     CtConfig*                  _pCtConfig;

--- a/modules/config.py
+++ b/modules/config.py
@@ -164,6 +164,7 @@ def get_toolbar_ui_str(dad):
     for i, toolbar_element in enumerate(dad.toolbar_ui_list):
         if toolbar_element == cons.CHAR_STAR: dad.toolbar_open_n_recent = i
         elif toolbar_element == cons.TAG_SEPARATOR: toolbar_ui_str += "<separator/>"
+        elif toolbar_element == menus.TOOLBAR_SPLIT: pass
         else: toolbar_ui_str += "<toolitem action='%s'/>" % toolbar_element
     return toolbar_ui_str + "</toolbar></ui>"
 

--- a/modules/menus.py
+++ b/modules/menus.py
@@ -878,6 +878,7 @@ UI_INFO = """
 </ui>
 """
 
+TOOLBAR_SPLIT = "toolbar_split"
 TOOLBAR_VEC_DEFAULT = ["tree_add_node", "tree_add_subnode", cons.TAG_SEPARATOR, "go_node_prev", "go_node_next", cons.TAG_SEPARATOR, cons.CHAR_STAR, "ct_save", "export_pdf", cons.TAG_SEPARATOR, "find_in_allnodes", cons.TAG_SEPARATOR, "handle_bull_list", "handle_num_list", "handle_todo_list", cons.TAG_SEPARATOR, "handle_image", "handle_table", "handle_codebox", "handle_embfile", "handle_link", "handle_anchor", cons.TAG_SEPARATOR, "fmt_rm", "fmt_color_fg", "fmt_color_bg", "fmt_bold", "fmt_italic", "fmt_underline", "fmt_strikethrough", "fmt_h1", "fmt_h2", "fmt_h3", "fmt_small", "fmt_superscript", "fmt_subscript", "fmt_monospace"]
 
-TOOLBAR_VEC_BLACKLIST = ["anch_cut", "anch_copy", "anch_del", "anch_edit", "emb_file_cut", "emb_file_copy", "emb_file_del", "emb_file_save", "emb_file_open", "img_save", "img_edit", "img_cut", "img_copy", "img_del", "img_link_edit", "img_link_dismiss", "toggle_show_mainwin"]
+TOOLBAR_VEC_BLACKLIST = [TOOLBAR_SPLIT, "anch_cut", "anch_copy", "anch_del", "anch_edit", "emb_file_cut", "emb_file_copy", "emb_file_del", "emb_file_save", "emb_file_open", "img_save", "img_edit", "img_cut", "img_copy", "img_del", "img_link_edit", "img_link_dismiss", "toggle_show_mainwin"]


### PR DESCRIPTION
Resolves #1010
- adds a special element "Split Toolbar" in Preference dlg to split and thus to create more toolbars than one. Maybe we need a new icon for it.
- fixes pygtk which doesn't work well with a new toolbar element
- renames functions from `toolbar` to `toolbars`