### PR TITLE
Fixes search

### DIFF
--- a/src/ct/ct_actions_find.cc
+++ b/src/ct/ct_actions_find.cc
@@ -197,7 +197,7 @@ void CtActions::_find_in_all_nodes(bool for_current_node)
             if (!all_matches ||  ctStatusBar.is_progress_stop()) break;
         }
         s_state.processed_nodes += 1;
-        if (s_state.matches_num == 1 || !all_matches) break;
+        if (s_state.matches_num == 1 && !all_matches) break;
         if (for_current_node && !s_state.from_find_iterated) break;
         Gtk::TreeIter last_top_node_iter = node_iter; // we need this if we start from a node that is not in top level
         if (forward) node_iter = ++node_iter;

--- a/src/ct/ct_actions_find.cc
+++ b/src/ct/ct_actions_find.cc
@@ -88,6 +88,7 @@ void CtActions::find_in_selected_node()
 
     if (all_matches) {
         s_state.match_store->clear();
+        s_state.match_store->saved_path.clear();
         s_state.all_matches_first_in_node = true;
         while (_parse_node_content_iter(_pCtMainWin->curr_tree_iter(), curr_buffer, re_pattern, forward, first_fromsel, all_matches, true))
             s_state.matches_num += 1;
@@ -168,7 +169,10 @@ void CtActions::_find_in_all_nodes(bool for_current_node)
         node_iter = forward ? _pCtMainWin->get_tree_store().get_iter_first() : _pCtMainWin->get_tree_store().get_tree_iter_last_sibling(_pCtMainWin->get_tree_store().get_store()->children());
     }
     s_state.matches_num = 0;
-    if (all_matches) s_state.match_store->clear();
+    if (all_matches) {
+        s_state.match_store->clear();
+        s_state.match_store->saved_path.clear();
+    }
 
     std::string tree_expanded_collapsed_string = _pCtMainWin->get_tree_store().treeview_get_tree_expanded_collapsed_string(_pCtMainWin->get_tree_view());
     // searching start
@@ -284,8 +288,10 @@ void CtActions::find_a_node()
         node_iter = forward ? _pCtMainWin->get_tree_store().get_iter_first() : _pCtMainWin->get_tree_store().get_tree_iter_last_sibling(_pCtMainWin->get_tree_store().get_store()->children());;
 
     s_state.matches_num = 0;
-    if (all_matches)
+    if (all_matches) {
         s_state.match_store->clear();
+        s_state.match_store->saved_path.clear();
+    }
     // searching start
     while (node_iter) {
         if (_parse_node_name(_pCtMainWin->get_tree_store().to_ct_tree_iter(node_iter), re_pattern, forward, all_matches)) {

--- a/src/ct/ct_dialogs.h
+++ b/src/ct/ct_dialogs.h
@@ -118,7 +118,7 @@ public:
 
     std::array<int, 2> dlg_size;
     std::array<int, 2> dlg_pos;
-    Gtk::TreePath      saved_path;
+    std::string        saved_path; // don't use Gtk::TreePath, see git log
 
 public:
     virtual ~CtMatchDialogStore() {}


### PR DESCRIPTION
Possible fixes freezing (#1105, #1078)
Fixes missed results, caused by wrong condition.

Freezing is caused by gtk bug. Maybe there are other freezing situations, but I found only one:
Two nodes. First node with codebox (content = 123) at the very beginning (otherwise bug doesn't 'work'). The second node other text. Select the second node and the text there. Search all nodes with 123, it is freezing when it tries to select codebox.
The temporary solution is to unselect text in the current buffer.
