### PR TITLE
option to export HTML as a single file

### DIFF
--- a/src/ct/ct_actions.h
+++ b/src/ct/ct_actions.h
@@ -434,7 +434,7 @@ private:
     // helper for export actions
     void _export_print(bool save_to_pdf, const fs::path& auto_path, bool auto_overwrite);
     void _export_to_html(const fs::path& auto_path, bool auto_overwrite);
-    void _export_to_txt(bool is_single, const fs::path& auto_path, bool auto_overwrite);
+    void _export_to_txt(const fs::path& auto_path, bool auto_overwrite);
 
     fs::path _get_pdf_filepath(const fs::path& proposed_name);
     fs::path _get_txt_filepath(const fs::path& proposed_name);
@@ -446,8 +446,7 @@ public:
     void export_print();
     void export_to_pdf();
     void export_to_html();
-    void export_to_txt_multiple();
-    void export_to_txt_single();
+    void export_to_txt();
     void export_to_ctd();
 
     void export_to_pdf_auto(const std::string& dir, bool overwrite);

--- a/src/ct/ct_actions_edit.cc
+++ b/src/ct/ct_actions_edit.cc
@@ -370,7 +370,7 @@ void CtActions::toc_insert()
     if (!_is_there_selected_node_or_error()) return;
     if (!_node_sel_and_rich_text()) return;
 
-    auto toc_type = CtDialogs::selnode_selnodeandsub_alltree_dialog(*_pCtMainWin, false, nullptr, nullptr, nullptr);
+    auto toc_type = CtDialogs::selnode_selnodeandsub_alltree_dialog(*_pCtMainWin, false, nullptr, nullptr, nullptr, nullptr);
 
     if (toc_type == CtExporting::NONE) return;
 

--- a/src/ct/ct_actions_export.cc
+++ b/src/ct/ct_actions_export.cc
@@ -70,7 +70,8 @@ void CtActions::export_to_ctd()
         true/*also_selection*/,
         nullptr/*include_node_name*/,
         nullptr/*new_node_page*/,
-        nullptr/*last_index_in_page*/
+        nullptr/*last_index_in_page*/,
+        nullptr/*last_single_file*/
     );
     if (CtExporting::NONE == export_type) {
         return;
@@ -156,7 +157,7 @@ void CtActions::_export_print(bool save_to_pdf, const fs::path& auto_path, bool 
     if (!_is_there_selected_node_or_error()) return;
     auto export_type = !auto_path.empty() ? CtExporting::ALL_TREE
                                        : CtDialogs::selnode_selnodeandsub_alltree_dialog(*_pCtMainWin, true, &_export_options.include_node_name,
-                                                                                         &_export_options.new_node_page, nullptr);
+                                                                                         &_export_options.new_node_page, nullptr, nullptr);
     if (export_type == CtExporting::NONE) return;
 
     fs::path pdf_filepath;
@@ -218,7 +219,7 @@ void CtActions::_export_to_html(const fs::path& auto_path, bool auto_overwrite)
     if (!_is_there_selected_node_or_error()) return;
     auto export_type = auto_path != "" ? CtExporting::ALL_TREE
                                        : CtDialogs::selnode_selnodeandsub_alltree_dialog(*_pCtMainWin, true, &_export_options.include_node_name,
-                                                                                         nullptr, &_export_options.index_in_page);
+                                                                                         nullptr, &_export_options.index_in_page, &_export_options.single_file);
     if (export_type == CtExporting::NONE) return;
 
     CtExport2Html export2html(_pCtMainWin);
@@ -233,13 +234,21 @@ void CtActions::_export_to_html(const fs::path& auto_path, bool auto_overwrite)
     {
         std::string folder_name = CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter());
         if (export2html.prepare_html_folder("", folder_name, false, ret_html_path))
