### PR TITLE
adds File Attachment Type-Based Icons on Linux, thanks to @metal450

### DIFF
--- a/future/src/ct/ct_clipboard.cc
+++ b/future/src/ct/ct_clipboard.cc
@@ -643,7 +643,7 @@ void CtClipboard::_on_received_to_uri_list(const Gtk::SelectionData& selection_d
             {
                 Glib::ustring file_path = element.substr(7);
                 file_path = str::replace(file_path, "%20", CtConst::CHAR_SPACE);
-                gchar* mimetype = g_content_type_guess(file_path.c_str(), nullptr, 0, nullptr);
+                g_autofree gchar* mimetype = g_content_type_guess(file_path.c_str(), nullptr, 0, nullptr);
                 if (mimetype and str::startswith(mimetype, "image/") and Glib::file_test(file_path, Glib::FILE_TEST_IS_REGULAR))
                 {
                     try

--- a/future/src/ct/ct_export2html.cc
+++ b/future/src/ct/ct_export2html.cc
@@ -667,7 +667,7 @@ namespace CtPandoc {
 // Checks if the specified file is in the PATH environment variable
 bool in_path(const std::string& file) 
 {
-    auto prog_name = g_find_program_in_path(file.c_str());
+    g_autofree gchar* prog_name = g_find_program_in_path(file.c_str());
     return prog_name != nullptr;
 }
 

--- a/future/src/ct/ct_image.h
+++ b/future/src/ct/ct_image.h
@@ -140,6 +140,9 @@ public:
     void update_label_widget();
 
 private:
+    static Glib::RefPtr<Gdk::Pixbuf> _get_file_icon(CtMainWin* pCtMainWin, const fs::path& fileName);
+
+private:
     bool _on_button_press_event(GdkEventButton* event);
 
 protected:


### PR DESCRIPTION
Rework #1031, resolves #1027

