### PR TITLE
Custom backup dir

### DIFF
--- a/future/src/ct/ct_config.cc
+++ b/future/src/ct/ct_config.cc
@@ -308,6 +308,8 @@ void CtConfig::_populate_keyfile_from_data()
     _uKeyFile->set_boolean(_currentGroup, "backup_copy", backupCopy);
     _uKeyFile->set_integer(_currentGroup, "backup_num", backupNum);
     _uKeyFile->set_boolean(_currentGroup, "autosave_on_quit", autosaveOnQuit);
+    _uKeyFile->set_boolean(_currentGroup, "enable_custom_backup_dir", customBackupDirOn);
+    _uKeyFile->set_string(_currentGroup, "custom_backup_dir", customBackupDir);
     _uKeyFile->set_integer(_currentGroup, "limit_undoable_steps", limitUndoableSteps);
 
     // [keyboard]
@@ -573,6 +575,8 @@ void CtConfig::_populate_data_from_keyfile()
     _populate_bool_from_keyfile("backup_copy", &backupCopy);
     _populate_int_from_keyfile("backup_num", &backupNum);
     _populate_bool_from_keyfile("autosave_on_quit", &autosaveOnQuit);
+    _populate_bool_from_keyfile("enable_custom_backup_dir", &customBackupDirOn);
+    _populate_string_from_keyfile("custom_backup_dir", &customBackupDir);
     _populate_int_from_keyfile("limit_undoable_steps", &limitUndoableSteps);
 
     // [keyboard]

--- a/future/src/ct/ct_config.h
+++ b/future/src/ct/ct_config.h
@@ -179,6 +179,8 @@ public:
     bool                                        backupCopy{true};
     int                                         backupNum{3};
     bool                                        autosaveOnQuit{false};
+    bool                                        customBackupDirOn{false};
+    std::string                                 customBackupDir{""};
     int                                         limitUndoableSteps{20};
     bool                                        usePandoc{true}; // Whether to use Pandoc for exporting
 

--- a/future/src/ct/ct_pref_dlg.cc
+++ b/future/src/ct/ct_pref_dlg.cc
@@ -1387,18 +1387,34 @@ Gtk::Widget* CtPrefDlg::build_tab_misc()
     Gtk::SpinButton* spinbutton_num_backups = Gtk::manage(new Gtk::SpinButton(adjustment_num_backups));
     spinbutton_num_backups->set_sensitive(pConfig->backupCopy);
     spinbutton_num_backups->set_value(pConfig->backupNum);
+    Gtk::CheckButton* checkbutton_custom_backup_dir = Gtk::manage(new Gtk::CheckButton(_("Custom Backup Directory")));
+    Gtk::Entry* entry_custom_backup_dir = Gtk::manage(new Gtk::Entry());
+    entry_custom_backup_dir->property_editable() = false;
+    Gtk::Button* button_custom_backup_dir = Gtk::manage(new Gtk::Button("..."));
+    Gtk::HBox* hbox_custom_backup_dir = Gtk::manage(new Gtk::HBox());
+    hbox_custom_backup_dir->set_spacing(4);
+
     hbox_num_backups->pack_start(*label_num_backups, false, false);
     hbox_num_backups->pack_start(*spinbutton_num_backups, false, false);
+    hbox_custom_backup_dir->pack_start(*entry_custom_backup_dir);
+    hbox_custom_backup_dir->pack_start(*button_custom_backup_dir, false, false);
     vbox_saving->pack_start(*hbox_autosave, false, false);
     vbox_saving->pack_start(*checkbutton_autosave_on_quit, false, false);
     vbox_saving->pack_start(*checkbutton_backup_before_saving, false, false);
     vbox_saving->pack_start(*hbox_num_backups, false, false);
+    vbox_saving->pack_start(*checkbutton_custom_backup_dir, false, false);
+    vbox_saving->pack_start(*hbox_custom_backup_dir, false, false);
 
     checkbutton_autosave->set_active(pConfig->autosaveOn);
     spinbutton_autosave->set_value(pConfig->autosaveVal);
     spinbutton_autosave->set_sensitive(pConfig->autosaveOn);
     checkbutton_autosave_on_quit->set_active(pConfig->autosaveOnQuit);
     checkbutton_backup_before_saving->set_active(pConfig->backupCopy);
+    checkbutton_custom_backup_dir->set_sensitive(pConfig->backupCopy);
+    checkbutton_custom_backup_dir->set_active(pConfig->customBackupDirOn);
+    entry_custom_backup_dir->set_text(pConfig->customBackupDir);
+    entry_custom_backup_dir->set_sensitive(pConfig->backupCopy && pConfig->customBackupDirOn);
+    button_custom_backup_dir->set_sensitive(pConfig->backupCopy && pConfig->customBackupDirOn);
 
     Gtk::Frame* frame_saving = Gtk::manage(new Gtk::Frame(std::string("<b>")+_("Saving")+"</b>"));
     ((Gtk::Label*)frame_saving->get_label_widget())->set_use_markup(true);
