### PR TITLE
Fixes reading/writing files on WIN

### DIFF
--- a/future/src/ct/ct_actions_edit.cc
+++ b/future/src/ct/ct_actions_edit.cc
@@ -26,7 +26,6 @@
 #include "ct_logging.h"
 #include "ct_storage_control.h"
 #include <gtkmm/dialog.h>
-#include <fstream>
 
 // A Special character insert was Requested
 void CtActions::insert_spec_char_action(gunichar ch)
@@ -107,9 +106,8 @@ void CtActions::table_handle()
         if (filename.empty()) return;
         _pCtMainWin->get_ct_config()->pickDirCsv = Glib::path_get_dirname(filename);
         // todo: find good csv lib
-        std::ifstream infile(filename);
-        pCtTable = CtTable::from_csv(infile, _pCtMainWin, CtConst::TABLE_CELL_TEXT_ID, 40, 60, _curr_buffer()->get_insert()->get_iter().get_offset(), "").release();
-        
+        std::string csv_content = fs::get_content(fs::path(filename));
+        pCtTable = CtTable::from_csv(csv_content, _pCtMainWin, CtConst::TABLE_CELL_TEXT_ID, 40, 60, _curr_buffer()->get_insert()->get_iter().get_offset(), "").release();
     }
 
     if (!pCtTable) {
@@ -198,12 +196,7 @@ void CtActions::embfile_insert()
         }
     }
 
-
-    auto file = std::fstream(filepath, std::ios::in | std::ios::binary);
-    std::vector<char> buffer(std::istreambuf_iterator<char>(file), {});
-    file.close();
-
-    auto blob = std::string(buffer.data(), buffer.size());
+    std::string blob = fs::get_content(filepath);
     std::string name = Glib::path_get_basename(filepath);
     CtAnchoredWidget* pAnchoredWidget = new CtImageEmbFile(_pCtMainWin, name, blob, std::time(nullptr), iter_insert.get_offset(), "");
     Glib::RefPtr<Gsv::Buffer> gsv_buffer = Glib::RefPtr<Gsv::Buffer>::cast_dynamic(_curr_buffer());

--- a/future/src/ct/ct_actions_import.cc
+++ b/future/src/ct/ct_actions_import.cc
@@ -27,7 +27,6 @@
 #include "ct_storage_xml.h"
 
 #include "ct_logging.h"
-#include <fstream>
 
 // Import a node from a html file
 void CtActions::import_node_from_html_file() noexcept 

--- a/future/src/ct/ct_actions_others.cc
+++ b/future/src/ct/ct_actions_others.cc
@@ -27,7 +27,6 @@
 #include "ct_clipboard.h"
 #include <gtkmm/dialog.h>
 #include <gtkmm/stock.h>
-#include <fstream>
 #include <cstdlib>
 #include "ct_logging.h"
 #include <spdlog/fmt/bundled/printf.h>
@@ -157,13 +156,8 @@ void CtActions::embfile_open()
             CtConst::CHAR_MINUS + std::to_string(getpid())+
             CtConst::CHAR_MINUS + curr_file_anchor->get_file_name().string();
     fs::path filepath = _pCtMainWin->get_ct_tmp()->getHiddenFilePath(filename);
-    std::fstream file(filepath.string(), std::ios::out | std::ios::binary);
-    long size = (long)curr_file_anchor->get_raw_blob().size();
-    file.write(curr_file_anchor->get_raw_blob().c_str(), size);
-    file.close();
 
-    spdlog::debug("embfile_open {}", filepath);
-
+    g_file_set_contents(filepath.c_str(), curr_file_anchor->get_raw_blob().c_str(), (gssize)curr_file_anchor->get_raw_blob().size(), nullptr);
     fs::open_filepath(filepath.c_str(), false, _pCtMainWin->get_ct_config());
     _embfiles_opened[filepath] = fs::getmtime(filepath);
 
@@ -481,10 +475,7 @@ void CtActions::codebox_load_from_file()
     if (filepath.empty()) return;
     _pCtMainWin->get_ct_config()->pickDirCbox = Glib::path_get_dirname(filepath);
 
-    auto file = std::fstream(filepath, std::ios::in);
-    std::string buffer(std::istreambuf_iterator<char>(file), {});
-    file.close();
-
+    std::string buffer = fs::get_content(filepath);
     curr_codebox_anchor->get_buffer()->set_text(buffer);
 }
 
