### PR TITLE
File Attachment Type-Based Icons

### DIFF
--- a/future/src/ct/ct_image.cc
+++ b/future/src/ct/ct_image.cc
@@ -283,7 +283,7 @@ CtImageEmbFile::CtImageEmbFile(CtMainWin* pCtMainWin,
                                const double& timeSeconds,
                                const int charOffset,
                                const std::string& justification)
- : CtImage(pCtMainWin, "ct_file_icon", pCtMainWin->get_ct_config()->embfileSize, charOffset, justification),
+ : CtImage(pCtMainWin, _get_icon_for_file(fileName.string()).c_str(), pCtMainWin->get_ct_config()->embfileSize, charOffset, justification),
    _fileName(fileName),
    _rawBlob(rawBlob),
    _timeSeconds(timeSeconds)
@@ -291,6 +291,33 @@ CtImageEmbFile::CtImageEmbFile(CtMainWin* pCtMainWin,
     signal_button_press_event().connect(sigc::mem_fun(*this, &CtImageEmbFile::_on_button_press_event), false);
     update_tooltip();
     update_label_widget();
+}
+
+const std::string CtImageEmbFile::_get_icon_for_file(const std::string& filename)
+{
+    //default icon
+    std::string result = "ct_file_icon";
+    char* content_type = g_content_type_guess(filename.c_str(), NULL, 0, NULL);
+    if (content_type != NULL)
+    {
+        char* mime_type = g_content_type_get_mime_type(content_type);
+        g_free(content_type);
+
+        if(mime_type != NULL)
+        {
+            char* icon_name = g_content_type_get_generic_icon_name(mime_type);
+            g_free(mime_type);
+
+            if(icon_name != NULL)
+            {
+                //Use the default icon for 'generic' filetypes
+                if(strcmp(icon_name,"application-x-generic") != 0)
+                    result = icon_name;
+                g_free(icon_name);
+            }
+        }
+    }
+    return result;
 }
 
 void CtImageEmbFile::to_xml(xmlpp::Element* p_node_parent, const int offset_adjustment, CtStorageCache*)

--- a/future/src/ct/ct_image.h
+++ b/future/src/ct/ct_image.h
@@ -142,6 +142,7 @@ public:
 private:
     bool _on_button_press_event(GdkEventButton* event);
     const std::string _get_icon_for_file(const std::string& filename);
+    Glib::RefPtr<Gdk::Pixbuf> _get_icon_pixbuf_for_file(const std::string& filename, int size);
 
 protected:
     fs::path      _fileName;

--- a/future/src/ct/ct_image.h
+++ b/future/src/ct/ct_image.h
@@ -141,6 +141,7 @@ public:
 
 private:
     bool _on_button_press_event(GdkEventButton* event);
+    const std::string _get_icon_for_file(const std::string& filename);
 
 protected:
     fs::path      _fileName;


### PR DESCRIPTION
Implements https://github.com/giuspen/cherrytree/issues/1027 on Linux.

Note that I included two different implementations, which produce different icon results.  The first is _get_icon_for_file(), which looks like:

![2020-07-22 20 05 09](https://user-images.githubusercontent.com/1877409/88248623-aecac700-cc56-11ea-8ad2-ba4e2573e9bb.png)

However, as this didn't produce unique icons on Windows, I tried a second approach, which is implemented in _get_icon_pixbuf_for_file(). On the same system as above, it looks like:

![2020-07-22 21 03 48](https://user-images.githubusercontent.com/1877409/88251204-e3db1780-cc5e-11ea-9c2b-ffaf743f226c.png)

I prefer the second, as it more accurately represents what I see in my file browser.  But I'm leaving both in this PR, because unfortunately this didn't produce icons in Windows either - so I figure having both could provide options for future expansion (not sure which would ultimately be easier to extend to Windows). Also, in the event that some issue is discovered later, swapping back & forth just requires calling the other function.  Easy drop-in :)