### PR TITLE
Fix pdf exporting issues after refractor

### DIFF
--- a/future/src/ct/ct_export2pdf.cc
+++ b/future/src/ct/ct_export2pdf.cc
@@ -366,10 +366,7 @@ void CtExport2Pdf::_nodes_all_export_print_iter(const CtTreeIter& tree_iter, con
 {
     CtPrintableVector node_printables;
 
-    // Push front node name
-    if (options.include_node_name) {
-        node_printables.emplace_back(generate_node_name_printable(tree_iter.get_node_name(), tree_iter.get_node_id()));
-    }
+   
 
     if (tree_iter.get_node_is_rich_text())
     {
@@ -381,6 +378,10 @@ void CtExport2Pdf::_nodes_all_export_print_iter(const CtTreeIter& tree_iter, con
         node_printables.emplace_back(std::make_shared<CtTextPrintable>(CtExport2Pango().pango_get_from_code_buffer(tree_iter.get_node_text_buffer(), -1, -1)));
     }
 
+     // Push front node name
+    if (options.include_node_name) {
+        node_printables.emplace(node_printables.cbegin(), generate_node_name_printable(tree_iter.get_node_name(), tree_iter.get_node_id()));
+    }
     
 
     std::shared_ptr<CtPrintable> break_printable;

--- a/future/src/ct/ct_export2pdf.cc
+++ b/future/src/ct/ct_export2pdf.cc
@@ -366,7 +366,10 @@ void CtExport2Pdf::_nodes_all_export_print_iter(const CtTreeIter& tree_iter, con
 {
     CtPrintableVector node_printables;
 
-   
+    // Push front node name
+    if (options.include_node_name) {
+        node_printables.emplace_back(generate_node_name_printable(tree_iter.get_node_name(), tree_iter.get_node_id()));
+    }
 
     if (tree_iter.get_node_is_rich_text())
     {
@@ -377,11 +380,10 @@ void CtExport2Pdf::_nodes_all_export_print_iter(const CtTreeIter& tree_iter, con
     {
         node_printables.emplace_back(std::make_shared<CtTextPrintable>(CtExport2Pango().pango_get_from_code_buffer(tree_iter.get_node_text_buffer(), -1, -1)));
     }
-
-     // Push front node name
     if (options.include_node_name) {
-        node_printables.emplace(node_printables.cbegin(), generate_node_name_printable(tree_iter.get_node_name(), tree_iter.get_node_id()));
+        assert(node_printables.size() >= 1);
     }
+    
     
 
     std::shared_ptr<CtPrintable> break_printable;
@@ -390,7 +392,10 @@ void CtExport2Pdf::_nodes_all_export_print_iter(const CtTreeIter& tree_iter, con
     } else {
         break_printable = std::make_shared<CtTextPrintable>(str::repeat(CtConst::CHAR_NEWLINE, 3));
     }
-    node_printables.emplace_back(break_printable);
+    if (!tree_printables.empty()) {
+        // Not first page
+        tree_printables.emplace_back(break_printable);
+    }
 
     tree_printables.insert(tree_printables.cend(), node_printables.cbegin(), node_printables.cend());  
 
@@ -653,7 +658,6 @@ void CtExport2Pango::pango_get_from_treestore_node(CtTreeIter node_iter, int sel
     if (exclude_anchors) {
         out_widgets.remove_if([](CtAnchoredWidget* widget) { return dynamic_cast<CtImageAnchor*>(widget); });
     }
-    out_printables.clear();
     int start_offset = sel_start < 1 ? 0 : sel_start;
     for (auto widget: out_widgets)
     {

--- a/future/src/ct/ct_export2pdf.h
+++ b/future/src/ct/ct_export2pdf.h
@@ -137,7 +137,7 @@ public:
 
     double height() const override;
     double width() const override;
-    double height_when_wrapped(double space) const override { return space; }
+    double height_when_wrapped(double space) const override;
 
 private:
     double _p_height;

--- a/future/src/ct/ct_export2pdf.h
+++ b/future/src/ct/ct_export2pdf.h
@@ -137,7 +137,7 @@ public:
 
     double height() const override;
     double width() const override;
-    double height_when_wrapped(double) const override { return height(); }
+    double height_when_wrapped(double space) const override { return space; }
 
 private:
     double _p_height;
@@ -234,13 +234,13 @@ class CtPrintCodeboxProxy : public CtPrintWidgetProxy
 public:
     CtPrintCodeboxProxy(CtCodebox* codebox) : _codebox(codebox), _use_proxy_text(false) {}
     CtPrintCodeboxProxy(CtCodebox* codebox, const Glib::ustring& proxy_text) : _codebox(codebox),_proxy_text(proxy_text), _use_proxy_text(true)  {}
-    CtCodebox*          get_codebox()          { return _codebox; }
-    bool                get_width_in_pixels()  { return _codebox->get_width_in_pixels(); }
-    int                 get_frame_width()      { return _codebox->get_frame_width(); }
-    const Glib::ustring get_text_content()     { return _use_proxy_text ? _proxy_text : pango_from_code_buffer(_codebox); }
+    CtCodebox*          get_codebox()         const { return _codebox; }
+    bool                get_width_in_pixels() const { return _codebox->get_width_in_pixels(); }
+    int                 get_frame_width() const     { return _codebox->get_frame_width(); }
+    const Glib::ustring get_text_content()    const { return _use_proxy_text ? _proxy_text : pango_from_code_buffer(_codebox); }
     void                set_proxy_content(const Glib::ustring& text) { _proxy_text = text; _use_proxy_text = true; }
 
-    Glib::ustring       pango_from_code_buffer(CtCodebox* codebox); // couldn't use CtExport2Pango in .h, so created helper function
+    Glib::ustring       pango_from_code_buffer(CtCodebox* codebox) const; // couldn't use CtExport2Pango in .h, so created helper function
 
 private:
     CtCodebox*    _codebox;
@@ -308,18 +308,8 @@ public:
 
 
 private:
-    struct DrawContext {
-        double height;
-        double width;
-        double x;
-        double y;
-    };
-
     Glib::RefPtr<Pango::Layout> _layout;
-    Glib::RefPtr<Pango::Layout> _calc_layout(const PrintInfo& print_info) const;
-
-    static void _draw_box(const Cairo::RefPtr<Cairo::Context>& cairo_context, const DrawContext& draw_context);
-    void _draw_code(const Cairo::RefPtr<Cairo::Context>& cairo_context, const DrawContext& draw_context);
+    std::size_t _drawn_lines = 0;
 };
 
 using CtWidgetSomePrintable = CtWidgetPrintable<CtPrintSomeProxy>;

--- a/future/src/ct/ct_table.h
+++ b/future/src/ct/ct_table.h
@@ -73,8 +73,8 @@ public:
     std::shared_ptr<CtAnchoredWidgetState> get_state() override;
 
     const CtTableMatrix& get_table_matrix() const { return _tableMatrix; }
-    constexpr int get_col_max() const { return _colMax; }
-    constexpr int get_col_min() const { return _colMin; }
+    int get_col_max() const { return _colMax; }
+    int get_col_min() const { return _colMin; }
 public:
     int  current_row() { return _currentRow < (int)_tableMatrix.size() ? _currentRow : 0; }
     int  current_column() { return _currentColumn < (int)_tableMatrix[0].size() ? _currentColumn : 0; }

--- a/future/src/ct/ct_table.h
+++ b/future/src/ct/ct_table.h
@@ -72,9 +72,9 @@ public:
     CtAnchWidgType get_type() override { return CtAnchWidgType::Table; }
     std::shared_ptr<CtAnchoredWidgetState> get_state() override;
 
-    const CtTableMatrix& get_table_matrix() { return _tableMatrix; }
-    int get_col_max() { return _colMax; }
-    int get_col_min() { return _colMin; }
+    const CtTableMatrix& get_table_matrix() const { return _tableMatrix; }
+    constexpr int get_col_max() const { return _colMax; }
+    constexpr int get_col_min() const { return _colMin; }
 public:
     int  current_row() { return _currentRow < (int)_tableMatrix.size() ? _currentRow : 0; }
     int  current_column() { return _currentColumn < (int)_tableMatrix[0].size() ? _currentColumn : 0; }


### PR DESCRIPTION
This fixes several issues introduced with the refractor of pdf exporting. 
- Codeboxes and tables will now extend over several pages.
- Page breaks are now properly calculated as part of required page number.
- Wrapping is now accounted for when calculating the number of pages.

I have tested this with ~200, ~2000, and ~4000 page documents. Note that page breaks are appended on the end of each page, which causes an extra page on the end of any document using page breaks. I do not see this as much of an issue but it would be a trivial fix if needed.


Fixes: #1012 
