### PR TITLE
join popup menus for header and ordinary cells

### DIFF
--- a/future/src/ct/ct_actions_edit.cc
+++ b/future/src/ct/ct_actions_edit.cc
@@ -91,7 +91,6 @@ void CtActions::table_handle()
     int col_max = _pCtMainWin->get_ct_config()->tableColMin;
     std::list<std::vector<std::string>> rows;
     if (res == 1) {
-        rows.push_back(std::vector<std::string>(_pCtMainWin->get_ct_config()->tableColumns, "click me"));
         std::vector<std::string> empty_row(_pCtMainWin->get_ct_config()->tableColumns, "");
         while ((int)rows.size() < _pCtMainWin->get_ct_config()->tableRows)
             rows.push_back(empty_row);

--- a/future/src/ct/ct_menu.cc
+++ b/future/src/ct/ct_menu.cc
@@ -475,7 +475,7 @@ Gtk::Menu* CtMenu::build_popup_menu(GtkWidget* pMenu,  POPUP_MENU_TYPE popupMenu
         _add_menu_item(pMenu, find_action("link_delete"));
         return Glib::wrap(GTK_MENU(pMenu));
     }
-    case CtMenu::POPUP_MENU_TYPE::TableHeaderCell:
+    case CtMenu::POPUP_MENU_TYPE::TableCell:
     {
         _add_menu_item(pMenu, find_action("table_cut"));
         _add_menu_item(pMenu, find_action("table_copy"));
@@ -486,16 +486,6 @@ Gtk::Menu* CtMenu::build_popup_menu(GtkWidget* pMenu,  POPUP_MENU_TYPE popupMenu
         _add_separator(pMenu);
         _add_menu_item(pMenu, find_action("table_column_left"));
         _add_menu_item(pMenu, find_action("table_column_right"));
-        _add_separator(pMenu);
-        _add_menu_item(pMenu, find_action("table_edit_properties"));
-        _add_menu_item(pMenu, find_action("table_export"));
-        return Glib::wrap(GTK_MENU(pMenu));
-    }
-    case CtMenu::POPUP_MENU_TYPE::TableCell:
-    {
-        _add_menu_item(pMenu, find_action("table_cut"));
-        _add_menu_item(pMenu, find_action("table_copy"));
-        _add_menu_item(pMenu, find_action("table_delete"));
         _add_separator(pMenu);
         _add_menu_item(pMenu, find_action("table_row_add"));
         _add_menu_item(pMenu, find_action("table_row_cut"));

--- a/future/src/ct/ct_menu.h
+++ b/future/src/ct/ct_menu.h
@@ -58,7 +58,7 @@ public:
     const std::string KB_SHIFT   = "<shift>";
     const std::string KB_ALT     = "<alt>";
 
-    enum POPUP_MENU_TYPE {Node, Text, Code, Link, TableHeaderCell, TableCell, Codebox, Image, Anchor, EmbFile, PopupMenuNum };
+    enum POPUP_MENU_TYPE {Node, Text, Code, Link, TableCell, Codebox, Image, Anchor, EmbFile, PopupMenuNum };
     enum ACCEL_TYPE {Menu, TreeView };
 
 public:

--- a/future/src/ct/ct_table.cc
+++ b/future/src/ct/ct_table.cc
@@ -344,7 +344,7 @@ void CtTable::_on_populate_popup_header_cell(Gtk::Menu* menu, int row, int col)
     _pCtMainWin->get_ct_actions()->curr_table_anchor = this;
     _currentRow = row;
     _currentColumn = col;
-    _pCtMainWin->get_ct_actions()->getCtMainWin()->get_ct_menu().build_popup_menu(GTK_WIDGET(menu->gobj()), CtMenu::POPUP_MENU_TYPE::TableHeaderCell);
+    _pCtMainWin->get_ct_actions()->getCtMainWin()->get_ct_menu().build_popup_menu(GTK_WIDGET(menu->gobj()), CtMenu::POPUP_MENU_TYPE::TableCell);
 }
 
 void CtTable::_on_populate_popup_cell(Gtk::Menu* menu, int row, int col)


### PR DESCRIPTION
Partly resolves  #1037
- remove "Click Me" in table header
- popup menu is the same for header or ordinary cell, so adding new columns is possible from any cell