-            export2html.nodes_all_export_to_html(false, _export_options);
+            if (_export_options.single_file) {
+                export2html.nodes_all_export_to_single_html(false, _export_options);
+            } else {
+                export2html.nodes_all_export_to_html(false, _export_options);
+            }
     }
     else if (export_type == CtExporting::ALL_TREE)
     {
         fs::path folder_name = _pCtMainWin->get_ct_storage()->get_file_name();
         if (export2html.prepare_html_folder(auto_path, folder_name, auto_overwrite, ret_html_path))
-            export2html.nodes_all_export_to_html(true, _export_options);
+            if (_export_options.single_file) {
+                export2html.nodes_all_export_to_single_html(true, _export_options);
+            } else {
+                export2html.nodes_all_export_to_html(true, _export_options);
+            }
     }
     else if (export_type == CtExporting::SELECTED_TEXT)
     {
@@ -267,7 +276,7 @@ void CtActions::_export_to_txt(bool is_single, const fs::path& auto_path, bool a
         export_type = CtExporting::ALL_TREE;
     }
     else
-        export_type = CtDialogs::selnode_selnodeandsub_alltree_dialog(*_pCtMainWin, true, &_export_options.include_node_name, nullptr, nullptr);
+        export_type = CtDialogs::selnode_selnodeandsub_alltree_dialog(*_pCtMainWin, true, &_export_options.include_node_name, nullptr, nullptr, nullptr);
     if (export_type == CtExporting::NONE) return;
 
     if (export_type == CtExporting::CURRENT_NODE)

--- a/src/ct/ct_actions_export.cc
+++ b/src/ct/ct_actions_export.cc
@@ -50,14 +50,9 @@ void CtActions::export_to_html()
     _export_to_html("", false);
 }
 
-void CtActions::export_to_txt_multiple()
+void CtActions::export_to_txt()
 {
-    _export_to_txt(false, "", false);
-}
-
-void CtActions::export_to_txt_single()
-{
-    _export_to_txt(true, "", false);
+    _export_to_txt("", false);
 }
 
 void CtActions::export_to_ctd()
@@ -149,7 +144,7 @@ void CtActions::export_to_txt_auto(const std::string& dir, bool overwrite)
 {
     spdlog::debug("txt export to: {}", dir);
     spdlog::debug("overwrite: {}", overwrite);
-    _export_to_txt(false, dir, overwrite);
+    _export_to_txt(dir, overwrite);
 }
 
 void CtActions::_export_print(bool save_to_pdf, const fs::path& auto_path, bool auto_overwrite)
