### PR TITLE
add fallback font support

### DIFF
--- a/future/src/ct/ct_config.h
+++ b/future/src/ct/ct_config.h
@@ -148,6 +148,7 @@ public:
     std::string                                 ptFont{"Sans 9"};
     std::string                                 treeFont{"Sans 8"};
     std::string                                 codeFont{"Monospace 9"};
+    std::string                                 fallbackFontFamily{"Sans"};
 
     // [colors]
     std::string                                 rtDefFg{CtConst::RICH_TEXT_DARK_FG};

--- a/future/src/ct/ct_export2pdf.cc
+++ b/future/src/ct/ct_export2pdf.cc
@@ -341,10 +341,15 @@ void CtPrint::print_text(CtMainWin* pCtMainWin, const fs::path& pdf_filepath, co
 // Here we Compute the Lines Positions, the Number of Pages Needed and the Page Breaks
 void CtPrint::_on_begin_print_text(const Glib::RefPtr<Gtk::PrintContext>& context, CtPrintData* print_data)
 {
+    auto get_fallback_font = [](Pango::FontDescription font, const std::string& fallbackFont) {
+        font.set_family(font.get_family() + "," + fallbackFont);
+        return font;
+    };
+
     print_data->context = context;
-    _rich_font = Pango::FontDescription(_pCtMainWin->get_ct_config()->rtFont);
-    _plain_font = Pango::FontDescription(_pCtMainWin->get_ct_config()->ptFont);
-    _code_font = Pango::FontDescription(_pCtMainWin->get_ct_config()->codeFont);
+    _rich_font = get_fallback_font(Pango::FontDescription(_pCtMainWin->get_ct_config()->rtFont), _pCtMainWin->get_ct_config()->fallbackFontFamily);
+    _plain_font = get_fallback_font(Pango::FontDescription(_pCtMainWin->get_ct_config()->ptFont), _pCtMainWin->get_ct_config()->fallbackFontFamily);
+    _code_font = get_fallback_font(Pango::FontDescription(_pCtMainWin->get_ct_config()->codeFont), "monospace");
     _text_window_width = _pCtMainWin->get_text_view().get_allocation().get_width();
     _table_text_row_height = _rich_font.get_size()/Pango::SCALE;
     _table_line_thickness = 6;

--- a/future/src/ct/ct_main_win.cc
+++ b/future/src/ct/ct_main_win.cc
@@ -560,17 +560,17 @@ void CtMainWin::config_update_data_from_curr_status()
 
 void CtMainWin::update_theme()
 { 
-    auto font_to_string = [](Pango::FontDescription font)
+    auto font_to_string = [](Pango::FontDescription font, std::string fallbackFont)
     {
-        return " { font-family: " + font.get_family() +
-               "; font-size: " + std::to_string(font.get_size()/Pango::SCALE) +
-               "pt; } ";
+        // add fallback font (to help with font on Win; on Linux, font works ok without explicit fallback
+        return " { font-family: \"" + font.get_family() + "\",\"" + fallbackFont +  "\";"
+                   "font-size: " + std::to_string(font.get_size()/Pango::SCALE) + "pt; } ";
     };
 
-    std::string rtFont = font_to_string(Pango::FontDescription(_pCtConfig->rtFont));
-    std::string plFont = font_to_string(Pango::FontDescription(_pCtConfig->ptFont));
-    std::string codeFont = font_to_string(Pango::FontDescription(_pCtConfig->codeFont));
-    std::string treeFont = font_to_string(Pango::FontDescription(_pCtConfig->treeFont));
+    std::string rtFont = font_to_string(Pango::FontDescription(_pCtConfig->rtFont), _pCtConfig->fallbackFontFamily);
+    std::string plFont = font_to_string(Pango::FontDescription(_pCtConfig->ptFont), _pCtConfig->fallbackFontFamily);
+    std::string codeFont = font_to_string(Pango::FontDescription(_pCtConfig->codeFont), "monospace");
+    std::string treeFont = font_to_string(Pango::FontDescription(_pCtConfig->treeFont), _pCtConfig->fallbackFontFamily);
 
     std::string font_css;
     font_css += ".ct-view-panel.ct-view-rich-text" + rtFont;

--- a/future/src/ct/ct_widgets.cc
+++ b/future/src/ct/ct_widgets.cc
@@ -641,7 +641,8 @@ void CtTextView::cursor_and_tooltips_handler(int x, int y)
 
     if (CtList(_pCtMainWin, get_buffer()).is_list_todo_beginning(text_iter))
     {
-        get_window(Gtk::TEXT_WINDOW_TEXT)->set_cursor(Gdk::Cursor::create(Gdk::X_CURSOR));
+        get_window(Gtk::TEXT_WINDOW_TEXT)->set_cursor(Gdk::Cursor::create(Gdk::HAND2)); // Gdk::X_CURSOR doesn't work on Win
+        //get_window(Gtk::TEXT_WINDOW_TEXT)->set_cursor(Gdk::Cursor::create(Gdk::X_CURSOR));
         set_tooltip_text("");
         return;
     }


### PR DESCRIPTION
Resolves #1055, some fonts cannot display checkbox symbols and symbols from languages. For some reason, Linux is not affected by this issue, I suppose, font config already has a fallback font.
- add fallback font "Sans" for textview, codebox, treevew. Also, fixes pdf output.
- change a cursor for checkboxes.