@@ -1501,12 +1517,26 @@ Gtk::Widget* CtPrefDlg::build_tab_misc()
     checkbutton_autosave_on_quit->signal_toggled().connect([pConfig, checkbutton_autosave_on_quit](){
         pConfig->autosaveOnQuit = checkbutton_autosave_on_quit->get_active();
     });
-    checkbutton_backup_before_saving->signal_toggled().connect([pConfig, checkbutton_backup_before_saving, spinbutton_num_backups](){
+    checkbutton_backup_before_saving->signal_toggled().connect([pConfig, checkbutton_backup_before_saving, spinbutton_num_backups, checkbutton_custom_backup_dir, entry_custom_backup_dir, button_custom_backup_dir](){
         pConfig->backupCopy = checkbutton_backup_before_saving->get_active();
         spinbutton_num_backups->set_sensitive(pConfig->backupCopy);
+        checkbutton_custom_backup_dir->set_sensitive(pConfig->backupCopy);
+        entry_custom_backup_dir->set_sensitive(pConfig->backupCopy && pConfig->customBackupDirOn);
+        button_custom_backup_dir->set_sensitive(pConfig->backupCopy && pConfig->customBackupDirOn);
     });
     spinbutton_num_backups->signal_value_changed().connect([pConfig, spinbutton_num_backups](){
         pConfig->backupNum = spinbutton_num_backups->get_value_as_int();
+    });
+    checkbutton_custom_backup_dir->signal_toggled().connect([pConfig, checkbutton_custom_backup_dir, entry_custom_backup_dir, button_custom_backup_dir](){
+        pConfig->customBackupDirOn = checkbutton_custom_backup_dir->get_active();
+        entry_custom_backup_dir->set_sensitive(checkbutton_custom_backup_dir->get_active());
+        button_custom_backup_dir->set_sensitive(checkbutton_custom_backup_dir->get_active());
+    });
+    button_custom_backup_dir->signal_clicked().connect([this, pConfig, entry_custom_backup_dir](){
+        auto dir_place = CtDialogs::folder_select_dialog(pConfig->customBackupDir, _pCtMainWin);
+        if (dir_place.empty()) return;
+        entry_custom_backup_dir->set_text(dir_place);
+        pConfig->customBackupDir = dir_place;
     });
     checkbutton_reload_doc_last->signal_toggled().connect([pConfig, checkbutton_reload_doc_last](){
         pConfig->reloadDocLast = checkbutton_reload_doc_last->get_active();

--- a/future/src/ct/ct_storage_control.cc
+++ b/future/src/ct/ct_storage_control.cc
@@ -277,13 +277,20 @@ void CtStorageControl::_put_in_backup(const fs::path& main_backup)
             hash_dir = str::replace(hash_dir, str, "_");
         std::string new_backup_dir = Glib::build_filename(_pCtMainWin->get_ct_config()->customBackupDir, hash_dir);
         Glib::RefPtr<Gio::File> dir_file = Gio::File::create_for_path(new_backup_dir);
-        if (!dir_file->query_exists())
+        try
+        {
+            if (!dir_file->query_exists())
             if (!dir_file->make_directory_with_parents())
             {
                 spdlog::error("failed to create backup directory: {}", new_backup_dir);
                 return "";
             }
-        return Glib::build_filename(new_backup_dir, _file_path.filename().string()) + CtConst::CHAR_TILDE;
+            return Glib::build_filename(new_backup_dir, _file_path.filename().string()) + CtConst::CHAR_TILDE;
+        }
+        catch (Glib::Error& ex) {
+            spdlog::error("failed to create backup directory: {}, \n{}", new_backup_dir, ex.what());
+            return "";
+        }
     };
 
     std::string new_backup_file = _file_path.string() + CtConst::CHAR_TILDE;

--- a/future/src/ct/ct_storage_control.h
+++ b/future/src/ct/ct_storage_control.h
@@ -82,7 +82,6 @@ private:
     fs::path                         _file_path;
     Glib::ustring                    _password;
     fs::path                         _extracted_file_path;
-    bool                             _need_backup{true};   // create a backup once, on the first saving
     std::unique_ptr<CtStorageEntity> _storage;
     CtStorageSyncPending             _syncPending;
 };


### PR DESCRIPTION
Resolves #1061

- custom backup dir
- if there is any issue with custom backup dir then standard backup is used
- removed save backup only once, now it's done every save
- the issue with long names in Win32 exists, but I did nothing to avoid it.