@@ -686,11 +677,12 @@ void CtActions::table_export()
     _pCtMainWin->get_ct_config()->pickDirCsv = Glib::path_get_dirname(filename);
 
     try {
-        std::ofstream outfile;
-        outfile.exceptions(std::ios::failbit);
-        outfile.open(filename);
+        std::stringstream buffer;
+        curr_table_anchor->to_csv(buffer);
+        std::string result = buffer.str();
 
-        curr_table_anchor->to_csv(outfile);
+        g_file_set_contents(filename.c_str(), result.c_str(), (gssize)result.size(), nullptr);
+
     } catch(std::exception& e) {
         spdlog::error("Exception caught while exporting table: {}", e.what());
         CtDialogs::error_dialog("Exception occured while exporting table, see log for details", *_pCtMainWin);
@@ -748,10 +740,8 @@ bool CtActions::_on_embfiles_sentinel_timeout()
                 if (CtImageEmbFile* embFile = dynamic_cast<CtImageEmbFile*>(widget))
                     if (((size_t)embFile->get_data("open_id")) == embfile_id)
                     {
-                        auto file = std::fstream(filepath.string(), std::ios::in | std::ios::binary);
-                        std::vector<char> buffer(std::istreambuf_iterator<char>(file), {});
-                        file.close();
-                        embFile->set_raw_blob(buffer.data(), buffer.size());
+                        std::string buffer = fs::get_content(filepath);
+                        embFile->set_raw_blob(buffer);
                         embFile->set_time(std::time(nullptr));
                         embFile->update_tooltip();
 

--- a/future/src/ct/ct_app.h
+++ b/future/src/ct/ct_app.h
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include <iostream>
 #include <unordered_map>
 
 #include <glibmm/i18n.h>

--- a/future/src/ct/ct_config.cc
+++ b/future/src/ct/ct_config.cc
@@ -21,7 +21,6 @@
  * MA 02110-1301, USA.
  */
 
-#include <iostream>
 #include <memory>
 #include <gtkmm.h>
 #include "ct_config.h"

--- a/future/src/ct/ct_export2html.cc
+++ b/future/src/ct/ct_export2html.cc
@@ -28,7 +28,6 @@
 #include "ct_storage_control.h"
 #include "ct_logging.h"
 #include "ct_process.h"
-#include <fstream>
 #include <filesystem>
 
 
@@ -276,10 +275,7 @@ Glib::ustring CtExport2Html::_get_embfile_html(CtImageEmbFile* embfile, CtTreeIt
     Glib::ustring embfile_html = "<table style=\"" + embfile_align_text + "\"><tr><td><a href=\"" +
             embfile_rel_path.string() + "\">Linked file: " + embfile->get_file_name().string() + " </a></td></tr></table>";
 
-    std::fstream file((embed_dir / embfile_name).string(), std::ios::out | std::ios::binary);
-    long size = (long)embfile->get_raw_blob().size();
-    file.write(embfile->get_raw_blob().c_str(), size);
-    file.close();
+    g_file_set_contents((embed_dir / embfile_name).c_str(), embfile->get_raw_blob().c_str(), (gssize)embfile->get_raw_blob().size(), nullptr);
 
     return embfile_html;
 }

--- a/future/src/ct/ct_filesystem.cc
+++ b/future/src/ct/ct_filesystem.cc
@@ -153,7 +153,9 @@ void open_filepath(const fs::path& filepath, bool open_folder_if_file_not_exists
             return;
         } else {
 #ifdef _WIN32
-            ShellExecute(GetActiveWindow(), "open", filepath.c_str(), NULL, NULL, SW_SHOWNORMAL);
+            glong utf16text_len = 0;
+            g_autofree gunichar2* utf16text = g_utf8_to_utf16(filepath.c_str(), (glong)Glib::ustring(filepath.c_str()).bytes(), nullptr, &utf16text_len, nullptr);
+            ShellExecuteW(GetActiveWindow(), L"open", (LPCWSTR)utf16text, NULL, NULL, SW_SHOWNORMAL);
 #else
             std::vector<std::string> argv = { "xdg-open", "file://" + filepath.string() };
             Glib::spawn_async("", argv, Glib::SpawnFlags::SPAWN_SEARCH_PATH);
@@ -176,7 +178,9 @@ void open_folderpath(const fs::path& folderpath, CtConfig* config)
     } else {
         // https://stackoverflow.com/questions/42442189/how-to-open-spawn-a-file-with-glib-gtkmm-in-windows
 #ifdef _WIN32
-        ShellExecute(NULL, "open", folderpath.c_str(), NULL, NULL, SW_SHOWDEFAULT);
+        glong utf16text_len = 0;
+        g_autofree gunichar2* utf16text = g_utf8_to_utf16(folderpath.c_str(), (glong)Glib::ustring(folderpath.c_str()).bytes(), nullptr, &utf16text_len, nullptr);
+        ShellExecuteW(GetActiveWindow(), L"open", (LPCWSTR)utf16text, NULL, NULL, SW_SHOWDEFAULT);
 #elif defined(__APPLE__)
         std::vector<std::string> argv = { "open", folderpath.string() };
         Glib::spawn_async("", argv, Glib::SpawnFlags::SPAWN_SEARCH_PATH);

--- a/future/src/ct/ct_filesystem.cc
+++ b/future/src/ct/ct_filesystem.cc
@@ -192,6 +192,20 @@ void open_folderpath(const fs::path& folderpath, CtConfig* config)
     }
 }
 
+std::string get_content(const path& filepath)
+{
+    gchar *contents = NULL;
+    gsize  length   = 0;
+    g_file_get_contents(filepath.c_str(), &contents, &length, NULL);
+    if (contents)
+    {
+        std::string result(contents, length);
+        g_free(contents);
+        return result;
+    }
+    return std::string();
+}
+
 path prepare_export_folder(const path& dir_place, path new_folder, bool overwrite_existing)
 {
     if (fs::is_directory(dir_place / new_folder))

--- a/future/src/ct/ct_filesystem.h
+++ b/future/src/ct/ct_filesystem.h
@@ -62,6 +62,8 @@ void open_weblink(const std::string& link);
 void open_filepath(const path& filepath, bool open_folder_if_file_not_exists, CtConfig* config);
 void open_folderpath(const path& folderpath, CtConfig* config);
 
+std::string get_content(const path& filepath);
+
 path prepare_export_folder(const path& dir_place, path new_folder, bool overwrite_existing);
 
 CtDocType get_doc_type(const path& fileName);

--- a/future/src/ct/ct_image.h
+++ b/future/src/ct/ct_image.h
@@ -132,7 +132,7 @@ public:
 
     const fs::path& get_file_name() { return _fileName; }
     const std::string&   get_raw_blob() { return _rawBlob; }
-    void                 set_raw_blob(char* buffer, size_t size) { _rawBlob = std::string(buffer, size);}
+    void                 set_raw_blob(const std::string& buffer) { _rawBlob = buffer; }
     double               get_time() { return _timeSeconds; }
     void                 set_time(time_t time) { _timeSeconds = time; }
 

--- a/future/src/ct/ct_main_win.h
+++ b/future/src/ct/ct_main_win.h
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include <iostream>
 #include <unordered_map>
 
 #include <glibmm/i18n.h>

--- a/future/src/ct/ct_misc_utils.cc
+++ b/future/src/ct/ct_misc_utils.cc
@@ -893,18 +893,19 @@ int str::indexOf(const Glib::ustring& str, const gunichar& uc)
     return index != std::string::npos ? static_cast<int>(index) : -1;
 }
 
-std::string str::xml_escape(const std::string& text)
+Glib::ustring str::xml_escape(const Glib::ustring& text)
 {
-    std::string buffer;
+    Glib::ustring buffer;
     buffer.reserve(text.size());
-    for(size_t pos = 0; pos != text.size(); ++pos) {
-        switch(text[pos]) {
+    for (auto ch = text.begin(); ch != text.end(); ++ch)
+    {
+        switch(*ch) {
             case '&':  buffer.append("&amp;");       break;
             case '\"': buffer.append("&quot;");      break;
             case '\'': buffer.append("&apos;");      break;
             case '<':  buffer.append("&lt;");        break;
             case '>':  buffer.append("&gt;");        break;
-            default:   buffer.append(&text[pos], 1); break;
+            default:   buffer.append(1, *ch); break;
         }
     }
     return buffer;
@@ -917,7 +918,7 @@ Glib::ustring str::sanitize_bad_symbols(const Glib::ustring& xml_content)
     return re_pattern->replace(xml_content, 0, "", static_cast<Glib::RegexMatchFlags>(0));
 }
 
-std::string str::re_escape(const std::string& text)
+Glib::ustring str::re_escape(const Glib::ustring& text)
 {
     return Glib::Regex::escape_string(text);
 }

--- a/future/src/ct/ct_misc_utils.h
+++ b/future/src/ct/ct_misc_utils.h
@@ -261,11 +261,11 @@ int indexOf(const std::array<T, size>& array, const T& uc)
     return -1;
 }
 
-std::string xml_escape(const std::string& text);
+Glib::ustring xml_escape(const Glib::ustring& text);
 
 Glib::ustring sanitize_bad_symbols(const Glib::ustring& xml_content);
 
-std::string re_escape(const std::string& text);
+Glib::ustring re_escape(const Glib::ustring& text);
 
 std::string time_format(const std::string& format, const time_t& time);
 
@@ -274,8 +274,7 @@ int byte_pos_to_symb_pos(const Glib::ustring& text, int byte_pos);
 
 Glib::ustring swapcase(const Glib::ustring& text);
 
-template<class String>
-std::string replace(const /* const: func doens't change the source! */ String& subjectStr, const std::string& searchStr, const std::string& replaceStr)
+inline Glib::ustring replace(const /* keep const to make sure source is not changed */ Glib::ustring& subjectStr, const std::string& searchStr, const std::string& replaceStr)
 {
     Glib::ustring text = subjectStr; // Glib::ustring works with unicode
     size_t pos = 0;
@@ -287,23 +286,24 @@ std::string replace(const /* const: func doens't change the source! */ String& s
     return text;
 }
 
-template<class String>
-String trim(String s)
+inline Glib::ustring trim(Glib::ustring s)
 {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) { return !std::isspace(ch); }));
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](gunichar ch) { return !g_unichar_isspace(ch); }));
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](gunichar ch) { return !g_unichar_isspace(ch); }).base(), s.end());
     return s;
 }
 
 template<typename ...Args>
 std::string format(const std::string& in_str, const Args&... args)
 {
-    return fmt::format(str::replace(in_str, "%s", "{}"), args...);
+    return fmt::format(str::replace(in_str, "%s", "{}").c_str(), args...);
 }
 
 template<class STRING>
 std::vector<STRING> split(const STRING& strToSplit, const char* delimiter)
 {
+    // maybe replace by Glib::Regex::split_simple
+
     std::vector<STRING> vecOfStrings;
     gchar** arrayOfStrings = g_strsplit(strToSplit.c_str(), delimiter, -1);
     for (gchar** ptr = arrayOfStrings; *ptr; ptr++)

--- a/future/src/ct/ct_parser.h
+++ b/future/src/ct/ct_parser.h
@@ -30,7 +30,7 @@
 #include <libxml++/libxml++.h>
 #include <gtkmm.h>
 #include <unordered_set>
-#include <fstream>
+#include <sstream>
 #include <unordered_map>
 #include <functional>
 #include <array>

--- a/future/src/ct/ct_parser_text.cc
+++ b/future/src/ct/ct_parser_text.cc
@@ -21,7 +21,7 @@
 
 #include "ct_parser.h"
 #include "ct_logging.h"
-#include <iostream>
+#include <sstream>
 
 namespace {
 

--- a/future/src/ct/ct_storage_xml.cc
+++ b/future/src/ct/ct_storage_xml.cc
@@ -29,7 +29,6 @@
 #include "ct_main_win.h"
 #include "ct_storage_control.h"
 #include "ct_logging.h"
-#include <fstream>
 
 
 CtStorageXml::CtStorageXml(CtMainWin* pCtMainWin) : _pCtMainWin(pCtMainWin)
@@ -218,9 +217,7 @@ std::unique_ptr<xmlpp::DomParser> CtStorageXml::_get_parser(const fs::path& file
         spdlog::error("CtStorageXml::_get_parser: failed to read xml file {}, {}", file_path.string(), e.what());
         spdlog::info("CtStorageXml::_get_parser: trying to sanitize xml file ...");
 
-        auto file = std::fstream(file_path.string(), std::ios::in);
-        std::string buffer(std::istreambuf_iterator<char>(file), {});
-        file.close();
+        std::string buffer =  fs::get_content(file_path);
         Glib::ustring xml_content = str::sanitize_bad_symbols(buffer);
         parser->parse_memory(xml_content);
         spdlog::info("CtStorageXml::_get_parser: xml file is sanitized");

--- a/future/src/ct/ct_table.cc
+++ b/future/src/ct/ct_table.cc
@@ -194,7 +194,8 @@ void CtTable::to_csv(std::ostream& output) const {
 }
 
 
-std::unique_ptr<CtTable> CtTable::from_csv(std::istream& input, CtMainWin* main_win, const Glib::ustring& syntax_highlighting, int col_min, int col_max, int offset, const Glib::ustring& justification) {
+std::unique_ptr<CtTable> CtTable::from_csv(const std::string& csv_content, CtMainWin* main_win, const Glib::ustring& syntax_highlighting, int col_min, int col_max, int offset, const Glib::ustring& justification) {
+    std::stringstream input(csv_content);
     CtCSV::CtStringTable str_tbl = CtCSV::table_from_csv(input);
 
     CtTableMatrix tbl_matrix;

--- a/future/src/ct/ct_table.h
+++ b/future/src/ct/ct_table.h
@@ -56,7 +56,7 @@ public:
      * @param input 
      * @return CtTable 
      */
-    static std::unique_ptr<CtTable> from_csv(std::istream& input, CtMainWin* main_win, const Glib::ustring& syntax_highlighting, int col_min, int col_max, int offset, const Glib::ustring& justification);
+    static std::unique_ptr<CtTable> from_csv(const std::string& csv_content, CtMainWin* main_win, const Glib::ustring& syntax_highlighting, int col_min, int col_max, int offset, const Glib::ustring& justification);
 
     void apply_width_height(const int /*parentTextWidth*/) override {}
     void apply_syntax_highlighting() override;

--- a/future/src/ct/ct_widgets.h
+++ b/future/src/ct/ct_widgets.h
@@ -29,7 +29,6 @@
 #include <gtksourceviewmm.h>
 #include <libxml++/libxml++.h>
 #include <sqlite3.h>
-#include <iostream>
 #include <unordered_map>
 #include <memory>
 #include <gspell/gspell.h>

--- a/future/tests/tests_filesystem.cpp
+++ b/future/tests/tests_filesystem.cpp
@@ -176,3 +176,19 @@ TEST(FileSystemGroup, remove)
     CHECK_FALSE(fs::exists(test_dir_path));
 
 }
+
+TEST(FileSystemGroup, get_content)
+{
+    std::string content = "blabla";
+    fs::path test_file_path = fs::path{UT::unitTestsDataDir} / fs::path{"test_file.txt"};
+    {
+        fs::remove(test_file_path);
+        std::ofstream test_file_ofstr{test_file_path.string()};
+        test_file_ofstr << content;
+        test_file_ofstr.close();
+    }
+
+    STRCMP_EQUAL(content.c_str(), fs::get_content(test_file_path.c_str()).c_str());
+
+    fs::remove(test_file_path);
+}

--- a/future/tests/tests_misc_utils.cpp
+++ b/future/tests/tests_misc_utils.cpp
@@ -236,6 +236,14 @@ TEST(MiscUtilsGroup, str__indexOf)
     LONGS_EQUAL(str::indexOf("Saitama さいたま市", uc), 8);
 }
 
+TEST(MiscUtilsGroup, str__xml_escape)
+{
+    STRCMP_EQUAL("", str::xml_escape("").c_str());
+    STRCMP_EQUAL("Ру", str::xml_escape("Ру").c_str());
+    STRCMP_EQUAL("&lt;Ру&gt;", str::xml_escape("<Ру>").c_str());
+    STRCMP_EQUAL("1&lt;2&quot;3&quot;4&amp;&gt;", str::xml_escape("1<2\"3\"4&>").c_str());
+}
+
 TEST(MiscUtilsGroup, str__join)
 {
     std::vector<std::string> empty_v;


### PR DESCRIPTION
Resolves #1029 , issues are caused by functions which don't understand UTF8 file names on WIN.
1. Cannot open links in the note if the address uses Russian characters. Caused by file streams, removed them everywhere except imports. String streams don't have that issue.
2. Files attached to a note with names in Russian cannot be opened. ShellExecute doesn't understand UTF8, fixed it by converting paths to UTF16,
3. Removing some characters from a node name. It was caused by `str::trim` which worked with ANSII symbols instead of UTF8. `str::xml_escape` also worked with ANSI, I'm surprised it hasn't cause any issue so far. 

  