@@ -233,22 +228,24 @@ void CtActions::_export_to_html(const fs::path& auto_path, bool auto_overwrite)
     else if (export_type == CtExporting::CURRENT_NODE_AND_SUBNODES)
     {
         std::string folder_name = CtMiscUtil::get_node_hierarchical_name(_pCtMainWin->curr_tree_iter());
-        if (export2html.prepare_html_folder("", folder_name, false, ret_html_path))
+        if (export2html.prepare_html_folder("", folder_name, false, ret_html_path)) {
             if (_export_options.single_file) {
                 export2html.nodes_all_export_to_single_html(false, _export_options);
             } else {
-                export2html.nodes_all_export_to_html(false, _export_options);
+                export2html.nodes_all_export_to_multiple_html(false, _export_options);
             }
+        }
     }
     else if (export_type == CtExporting::ALL_TREE)
     {
         fs::path folder_name = _pCtMainWin->get_ct_storage()->get_file_name();
-        if (export2html.prepare_html_folder(auto_path, folder_name, auto_overwrite, ret_html_path))
-            if (_export_options.single_file) {
+        if (export2html.prepare_html_folder(auto_path, folder_name, auto_overwrite, ret_html_path)) {
+            if (auto_path.empty() && _export_options.single_file) {
                 export2html.nodes_all_export_to_single_html(true, _export_options);
             } else {
-                export2html.nodes_all_export_to_html(true, _export_options);
+                export2html.nodes_all_export_to_multiple_html(true, _export_options);
             }
+        }
     }
     else if (export_type == CtExporting::SELECTED_TEXT)
     {
@@ -266,7 +263,7 @@ void CtActions::_export_to_html(const fs::path& auto_path, bool auto_overwrite)
 }
 
 // Export To Plain Text Multiple (or single) Files
-void CtActions::_export_to_txt(bool is_single, const fs::path& auto_path, bool auto_overwrite)
+void CtActions::_export_to_txt(const fs::path& auto_path, bool auto_overwrite)
 {
     if (!_is_there_selected_node_or_error()) return;
     CtExporting export_type;
@@ -276,7 +273,7 @@ void CtActions::_export_to_txt(bool is_single, const fs::path& auto_path, bool a
         export_type = CtExporting::ALL_TREE;
     }
     else
-        export_type = CtDialogs::selnode_selnodeandsub_alltree_dialog(*_pCtMainWin, true, &_export_options.include_node_name, nullptr, nullptr, nullptr);
+        export_type = CtDialogs::selnode_selnodeandsub_alltree_dialog(*_pCtMainWin, true, &_export_options.include_node_name, nullptr, nullptr, &_export_options.single_file);
     if (export_type == CtExporting::NONE) return;
 
     if (export_type == CtExporting::CURRENT_NODE)
@@ -288,7 +285,7 @@ void CtActions::_export_to_txt(bool is_single, const fs::path& auto_path, bool a
     }
     else if (export_type == CtExporting::CURRENT_NODE_AND_SUBNODES)
     {
-        if (is_single)
+        if (_export_options.single_file)
         {
            fs::path txt_filepath = _get_txt_filepath(_pCtMainWin->get_ct_storage()->get_file_name());
            if (txt_filepath.empty()) return;
@@ -303,7 +300,7 @@ void CtActions::_export_to_txt(bool is_single, const fs::path& auto_path, bool a
     }
     else if (export_type == CtExporting::ALL_TREE)
     {
-        if (is_single)
+        if (auto_path.empty() && _export_options.single_file)
         {
             fs::path txt_filepath = _get_txt_filepath(_pCtMainWin->get_ct_storage()->get_file_name());
             if (txt_filepath.empty()) return;

--- a/src/ct/ct_dialogs.cc
+++ b/src/ct/ct_dialogs.cc
@@ -124,7 +124,8 @@ CtExporting CtDialogs::selnode_selnodeandsub_alltree_dialog(Gtk::Window& parent,
                                                             bool also_selection,
                                                             bool* last_include_node_name,
                                                             bool* last_new_node_page,
-                                                            bool* last_index_in_page)
+                                                            bool* last_index_in_page,
+                                                            bool* last_single_file)
 {
     Gtk::Dialog dialog(_("Involved Nodes"),
                        parent,
@@ -175,12 +176,18 @@ CtExporting CtDialogs::selnode_selnodeandsub_alltree_dialog(Gtk::Window& parent,
         checkbutton_new_node_page.set_active(*last_new_node_page);
         content_area->pack_start(checkbutton_new_node_page);
     }
+    auto checkbutton_single_file = Gtk::CheckButton(_("Single File"));
+    if (last_single_file != nullptr) {
+        checkbutton_single_file.set_active(*last_single_file);
+        content_area->pack_start(checkbutton_single_file);
+    }
     content_area->show_all();
     int response = dialog.run();
 
     if (last_include_node_name != nullptr) *last_include_node_name = checkbutton_node_name.get_active();
     if (last_index_in_page != nullptr) *last_index_in_page = checkbutton_index_in_page.get_active();
     if (last_new_node_page != nullptr) *last_new_node_page = checkbutton_new_node_page.get_active();
+    if (last_single_file != nullptr) *last_single_file = checkbutton_single_file.get_active();
 
     if (response != Gtk::RESPONSE_ACCEPT) return CtExporting::NONE;
     if (radiobutton_selnode.get_active()) return CtExporting::CURRENT_NODE;

--- a/src/ct/ct_dialogs.h
+++ b/src/ct/ct_dialogs.h
@@ -159,9 +159,10 @@ Gtk::TreeIter choose_item_dialog(Gtk::Window& parent,
 // Dialog to select between the Selected Node/Selected Node + Subnodes/All Tree
 CtExporting selnode_selnodeandsub_alltree_dialog(Gtk::Window& parent,
                                                  bool also_selection,
-                                                 bool* last_include_node_name /*= nullptr*/,
-                                                 bool* last_new_node_page /*= nullptr*/,
-                                                 bool* last_index_in_page /*= nullptr*/);
+                                                 bool* last_include_node_name,
+                                                 bool* last_new_node_page,
+                                                 bool* last_index_in_page,
+                                                 bool* last_single_file);
 
 // Dialog to select a color, featuring a palette
 enum class CtPickDlgState {SELECTED, CANCEL, REMOVE_COLOR };

--- a/src/ct/ct_export2html.cc
+++ b/src/ct/ct_export2html.cc
@@ -145,7 +145,7 @@ void CtExport2Html::node_export_to_html(CtTreeIter tree_iter, const CtExportOpti
 }
 
 // Export All Nodes To HTML
-void CtExport2Html::nodes_all_export_to_html(bool all_tree, const CtExportOptions& options)
+void CtExport2Html::nodes_all_export_to_multiple_html(bool all_tree, const CtExportOptions& options)
 {
     fs::path home_svg = fs::get_cherrytree_datadir() / fs::path("icons") / "ct_home.svg";
     fs::copy_file(home_svg, _images_dir / "home.svg");

--- a/src/ct/ct_export2html.h
+++ b/src/ct/ct_export2html.h
@@ -49,6 +49,7 @@ public:
 
     void          node_export_to_html(CtTreeIter tree_iter, const CtExportOptions& options, const Glib::ustring& index, int sel_start, int sel_end);
     void          nodes_all_export_to_html(bool all_tree, const CtExportOptions& options);
+    void          nodes_all_export_to_single_html(bool all_tree, const CtExportOptions& options);
     Glib::ustring selection_export_to_html(Glib::RefPtr<Gtk::TextBuffer> text_buffer, Gtk::TextIter start_iter,
                                            Gtk::TextIter end_iter, const Glib::ustring& syntax_highlighting);
     Glib::ustring table_export_to_html(CtTable* table);

--- a/src/ct/ct_export2html.h
+++ b/src/ct/ct_export2html.h
@@ -48,7 +48,7 @@ public:
     CtExport2Html(CtMainWin* pCtMainWin);
 
     void          node_export_to_html(CtTreeIter tree_iter, const CtExportOptions& options, const Glib::ustring& index, int sel_start, int sel_end);
-    void          nodes_all_export_to_html(bool all_tree, const CtExportOptions& options);
+    void          nodes_all_export_to_multiple_html(bool all_tree, const CtExportOptions& options);
     void          nodes_all_export_to_single_html(bool all_tree, const CtExportOptions& options);
     Glib::ustring selection_export_to_html(Glib::RefPtr<Gtk::TextBuffer> text_buffer, Gtk::TextIter start_iter,
                                            Gtk::TextIter end_iter, const Glib::ustring& syntax_highlighting);

--- a/src/ct/ct_menu.cc
+++ b/src/ct/ct_menu.cc
@@ -219,8 +219,7 @@ void CtMenu::init_actions(CtActions* pActions)
     const char* export_cat = _("Export");
     _actions.push_back(CtMenuAction{export_cat, "export_pdf", "ct_to_pdf", _("Export To _PDF"), None, _("Export To PDF"), sigc::mem_fun(*pActions, &CtActions::export_to_pdf)});
     _actions.push_back(CtMenuAction{export_cat, "export_html", "ct_to_html", _("Export To _HTML"), None, _("Export To HTML"), sigc::mem_fun(*pActions, &CtActions::export_to_html)});
-    _actions.push_back(CtMenuAction{export_cat, "export_txt_multiple", "ct_to_txt", _("Export to Multiple Plain _Text Files"), None, _("Export to Multiple Plain Text Files"), sigc::mem_fun(*pActions, &CtActions::export_to_txt_multiple)});
-    _actions.push_back(CtMenuAction{export_cat, "export_txt_single", "ct_to_txt", _("Export to _Single Plain Text File"), None, _("Export to Single Plain Text File"), sigc::mem_fun(*pActions, &CtActions::export_to_txt_single)});
+    _actions.push_back(CtMenuAction{export_cat, "export_txt", "ct_to_txt", _("Export to Plain _Text"), None, _("Export to Plain Text"), sigc::mem_fun(*pActions, &CtActions::export_to_txt)});
     _actions.push_back(CtMenuAction{export_cat, "export_ctd", "ct_to_cherrytree", _("_Export To CherryTree Document"), None, _("Export To CherryTree Document"), sigc::mem_fun(*pActions, &CtActions::export_to_ctd)});
     const char* import_cat = _("Import");
     _actions.push_back(CtMenuAction{import_cat, "import_cherrytree", "ct_from_cherrytree", _("From _CherryTree File"), None, _("Add Nodes of a CherryTree File to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_ct_file) /* dad.nodes_add_from_cherrytree_file */});
@@ -922,8 +921,7 @@ const char* CtMenu::_get_ui_str_menu()
     <menu action='TreeExportMenu'>
       <menuitem action='export_pdf'/>
       <menuitem action='export_html'/>
-      <menuitem action='export_txt_multiple'/>
-      <menuitem action='export_txt_single'/>
+      <menuitem action='export_txt'/>
       <menuitem action='export_ctd'/>
     </menu>
     <separator/>
@@ -992,8 +990,7 @@ const char* CtMenu::_get_ui_str_menu()
   <menu action='ExportMenu'>
     <menuitem action='export_pdf'/>
     <menuitem action='export_html'/>
-    <menuitem action='export_txt_multiple'/>
-    <menuitem action='export_txt_single'/>
+    <menuitem action='export_txt'/>
     <menuitem action='export_ctd'/>
   </menu>
 

--- a/src/ct/ct_types.h
+++ b/src/ct/ct_types.h
@@ -201,6 +201,7 @@ struct CtExportOptions
     bool include_node_name{true};
     bool new_node_page{false};
     bool index_in_page{true};
+    bool single_file{false};
 };
 
 struct CtSummaryInfo


### PR DESCRIPTION
@giuspen , I couldn't come up with a nice menu title for the command, so I decided just to add an option 'Single File' on the export dialog. If you have any comments about that, I'd be glad to hear them. 
To be honest, I'd prefer that commands have similar behavior; it's better to have either two commands for HTML export (multi/single) or join plain text export commands into one command.

