### PR TITLE
unified link data parsing by CtMiscUtil::get_link_entry

### DIFF
--- a/src/ct/ct_actions.h
+++ b/src/ct/ct_actions.h
@@ -53,7 +53,7 @@ public:
     CtImageEmbFile* curr_file_anchor{nullptr};
 
 private:
-    CtDialogs::CtLinkEntry _link_entry;
+    CtLinkEntry _link_entry;
 
 private:
     size_t                          _next_opened_emb_file_id{1};
@@ -262,8 +262,8 @@ private:
     text_view_n_buffer_codebox_proof _get_text_view_n_buffer_codebox_proof();
     CtCodebox* _codebox_in_use();
 
-    bool _links_entries_pre_dialog(const Glib::ustring& curr_link, CtDialogs::CtLinkEntry& link_entry);
-    Glib::ustring _links_entries_post_dialog(CtDialogs::CtLinkEntry& link_entry);
+    bool _links_entries_pre_dialog(const Glib::ustring& curr_link, CtLinkEntry& link_entry);
+    Glib::ustring _links_entries_post_dialog(CtLinkEntry& link_entry);
     Glib::ustring _link_check_around_cursor();
 
 public:

--- a/src/ct/ct_actions_format.cc
+++ b/src/ct/ct_actions_format.cc
@@ -282,7 +282,7 @@ void CtActions::_apply_tag(const Glib::ustring& tag_property, Glib::ustring prop
         if (tag_property != CtConst::TAG_JUSTIFICATION) {
             if (not _is_there_selected_node_or_error()) return;
             if (tag_property == CtConst::TAG_LINK)
-                _link_entry = CtDialogs::CtLinkEntry(); // reset
+                _link_entry = CtLinkEntry(); // reset
             if (not text_buffer->get_has_selection()) {
                 if (tag_property != CtConst::TAG_LINK) {
                     if (not _pCtMainWin->apply_tag_try_automatic_bounds(text_buffer, text_buffer->get_insert()->get_iter())) {
@@ -425,29 +425,20 @@ CtCodebox* CtActions::_codebox_in_use()
 }
 
 // Prepare Global Links Variables for Dialog
-bool CtActions::_links_entries_pre_dialog(const Glib::ustring& curr_link, CtDialogs::CtLinkEntry& link_entry)
+bool CtActions::_links_entries_pre_dialog(const Glib::ustring& curr_link, CtLinkEntry& link_entry)
 {
-    auto vec = str::split(curr_link, " ");
-    link_entry.type = vec[0];
-    if (link_entry.type == CtConst::LINK_TYPE_WEBS)        link_entry.webs = vec[1];
-    else if (link_entry.type == CtConst::LINK_TYPE_FILE)   link_entry.file = Glib::Base64::decode(vec[1]);
-    else if (link_entry.type == CtConst::LINK_TYPE_FOLD)   link_entry.fold = Glib::Base64::decode(vec[1]);
-    else if (link_entry.type == CtConst::LINK_TYPE_NODE) {
-        link_entry.node_id = std::stol(vec[1]);
-        if (vec.size() >= 3) {
-            if (vec.size() == 3) link_entry.anch = vec[2];
-            else                 link_entry.anch = curr_link.substr(vec[0].size() + vec[1].size() + 2);
-        }
-    } else {
-        CtDialogs::error_dialog(str::format("Tag Name Not Recognized! (%s)", std::string(link_entry.type)), *_pCtMainWin);
+    const CtLinkEntry new_entry = CtMiscUtil::get_link_entry(curr_link);
+    if (new_entry.type.empty()) {
+        CtDialogs::error_dialog(str::format("Tag Name Not Recognized! (%s)", std::string(curr_link)), *_pCtMainWin);
         link_entry.type = CtConst::LINK_TYPE_WEBS;
         return false;
     }
+    link_entry = new_entry;
     return true;
 }
 
 // Read Global Links Variables from Dialog
-Glib::ustring CtActions::_links_entries_post_dialog(CtDialogs::CtLinkEntry& link_entry)
+Glib::ustring CtActions::_links_entries_post_dialog(CtLinkEntry& link_entry)
 {
      Glib::ustring property_value = "";
      if (link_entry.type == CtConst::LINK_TYPE_WEBS) {

--- a/src/ct/ct_actions_others.cc
+++ b/src/ct/ct_actions_others.cc
@@ -258,10 +258,10 @@ void CtActions::toggle_show_hide_main_window()
 // Function Called at Every Link Click
 void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_wheel)
 {
-     auto vec = str::split(tag_property_value, " ");
-     if (vec[0] == CtConst::LINK_TYPE_WEBS) // link to webpage
+    CtLinkEntry link_entry = CtMiscUtil::get_link_entry(tag_property_value);
+     if (link_entry.type == CtConst::LINK_TYPE_WEBS) // link to webpage
      {
-         Glib::ustring clean_weblink = str::replace(vec[1], "amp;", "");
+         Glib::ustring clean_weblink = str::replace(link_entry.webs, "amp;", "");
          if (_pCtMainWin->get_ct_config()->weblinkCustomOn)
          {
              std::string cmd = fmt::sprintf(_pCtMainWin->get_ct_config()->weblinkCustomAct, clean_weblink);
@@ -274,9 +274,9 @@ void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_
          }
          else fs::open_weblink(clean_weblink);
      }
-     else if (vec[0] == CtConst::LINK_TYPE_FILE) // link to file
+     else if (link_entry.type == CtConst::LINK_TYPE_FILE) // link to file
      {
-         fs::path filepath = CtExport2Html::_link_process_filepath(vec[1]);
+         fs::path filepath = CtExport2Html::_link_process_filepath(link_entry.file);
          if (not Glib::file_test(filepath.string(), Glib::FILE_TEST_IS_REGULAR))
          {
              CtDialogs::error_dialog(str::format(_("The File Link '%s' is Not Valid"), filepath.string()), *_pCtMainWin);
@@ -286,9 +286,9 @@ void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_
              filepath = fs::absolute(filepath).parent_path();
          fs::open_filepath(filepath, true, _pCtMainWin->get_ct_config());
      }
-     else if (vec[0] == CtConst::LINK_TYPE_FOLD) // link to folder
+     else if (link_entry.type == CtConst::LINK_TYPE_FOLD) // link to folder
      {
-         fs::path folderpath = CtExport2Html::_link_process_folderpath(vec[1]).c_str();
+         fs::path folderpath = CtExport2Html::_link_process_folderpath(link_entry.fold).c_str();
          if (not fs::is_directory(folderpath))
          {
              CtDialogs::error_dialog(str::format(_("The Folder Link '%s' is Not Valid"), folderpath.string()), *_pCtMainWin);
@@ -298,24 +298,21 @@ void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_
              folderpath = Glib::path_get_dirname(fs::absolute(folderpath).string());
          fs::open_folderpath(folderpath, _pCtMainWin->get_ct_config());
      }
-     else if (vec[0] == CtConst::LINK_TYPE_NODE) // link to a tree node
+     else if (link_entry.type == CtConst::LINK_TYPE_NODE) // link to a tree node
      {
-         CtTreeIter tree_iter = _pCtMainWin->get_tree_store().get_node_from_node_id(std::stol(vec[1]));
+         CtTreeIter tree_iter = _pCtMainWin->get_tree_store().get_node_from_node_id(link_entry.node_id);
          if (not tree_iter)
          {
-             CtDialogs::error_dialog(str::format(_("The Link Refers to a Node that Does Not Exist Anymore (Id = %s)"), std::string(vec[1])), *_pCtMainWin);
+             CtDialogs::error_dialog(str::format(_("The Link Refers to a Node that Does Not Exist Anymore (Id = %s)"), std::to_string(link_entry.node_id)), *_pCtMainWin);
              return;
          }
          _pCtMainWin->get_tree_view().set_cursor_safe(tree_iter);
          _pCtMainWin->get_text_view().grab_focus();
          _pCtMainWin->get_text_view().get_window(Gtk::TEXT_WINDOW_TEXT)->set_cursor(Gdk::Cursor::create(Gdk::XTERM));
          _pCtMainWin->get_text_view().set_tooltip_text("");
-         if (vec.size() >= 3)
+         if (!link_entry.anch.empty())
          {
-             Glib::ustring anchor_name;
-             if (vec.size() == 3) anchor_name = vec[2];
-             else anchor_name = tag_property_value.substr(vec[0].size() + vec[1].size() + 2);
-
+             Glib::ustring anchor_name = link_entry.anch;
              CtImageAnchor* imageAnchor = nullptr;
              for (auto& widget: tree_iter.get_embedded_pixbufs_tables_codeboxes_fast())
                  if (CtImageAnchor* anchor = dynamic_cast<CtImageAnchor*>(widget))
@@ -336,7 +333,7 @@ void CtActions::link_clicked(const Glib::ustring& tag_property_value, bool from_
          }
      }
      else
-         CtDialogs::error_dialog(str::format("Tag Name Not Recognized! (%s)", std::string(vec[0])), *_pCtMainWin);
+         CtDialogs::error_dialog(str::format("Tag Name Not Recognized! (%s)", std::string(tag_property_value)), *_pCtMainWin);
 }
 
 // Cut CodeBox

--- a/src/ct/ct_actions_others.cc
+++ b/src/ct/ct_actions_others.cc
@@ -224,7 +224,7 @@ void CtActions::image_delete()
 void CtActions::image_link_edit()
 {
     if (not _is_curr_node_not_read_only_or_error()) return;
-    _link_entry = CtDialogs::CtLinkEntry();
+    _link_entry = CtLinkEntry();
     if  (curr_image_anchor->get_link().empty())
         _link_entry.type = CtConst::LINK_TYPE_WEBS; // default value
     else if (not _links_entries_pre_dialog(curr_image_anchor->get_link(), _link_entry))

--- a/src/ct/ct_dialogs.h
+++ b/src/ct/ct_dialogs.h
@@ -209,16 +209,6 @@ Glib::ustring img_n_entry_dialog(Gtk::Window& parent,
                                  const Glib::ustring& entry_content,
                                  const char* img_stock);
 
-struct CtLinkEntry
-{
-    Glib::ustring type;
-    gint64        node_id{-1};
-    Glib::ustring webs;
-    Glib::ustring file;
-    Glib::ustring fold;
-    Glib::ustring anch;
-};
-
 // Dialog to Insert/Edit Links
 bool link_handle_dialog(CtMainWin& ctMainWin,
                         const Glib::ustring& title,

--- a/src/ct/ct_export2pdf.h
+++ b/src/ct/ct_export2pdf.h
@@ -65,9 +65,9 @@ public:
     void pango_get_from_treestore_node(CtTreeIter node_iter, int sel_start, int sel_end, std::vector<CtPangoObjectPtr>& out_slots);
 
 private:
-    void          _pango_process_slot(int start_offset, int end_offset, Glib::RefPtr<Gtk::TextBuffer> curr_buffer, std::vector<CtPangoObjectPtr>& out_slots);
-    void          _pango_text_serialize(const Gtk::TextIter& start_iter, Gtk::TextIter end_iter, const std::map<std::string_view, std::string> &curr_attributes, std::vector<CtPangoObjectPtr>& out_slots);
-    Glib::ustring _pango_link_url(const Glib::ustring& url);
+    void                         _pango_process_slot(int start_offset, int end_offset, Glib::RefPtr<Gtk::TextBuffer> curr_buffer, std::vector<CtPangoObjectPtr>& out_slots);
+    void                         _pango_text_serialize(const Gtk::TextIter& start_iter, Gtk::TextIter end_iter, const std::map<std::string_view, std::string> &curr_attributes, std::vector<CtPangoObjectPtr>& out_slots);
+    std::shared_ptr<CtPangoText> _pango_link_url(const Glib::ustring& tagged_text, const Glib::ustring& link);
 };
 
 

--- a/src/ct/ct_main_win.cc
+++ b/src/ct/ct_main_win.cc
@@ -378,26 +378,19 @@ const std::string CtMainWin::get_text_tag_name_exist_or_create(const std::string
 // Get the tooltip for the underlying link
 Glib::ustring CtMainWin::sourceview_hovering_link_get_tooltip(const Glib::ustring& link)
 {
+    CtLinkEntry link_entry = CtMiscUtil::get_link_entry(link);
     Glib::ustring tooltip;
-    auto vec = str::split(link, " ");
-    if (vec.size() == 1) { // case when link has wrong format
+    if (link_entry.type == "") { // case when link has wrong format
         tooltip = str::replace(link, "amp;", "");
     } 
-    else if (vec[0] == CtConst::LINK_TYPE_FILE or vec[0] == CtConst::LINK_TYPE_FOLD) {
-        tooltip = Glib::Base64::decode(vec[1]);
-    }
-    else
-    {
-        if (vec[0] == CtConst::LINK_TYPE_NODE)
-            tooltip = _uCtTreestore->get_node_name_from_node_id(std::stol(vec[1]));
-        else
-            tooltip = str::replace(vec[1], "amp;", "");
-        if (vec.size() >= 3)
-        {
-            if (vec.size() == 3) tooltip += "#" + vec[2];
-            else
-                tooltip += "#" + link.substr(vec[0].length() + vec[1].length() + 2);
-        }
+    else if (link_entry.type == CtConst::LINK_TYPE_FILE) {
+        tooltip = link_entry.file;
+    } else if (link_entry.type == CtConst::LINK_TYPE_FOLD) {
+        tooltip = link_entry.fold;
+    } else if (link_entry.type == CtConst::LINK_TYPE_NODE) {
+        tooltip = _uCtTreestore->get_node_name_from_node_id(link_entry.node_id);
+        if (!link_entry.anch.empty())
+            tooltip += "#" + link_entry.anch;
     }
     return tooltip;
 }

--- a/src/ct/ct_misc_utils.h
+++ b/src/ct/ct_misc_utils.h
@@ -65,6 +65,8 @@ std::string clean_from_chars_not_for_filename(std::string filename);
 
 Gtk::BuiltinIconSize getIconSize(int size);
 
+CtLinkEntry get_link_entry(const Glib::ustring& link);
+
 /**
  * @brief Check if the the mime for a file contains a given string
  * @return
@@ -198,8 +200,6 @@ Glib::ustring get_accelerator_label(const std::string& accelerator);
 
 std::string get_internal_link_from_http_url(std::string link_url);
 
-/// reverse get_internal_link_from_http_url and strips internal identifiers
-std::string external_uri_from_internal(std::string internal_uri);
 
 } // namespace CtStrUtil
 

--- a/src/ct/ct_types.h
+++ b/src/ct/ct_types.h
@@ -60,6 +60,16 @@ class CtCodebox;
 class CtMainWin;
 typedef std::pair<CtCodebox*, CtMainWin*>   CtPairCodeboxMainWin;
 
+struct CtLinkEntry
+{
+    Glib::ustring type;
+    gint64        node_id{-1};
+    Glib::ustring webs;
+    Glib::ustring file;
+    Glib::ustring fold;
+    Glib::ustring anch;
+};
+
 struct CtListInfo
 {
     CtListType type = CtListType::None;

--- a/tests/tests_misc_utils.cpp
+++ b/tests/tests_misc_utils.cpp
@@ -378,14 +378,21 @@ TEST(MiscUtilsGroup, parallel_for)
         }
 }
 
-TEST(MiscUtilsGroup, external_uri_from_internal) 
+TEST(MiscUtilsGroup, get_link_entry)
 {
-    STRCMP_EQUAL("https://example.com", CtStrUtil::external_uri_from_internal("webs https://example.com").c_str());
-    STRCMP_EQUAL("/home/foo/bar\n", CtStrUtil::external_uri_from_internal("file L2hvbWUvZm9vL2Jhcgo=").c_str());
-    // looks like CppUTest is built on Win32 without the Standard C++ Library 
-#ifndef _WIN32
-    CHECK_THROWS(std::logic_error, CtStrUtil::external_uri_from_internal("https://example.com"));
-    CHECK_THROWS(std::logic_error, CtStrUtil::external_uri_from_internal("/home/foo/bar"));
-#endif
+    STRCMP_EQUAL(CtConst::LINK_TYPE_WEBS, CtMiscUtil::get_link_entry("webs https://example.com").type.c_str());
+    STRCMP_EQUAL("https://example.com", CtMiscUtil::get_link_entry("webs https://example.com").webs.c_str());
+    STRCMP_EQUAL(CtConst::LINK_TYPE_FILE, CtMiscUtil::get_link_entry("file L2hvbWUvZm9vL2Jhcgo=").type.c_str());
+    STRCMP_EQUAL("/home/foo/bar\n", CtMiscUtil::get_link_entry("file L2hvbWUvZm9vL2Jhcgo=").file.c_str());
+    STRCMP_EQUAL(CtConst::LINK_TYPE_FOLD, CtMiscUtil::get_link_entry("fold L2hvbWUvZm9vL2Jhcgo=").type.c_str());
+    STRCMP_EQUAL("/home/foo/bar\n", CtMiscUtil::get_link_entry("fold L2hvbWUvZm9vL2Jhcgo=").fold.c_str());
+    STRCMP_EQUAL(CtConst::LINK_TYPE_NODE, CtMiscUtil::get_link_entry("node 2 hi hi").type.c_str());
+    CHECK(CtMiscUtil::get_link_entry("node 2 hi hi").node_id == 2);
+    STRCMP_EQUAL("hi hi", CtMiscUtil::get_link_entry("node 2 hi hi").anch.c_str());
+
+    STRCMP_EQUAL("", CtMiscUtil::get_link_entry("").type.c_str());
+    STRCMP_EQUAL("", CtMiscUtil::get_link_entry("https://example.com").type.c_str());
+    STRCMP_EQUAL("", CtMiscUtil::get_link_entry("/home/foo/bar").type.c_str());
+    STRCMP_EQUAL("", CtMiscUtil::get_link_entry("home https://example.com").type.c_str());
 }
 


### PR DESCRIPTION
- CtMiscUtil::get_link_entry is used to get link data
- removes exceptions for `invalid` links during pdf export
- adds underlining for links in pdf export ( #1113) 