### PR TITLE
Add travis bionic build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,11 @@ before_install:
         sudo apt install build-essential libgtkmm-3.0-dev xvfb
         sudo apt install libgtksourceviewmm-3.0-dev libxml++2.6-dev libsqlite3-dev
         sudo apt install libcpputest-dev gettext python3-lxml libgspell-1-dev libcurl4-openssl-dev
+        
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+        sudo apt update
+        sudo apt install gcc-9 g++-9 -y
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9 
         ;;
       windows)
         [[ ! -f C:/tools/msys64/msys2_shell.cmd ]] && rm -rf C:/tools/msys64

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ jobs:
       addons:
         apt:
           update: true
+    - os: linux
+      dist: bionic
+      cache: apt
+      addons:
+        apt:
+          update: true
     - os: windows
     - os: osx
       osx_image: xcode11.4
@@ -59,12 +65,7 @@ install:
       linux)
         export DEPS_DIR="${HOME}/deps"
         mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
-        export CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0-Linux-x86_64.tar.gz";
-        mkdir cmake;
-        travis_retry wget --no-check-certificate -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake;
-        export PATH=${DEPS_DIR}/cmake/bin:${PATH};
-        echo ${PATH};
-        cmake --version
+        
         ;;
       windows)
         $mingw64 wget https://github.com/cpputest/cpputest/releases/download/v3.8/cpputest-3.8.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,12 +66,7 @@ before_install:
     esac
 install:
 - |-
-    case $TRAVIS_OS_NAME in
-      linux)
-        export DEPS_DIR="${HOME}/deps"
-        mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
-        
-        ;;
+    case $TRAVIS_OS_NAME in  
       windows)
         $mingw64 wget https://github.com/cpputest/cpputest/releases/download/v3.8/cpputest-3.8.tar.gz
         $mingw64 tar xf cpputest-3.8.tar.gz


### PR DESCRIPTION
This adds a bionic build to travis. 

In order to get it to build on bionic I had to install gcc9 from the "testing" toolchain repo. I have also removed the cmake build from source since it is no longer needed.

~~Build times are _much_ faster now, testing this it took 8-9 minutes to build the linux ones vs the 20+ minutes it used to take~~ nvm I am wrong, this does not seem to affect build times