### PR TITLE
Redesign pdf export

### DIFF
--- a/future/src/ct/ct_export2pdf.cc
+++ b/future/src/ct/ct_export2pdf.cc
@@ -296,7 +296,7 @@ CtPrint::CtPrint()
 {
     _pPrintSettings = Gtk::PrintSettings::create();
     _pPageSetup = Gtk::PageSetup::create();
-    //_pPageSetup->set_paper_size(Gtk::PaperSize("iso_a4"));
+    _pPageSetup->set_paper_size(Gtk::PaperSize("iso_a4"));
 }
 
 void CtPrint::run_page_setup_dialog(Gtk::Window* pWin)
@@ -493,6 +493,17 @@ void CtPrint::_process_pango_text(CtPrintData* print_data, CtPangoText* text_slo
 
         if (!pages.last_line().test_element_height(size.height, _page_height))
             pages.line_on_new_page();
+
+        // situation when a bit of space is left but pango cannot wrap the first word
+        // make it on a new line
+        if (text_slot->text != "\n" && pages.last_line().cur_x > 0)
+            if (pages.last_line().cur_x + size.width > _page_width)
+            {
+                pages.new_line();
+                _process_pango_text(print_data, text_slot);
+                return;
+            }
+
 
         pages.last_line().set_height(size.height);
         if (tag_name.empty())

--- a/future/src/ct/ct_export2pdf.h
+++ b/future/src/ct/ct_export2pdf.h
@@ -26,139 +26,52 @@
 #include <iterator>
 
 
-struct CtPrintData;
-class CtPrintWidgetProxy;
-/**
- * @brief Interface for printables used by pdf exporter
- */
-class CtPrintable 
+struct CtPangoObject
+{
+    virtual ~CtPangoObject() = default;
+};
+struct CtPangoNewPage : public CtPangoObject
+{
+
+};
+struct CtPangoText : public CtPangoObject
+{
+    CtPangoText(const Glib::ustring& text, const Glib::ustring& synt_highl) : text(text), synt_highl(synt_highl) {}
+    Glib::ustring text;
+    Glib::ustring synt_highl;
+};
+struct CtPangoLink : public CtPangoText
+{
+    CtPangoLink(const Glib::ustring& text, const Glib::ustring& link) : CtPangoText(text, CtConst::RICH_TEXT_ID), link(link) {}
+    Glib::ustring link;
+};
+struct CtPangoDest : public CtPangoText
+{
+    CtPangoDest(const Glib::ustring& text, const Glib::ustring& synt_highl, const Glib::ustring& dest) : CtPangoText(text, synt_highl), dest(dest) {}
+    Glib::ustring dest;
+};
+struct CtPangoWidget : public CtPangoObject
+{
+    CtPangoWidget(CtAnchoredWidget* widget) : widget(widget) {}
+    CtAnchoredWidget* widget;
+};
+using CtPangoObjectPtr = std::shared_ptr<CtPangoObject>;
+
+
+
+class CtExport2Pango
 {
 public:
-    struct PrintInfo {
-        Glib::RefPtr<Gtk::PrintContext> print_context;
-        Pango::FontDescription font;
-        Pango::FontDescription codebox_font;
-        double page_width;
-        double page_height;
-        double newline_height;
-        int table_line_thickness;
-        int text_window_width;
-    };
-    struct PrintPosition {
-        double x;
-        double y;
-    };
-    struct PrintingContext {
-        Cairo::RefPtr<Cairo::Context> cairo_context;
-        PrintInfo print_info;
-        CtPrintData& print_data;
-        PrintPosition position;
-    };
-
-    virtual void setup(const PrintInfo& print_info) = 0;
-    virtual PrintPosition print(const PrintingContext& context) = 0;
-    [[nodiscard]] virtual double height() const = 0;
-    [[nodiscard]] virtual double width() const = 0;
-    [[nodiscard]] constexpr bool done() const { return _done; }
-    virtual double height_when_wrapped(double space_left) const = 0;
-
-    virtual ~CtPrintable() = default;
-protected:
-    bool _done = false;
-};
-
-class CtTextPrintable: public CtPrintable
-{
-public:
-    explicit CtTextPrintable(Glib::ustring text) : _text(std::move(text)) {}
-
-    void setup(const PrintInfo& print_info) override;
-
-    PrintPosition print(const PrintingContext& context) override;
-
-    [[nodiscard]] double height() const override;
-    [[nodiscard]] double width() const override;
-    [[nodiscard]] std::size_t lines() const;
-    [[nodiscard]] const Glib::RefPtr<Pango::Layout>& layout() const { return _layout; }
-    [[nodiscard]] constexpr bool is_newline() const { return _is_newline; }
-    [[nodiscard]] const Glib::ustring& text() const { return _text; }
-    double height_when_wrapped(double) const override { return height(); }
-
-    virtual ~CtTextPrintable() = default;
-private:
-    Glib::ustring _text;
-    Glib::RefPtr<Pango::Layout> _layout;
-    bool _is_newline = false;
-    int _line_index = 0;
-
-    /// Calculate the heights of all the destinct lines 
-    double _calc_lines_heights() const;
-};
-
-/**
- * @brief 
- * 
- */
-
-class CtLinkPrintable: public CtTextPrintable 
-{
-public:
-    CtLinkPrintable(Glib::ustring title, std::string url);
-
-
-    PrintPosition print(const PrintingContext& context) override;
+    Glib::ustring pango_get_from_code_buffer(Glib::RefPtr<Gsv::Buffer> code_buffer, int sel_start, int sel_end);
+    void pango_get_from_treestore_node(CtTreeIter node_iter, int sel_start, int sel_end, std::vector<CtPangoObjectPtr>& out_slots);
 
 private:
-    std::string _url;
-    bool _is_internal = false;
+    std::vector<CtPangoObjectPtr> _pango_process_slot(int start_offset, int end_offset, Glib::RefPtr<Gtk::TextBuffer> curr_buffer);
+    CtPangoObjectPtr              _pango_text_serialize(const Gtk::TextIter& start_iter, Gtk::TextIter end_iter, const std::map<std::string_view, std::string> &curr_attributes);
+    CtPangoObjectPtr              _pango_link(const Glib::ustring& pango_text, const Glib::ustring& url);
 };
 
-class CtDestPrintable: public CtTextPrintable 
-{
-public:
-    CtDestPrintable(Glib::ustring txt, std::string id) : CtTextPrintable(std::move(txt)), _id(std::move(id)) {}
-    CtDestPrintable(CtImageAnchor* anchor, int node_id);
 
-    PrintPosition print(const PrintingContext& context) override;
-
-    ~CtDestPrintable() = default;
-
-private:
-    std::string _id;
-};
-
-class CtPageBreakPrintable: public CtPrintable {
-public:
-    CtPageBreakPrintable() = default;
-
-    void setup(const PrintInfo& print_info) override;
-
-    PrintPosition print(const PrintingContext& context) override;
-
-    double height() const override;
-    double width() const override;
-    double height_when_wrapped(double space) const override;
-
-private:
-    double _p_height;
-};
-
-class CtDefaultWrappable: public CtPrintable {
-public:
-    double height_when_wrapped(double space_left) const override;
-};
-
-template<class WIDGET_TYPE_T>
-class CtWidgetPrintable : public CtDefaultWrappable {
-    using wrap_ptr_t = std::shared_ptr<WIDGET_TYPE_T>;
-public:
-    explicit CtWidgetPrintable(wrap_ptr_t widget_proxy) : _widget_proxy(std::move(widget_proxy)) {}
-
-protected:
-    wrap_ptr_t _widget_proxy;
-};
-
-using CtPrintableVector = std::vector<std::shared_ptr<CtPrintable>>;
 
 class CtExport2Pdf
 {
@@ -170,8 +83,8 @@ public:
     void tree_export_print(const fs::path& pdf_filepath, CtTreeIter tree_iter, const CtExportOptions& options);
 
 private:
-    void _nodes_all_export_print_iter(const CtTreeIter& tree_iter, const CtExportOptions& options,
-                                      CtPrintableVector& tree_printables, Glib::ustring& text_font);
+    void             _nodes_all_export_print_iter(CtTreeIter tree_iter, const CtExportOptions& options, std::vector<CtPangoObjectPtr>& tree_pango_slots);
+    CtPangoObjectPtr _generate_pango_node_name(CtTreeIter tree_iter);
 
 private:
     CtMainWin* _pCtMainWin;
@@ -179,191 +92,122 @@ private:
 
 
 
-// base class for proxy
-class CtPrintWidgetProxy
+struct CtPageElement
 {
-public:
-    virtual ~CtPrintWidgetProxy() {}
+    CtPageElement(int x, int y) : x(x), y(y) {}
+    virtual ~CtPageElement() = default;
+    int x;
+    int y;
 };
-
-// proxy to keep pixbuf
-class CtPrintImageProxy : public CtPrintWidgetProxy
+struct CtPageLine : public CtPageElement
 {
-public:
-    CtPrintImageProxy(CtImage* image) : _image(image) {}
-    CtImage*                  get_image()  { return _image; }
-    Glib::RefPtr<Gdk::Pixbuf> get_pixbuf() { return _image->get_pixbuf(); }
-
-private:
-    CtImage* _image;
+    CtPageLine(int x, int y, Glib::RefPtr<Pango::LayoutLine> layout_line) : CtPageElement(x, y), layout_line(layout_line) {}
+    Glib::RefPtr<Pango::LayoutLine> layout_line;
 };
-
-// proxy to split tables
-class CtPrintTableProxy : public CtPrintWidgetProxy
+struct CtPageTagLine : public CtPageElement
 {
-public:
-    CtPrintTableProxy(CtTable* table, int startRow, int rowNum): _table(table), _startRow(startRow), _rowNum(rowNum) {}
-
-    std::shared_ptr<CtPrintTableProxy> create_new_with(int row_num) { return std::shared_ptr<CtPrintTableProxy>(new CtPrintTableProxy(_table, _startRow, row_num)); }
-
-    void     remove_first_rows(int remove_row_num) { _startRow += remove_row_num; _rowNum -= remove_row_num; }
-    constexpr CtTable* get_table()   const            { return _table; }
-    constexpr int      get_row_num() const            { return _rowNum; }
-    std::size_t      get_col_num() const            { return _table->get_table_matrix().begin()->size(); }
-    // todo: it can work slow because of moving iterators every time; to fix: replace list by vector or use cache
-    Glib::ustring get_cell(int row, int col) const {
-        // 0 row is always header row, 1 row starts from _startRow
-        row = (row == 0) ? 0 : row - 1 + _startRow;
-        auto tableRow = _table->get_table_matrix().begin();
-        std::advance(tableRow, row);
-        auto tableCell = tableRow->begin();
-        std::advance(tableCell, col);
-        return (*tableCell)->get_text_content();
-    }
-
-private:
-    CtTable* _table;
-    int      _startRow;  // never starts from header row (because proxies for the same table have the same header)
-    int      _rowNum;    // includes header row
-
+    CtPageTagLine(int x, int y, Glib::RefPtr<Pango::LayoutLine> layout_line, const std::string& tag_name, const std::string& tag_attr)
+        : CtPageElement(x, y), layout_line(layout_line), tag_name(tag_name), tag_attr(tag_attr) {}
+    Glib::RefPtr<Pango::LayoutLine> layout_line;
+    std::string tag_name;
+    std::string tag_attr;
 };
-
-// proxy to split codebox
-class CtPrintCodeboxProxy : public CtPrintWidgetProxy
+struct CtPageImage : public CtPageElement
 {
-public:
-    CtPrintCodeboxProxy(CtCodebox* codebox) : _codebox(codebox), _use_proxy_text(false) {}
-    CtPrintCodeboxProxy(CtCodebox* codebox, const Glib::ustring& proxy_text) : _codebox(codebox),_proxy_text(proxy_text), _use_proxy_text(true)  {}
-    CtCodebox*          get_codebox()         const { return _codebox; }
-    bool                get_width_in_pixels() const { return _codebox->get_width_in_pixels(); }
-    int                 get_frame_width() const     { return _codebox->get_frame_width(); }
-    const Glib::ustring get_text_content()    const { return _use_proxy_text ? _proxy_text : pango_from_code_buffer(_codebox); }
-    void                set_proxy_content(const Glib::ustring& text) { _proxy_text = text; _use_proxy_text = true; }
-
-    Glib::ustring       pango_from_code_buffer(CtCodebox* codebox) const; // couldn't use CtExport2Pango in .h, so created helper function
-
-private:
-    CtCodebox*    _codebox;
-    Glib::ustring _proxy_text;
-    bool          _use_proxy_text;
+    CtPageImage(int x, int y, CtImage* image, double scale) : CtPageElement(x, y), image(image), scale(scale) {}
+    CtImage* image;
+    double   scale;
 };
-
-// proxy for nullptr and others
-class CtPrintSomeProxy : public CtPrintWidgetProxy
+struct CtPageCodebox : public CtPageElement
 {
-public:
-    CtPrintSomeProxy(CtAnchoredWidget*) {}
+    CtPageCodebox(int x, int y, Glib::RefPtr<Pango::Layout> layout) : CtPageElement(x, y), layout(layout) {}
+    Glib::RefPtr<Pango::Layout> layout;
+};
+struct CtPageTable : public CtPageElement
+{
+    using TableLayouts = std::vector<std::vector<Glib::RefPtr<Pango::Layout>>>;
+    CtPageTable(int x, int y, TableLayouts layouts, int col_min) : CtPageElement(x, y), layouts(layouts), col_min(col_min) {}
+    TableLayouts layouts;
+    int          col_min;
+};
+using CtPageElementPtr = std::shared_ptr<CtPageElement>;
+
+
+struct CtPrintPage
+{
+    std::vector<CtPageElementPtr> elements;
+    int cur_x {0};
+    int cur_y {0};
 };
 
-
-class CtWidgetImagePrintable: public CtWidgetPrintable<CtPrintImageProxy> {
-public:
-    using CtWidgetPrintable::CtWidgetPrintable;
-
-    PrintPosition print(const PrintingContext& context) override;
-
-    void setup(const PrintInfo& print_info) override;
-
-    double width() const override;
-
-    double height() const override;
-
-private:
-    double _last_width = 0;
-    double _last_height = 0;
-};
-
-class CtWidgetTablePrintable: public CtWidgetPrintable<CtPrintTableProxy> {
-public:
-    using tbl_layouts_t = std::vector<std::vector<Glib::RefPtr<Pango::Layout>>>;
-    using tbl_grid_t = std::pair<std::vector<double>, std::vector<double>>;
-    
-    using CtWidgetPrintable::CtWidgetPrintable;
-
-    PrintPosition print(const PrintingContext& context) override;
-
-    double width() const override;
-
-    double height() const override;
-
-    void setup(const PrintInfo& print_info) override;
-private:
-    std::size_t _printed_rows = 0;
-    tbl_layouts_t _tbl_layouts;
-    tbl_grid_t _tbl_grid;
-
-};
-
-class CtWidgetCodeboxPrintable: public CtWidgetPrintable<CtPrintCodeboxProxy> {
-public:
-    using CtWidgetPrintable::CtWidgetPrintable;
-
-    void setup(const PrintInfo& print_info) override;
-
-    PrintPosition print(const PrintingContext& context) override;
-
-    double height() const override;
-
-    double width() const override;
-
-
-private:
-    Glib::RefPtr<Pango::Layout> _layout;
-    std::size_t _drawn_lines = 0;
-};
-
-using CtWidgetSomePrintable = CtWidgetPrintable<CtPrintSomeProxy>;
-
-class CtPrintable;
 // Print Operation Data
 struct CtPrintData
 {
-    std::vector<std::shared_ptr<CtPrintable>> printables;
-    std::size_t                               curr_printable_i = 0;
-    Glib::RefPtr<Gtk::PrintOperation>         operation;
-    Glib::ustring                             warning;
-    int                                       nb_pages;
+    std::vector<CtPangoObjectPtr>      slots;
+
+    Glib::RefPtr<Gtk::PrintOperation>  operation;
+    Glib::RefPtr<Gtk::PrintContext>    context;
+
+    std::vector<CtPrintPage>           pages;
+    Glib::ustring                      warning;
 };
 
 
 class CtPrint
 {
 public:
-    static const int BOX_OFFSET = 4;
+    const int BOX_OFFSET = 4;
 
 public:
     CtPrint();
 
 public:
-    static          Cairo::Rectangle layout_line_get_width_height(Glib::RefPtr<const Pango::LayoutLine> line);
-    static double   get_height_from_layout(Glib::RefPtr<Pango::Layout> layout);
-    static  double  get_width_from_layout(Glib::RefPtr<Pango::Layout> layout);
-
-public:
     void run_page_setup_dialog(Gtk::Window* pMainWin);
+    void print_text(CtMainWin* pCtMainWin, const fs::path& pdf_filepath, const std::vector<CtPangoObjectPtr>& slots);
 
-    void print_text(CtMainWin* pCtMainWin, const fs::path& pdf_filepath,
-                    CtPrintableVector printables, const Glib::ustring& text_font, const Glib::ustring& code_font,
-                    int text_window_width);
-    
 private:
     void _on_begin_print_text(const Glib::RefPtr<Gtk::PrintContext>& context, CtPrintData* print_data);
     void _on_draw_page_text(const Glib::RefPtr<Gtk::PrintContext>& context, int page_nr, CtPrintData* print_data);
 
 private:
+    void _process_pango_text(CtPrintData* print_data, CtPangoText* text_slot);
+    void _process_pango_image(CtPrintData* print_data, CtImage* image, bool& any_image_resized);
+    void _process_pango_codebox(CtPrintData* print_data, CtCodebox* codebox);
+    void _process_pango_table(CtPrintData* print_data, CtTable* table);
+
+    Glib::RefPtr<Pango::Layout> _codebox_get_layout(CtCodebox* codebox, Glib::ustring content, Glib::RefPtr<Gtk::PrintContext> context);
+    void                        _codebox_split_content(CtCodebox* codebox, Glib::ustring original_content, const int check_height, const Glib::RefPtr<Gtk::PrintContext>& context,
+                                                       Glib::ustring& first_split, Glib::ustring& second_split);
+
+    CtPageTable::TableLayouts   _table_get_layouts(CtTable* table, const int first_row, const int last_row, const Glib::RefPtr<Gtk::PrintContext>& context);
+    void                        _table_get_grid(const CtPageTable::TableLayouts& table_layouts, const int col_min, std::vector<double>& rows_h, std::vector<double>& cols_w);
+    double                      _table_get_width_height(std::vector<double>& data);
+    int                         _table_split_content(CtTable* table, const int start_row, const int check_height, const Glib::RefPtr<Gtk::PrintContext>& context);
+
+    void _draw_codebox_box(Cairo::RefPtr<Cairo::Context> cairo_context, double x0, double y0, double codebox_width, double codebox_height);
+    void _draw_codebox_code(Cairo::RefPtr<Cairo::Context> cairo_context, Glib::RefPtr<Pango::Layout> codebox_layout, double x0, double y0);
+    void _draw_table_grid(Cairo::RefPtr<Cairo::Context> cairo_context, const std::vector<double>& rows_h, const std::vector<double>& cols_w,
+                          double x0, double y0, double table_width, double table_height);
+    void _draw_table_text(Cairo::RefPtr<Cairo::Context> cairo_context, const std::vector<double>& rows_h, const std::vector<double>& cols_w,
+                          const CtPageTable::TableLayouts& table_layouts, double x0, double y0);
+
+    Cairo::Rectangle _get_width_height_from_layout_line(Glib::RefPtr<const Pango::LayoutLine> line);
+    double           _get_height_from_layout(Glib::RefPtr<Pango::Layout> layout);
+    double           _get_width_from_layout(Glib::RefPtr<Pango::Layout> layout);
+
+private:
     CtMainWin*                       _pCtMainWin;
     Glib::RefPtr<Gtk::PrintSettings> _pPrintSettings;
     Glib::RefPtr<Gtk::PageSetup>     _pPageSetup;
-    CtPrintable::PrintInfo           _print_info;
-};
 
-class CtExport2Pango
-{
-public:
-    Glib::ustring pango_get_from_code_buffer(Glib::RefPtr<Gsv::Buffer> code_buffer, int sel_start, int sel_end);
-    static void pango_get_from_treestore_node(CtTreeIter node_iter, int sel_start, int sel_end,
-                                              CtPrintableVector& out_printables, bool exclude_anchors);
-private:
-    static CtPrintableVector _pango_process_slot(int start_offset, int end_offset, Glib::RefPtr<Gtk::TextBuffer> curr_buffer);
-    static std::unique_ptr<CtPrintable> _pango_text_serialize(const Gtk::TextIter& start_iter, Gtk::TextIter end_iter, const std::map<std::string_view, std::string> &curr_attributes);
+    Pango::FontDescription           _rich_font;
+    Pango::FontDescription           _plain_font;
+    Pango::FontDescription           _code_font;
+    int                              _text_window_width;
+
+    int                              _table_text_row_height;
+    int                              _table_line_thickness;
+    double                           _layout_newline_height;
+    double                           _page_width;
+    double                           _page_height;
 };

--- a/future/src/ct/ct_export2pdf.h
+++ b/future/src/ct/ct_export2pdf.h
@@ -34,20 +34,20 @@ struct CtPangoNewPage : public CtPangoObject
 {
 
 };
-struct CtPangoText : public CtPangoObject
+struct CtPangoWord : public CtPangoObject
 {
-    CtPangoText(const Glib::ustring& text, const Glib::ustring& synt_highl) : text(text), synt_highl(synt_highl) {}
+    CtPangoWord(const Glib::ustring& text, const Glib::ustring& synt_highl) : text(text), synt_highl(synt_highl) {}
     Glib::ustring text;
     Glib::ustring synt_highl;
 };
-struct CtPangoLink : public CtPangoText
+struct CtPangoLink : public CtPangoWord
 {
-    CtPangoLink(const Glib::ustring& text, const Glib::ustring& link) : CtPangoText(text, CtConst::RICH_TEXT_ID), link(link) {}
+    CtPangoLink(const Glib::ustring& text, const Glib::ustring& link) : CtPangoWord(text, CtConst::RICH_TEXT_ID), link(link) {}
     Glib::ustring link;
 };
-struct CtPangoDest : public CtPangoText
+struct CtPangoDest : public CtPangoWord
 {
-    CtPangoDest(const Glib::ustring& text, const Glib::ustring& synt_highl, const Glib::ustring& dest) : CtPangoText(text, synt_highl), dest(dest) {}
+    CtPangoDest(const Glib::ustring& text, const Glib::ustring& synt_highl, const Glib::ustring& dest) : CtPangoWord(text, synt_highl), dest(dest) {}
     Glib::ustring dest;
 };
 struct CtPangoWidget : public CtPangoObject
@@ -67,8 +67,8 @@ public:
 
 private:
     std::vector<CtPangoObjectPtr> _pango_process_slot(int start_offset, int end_offset, Glib::RefPtr<Gtk::TextBuffer> curr_buffer);
-    CtPangoObjectPtr              _pango_text_serialize(const Gtk::TextIter& start_iter, Gtk::TextIter end_iter, const std::map<std::string_view, std::string> &curr_attributes);
-    CtPangoObjectPtr              _pango_link(const Glib::ustring& pango_text, const Glib::ustring& url);
+    std::shared_ptr<CtPangoWord>  _pango_text_serialize(const Gtk::TextIter& start_iter, Gtk::TextIter end_iter, const std::map<std::string_view, std::string> &curr_attributes);
+    std::shared_ptr<CtPangoWord>  _pango_link(const Glib::ustring& pango_text, const Glib::ustring& url);
 };
 
 
@@ -99,14 +99,14 @@ struct CtPageElement
     int x;
     int y;
 };
-struct CtPageLine : public CtPageElement
+struct CtPageWord : public CtPageElement
 {
-    CtPageLine(int x, int y, Glib::RefPtr<Pango::LayoutLine> layout_line) : CtPageElement(x, y), layout_line(layout_line) {}
+    CtPageWord(int x, int y, Glib::RefPtr<Pango::LayoutLine> layout_line) : CtPageElement(x, y), layout_line(layout_line) {}
     Glib::RefPtr<Pango::LayoutLine> layout_line;
 };
-struct CtPageTagLine : public CtPageElement
+struct CtPageTagWord : public CtPageElement
 {
-    CtPageTagLine(int x, int y, Glib::RefPtr<Pango::LayoutLine> layout_line, const std::string& tag_name, const std::string& tag_attr)
+    CtPageTagWord(int x, int y, Glib::RefPtr<Pango::LayoutLine> layout_line, const std::string& tag_name, const std::string& tag_attr)
         : CtPageElement(x, y), layout_line(layout_line), tag_name(tag_name), tag_attr(tag_attr) {}
     Glib::RefPtr<Pango::LayoutLine> layout_line;
     std::string tag_name;
@@ -157,6 +157,7 @@ class CtPrint
 {
 public:
     const int BOX_OFFSET = 4;
+    const int LINE_SPACE_OFFSET = 2;
 
 public:
     CtPrint();
@@ -170,7 +171,7 @@ private:
     void _on_draw_page_text(const Glib::RefPtr<Gtk::PrintContext>& context, int page_nr, CtPrintData* print_data);
 
 private:
-    void _process_pango_text(CtPrintData* print_data, CtPangoText* text_slot);
+    void _process_pango_text(CtPrintData* print_data, CtPangoWord* text_slot);
     void _process_pango_image(CtPrintData* print_data, CtImage* image, bool& any_image_resized);
     void _process_pango_codebox(CtPrintData* print_data, CtCodebox* codebox);
     void _process_pango_table(CtPrintData* print_data, CtTable* table);


### PR DESCRIPTION
I thought I would never finish that work, but here we are.
I couldn't much understand how to fix the previous code, so I rewrote it back using the same pygtk version, but actually improved (and it still supports links).

- `CtExport2Pango` just returns tokens (text, link, dest, new page, widget) from buffer
- `CtExport2Pdf` makes only one pass to create pages based on tokens and uses these pages to draw pdf.

The main difference is that there is only one pass instead of two (before it was to calculate element positions to figure out number of pages and then do it again to draw elements).
The second difference, a page has lines (one line per `y` coordinate), every line has a number of elements (line of text, widgets). So it is much easier to see what is going on. 
The third difference, because we have to draw lines after links, I use layout::set_indent to start the first line right after the link (or any other text or widget), and the pango layout still do the right wrapping.


