### PR TITLE
WIP: Make it possible to use an external spdlog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,17 @@ elseif (CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 
+# Add an option to use an external spdlog build instead of the bundled
+# Call it SPDLOG_FMT_EXTERNAL instead of something like EXTERNAL_SPDLOG because
+# the former is used as a #define in a couple of files so it simplifies things
+# just a little bit.
+option(SPDLOG_FMT_EXTERNAL "Use external spdlog and fmt" OFF)
+
 # Create the configuration files config.h in the root dir
 configure_file(${CMAKE_SOURCE_DIR}/config.h.cmake ${CMAKE_SOURCE_DIR}/config.h)
+# Create a configuration file for spdlog in the src/ct dir
+configure_file(${CMAKE_SOURCE_DIR}/src/ct/config_spdlog.h.cmake ${CMAKE_SOURCE_DIR}/src/ct/config_spdlog.h)
+
 
 option(BUILD_TESTING "Build tests" ON)
 if (BUILD_TESTING)
@@ -104,14 +113,18 @@ pkg_check_modules(GSPELL gspell-1 REQUIRED)
 pkg_check_modules(LIBXML libxml++-2.6 REQUIRED)
 pkg_check_modules(SQLITE sqlite3 REQUIRED)
 pkg_check_modules(CURL libcurl REQUIRED)
+if(SPDLOG_FMT_EXTERNAL)
+  pkg_check_modules(SPDLOG spdlog REQUIRED)
+endif()
 if(BUILD_TESTING)
   pkg_check_modules(CPPUTEST cpputest  REQUIRED)
 endif()
 
 add_subdirectory(src/7za)
 
-# Spdlog
-add_subdirectory(src/spdlog)
+if(NOT SPDLOG_FMT_EXTERNAL)
+  add_subdirectory(src/spdlog)
+endif()
 
 
 include(FindPackageHandleStandardArgs)
@@ -128,6 +141,9 @@ include_directories(
   SYSTEM ${CURL_INCLUDE_DIRS}
   include_directories(.) # to find src/fmt
 )
+if(SPDLOG_FMT_EXTERNAL)
+  include_directories(SYSTEM ${SPDLOG_INCLUDE_DIRS})
+endif()
 
 add_subdirectory(src/ct)
 

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -27,3 +27,6 @@
 /* folder with root CMakeLists.txt */
 #define _CMAKE_SOURCE_DIR "${CMAKE_SOURCE_DIR}"
 #define _CMAKE_BINARY_DIR "${CMAKE_BINARY_DIR}"
+
+/* Use an external spdlog/fmt or the one we bundle? */
+#cmakedefine SPDLOG_FMT_EXTERNAL

--- a/src/ct/CMakeLists.txt
+++ b/src/ct/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 add_compile_options(-Wall -Wextra -Wunreachable-code -Wuninitialized)
 
 if(USE_NLS)
@@ -76,8 +75,12 @@ target_link_libraries(cherrytree_shared
     ${CURL_LIBRARIES}
     pthread
     7za_static
-    spdlog::spdlog
 )
+if(SPDLOG_FMT_EXTERNAL)
+  target_link_libraries(cherrytree_shared ${SPDLOG_LIBRARIES})
+else()
+  target_link_libraries(cherrytree_shared spdlog::spdlog)
+endif()
 
 target_include_directories(cherrytree_shared PUBLIC "..")
 

--- a/src/ct/config_spdlog.h.cmake
+++ b/src/ct/config_spdlog.h.cmake
@@ -1,0 +1,6 @@
+#cmakedefine SPDLOG_FMT_EXTERNAL
+#ifdef SPDLOG_FMT_EXTERNAL
+#include <fmt/printf.h>
+#else
+#include <spdlog/fmt/bundled/printf.h>
+#endif

--- a/src/ct/ct_actions.h
+++ b/src/ct/ct_actions.h
@@ -1,4 +1,5 @@
 /*
+ *
  * ct_actions.h
  *
  * Copyright 2009-2020

--- a/src/ct/ct_actions_others.cc
+++ b/src/ct/ct_actions_others.cc
@@ -30,7 +30,7 @@
 #include <gtkmm/stock.h>
 #include <cstdlib>
 #include "ct_logging.h"
-#include <spdlog/fmt/bundled/printf.h>
+#include "config_spdlog.h"
 
 // Cut Link
 void CtActions::link_cut()

--- a/src/ct/ct_filesystem.cc
+++ b/src/ct/ct_filesystem.cc
@@ -24,7 +24,6 @@
 #include <glibmm/miscutils.h>
 #include <glib/gstdio.h>
 #include <curl/curl.h>
-#include <spdlog/fmt/bundled/printf.h>
 #include <system_error>
 
 #include "ct_filesystem.h"
@@ -32,6 +31,7 @@
 #include "ct_const.h"
 #include "ct_logging.h"
 #include "ct_config.h"
+#include "config_spdlog.h"
 
 namespace fs {
 

--- a/src/ct/ct_filesystem.h
+++ b/src/ct/ct_filesystem.h
@@ -29,6 +29,7 @@
 #include "ct_types.h"
 #include "ct_logging.h"
 #include <glibmm/miscutils.h>
+#include "config_spdlog.h"
 
 class CtConfig;
 

--- a/src/ct/ct_logging.h
+++ b/src/ct/ct_logging.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-
+#include "config.h"
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/fmt.h>

--- a/src/ct/ct_misc_utils.cc
+++ b/src/ct/ct_misc_utils.cc
@@ -32,7 +32,7 @@
 #include <regex>
 #include <glib/gstdio.h> // to get stats
 #include <curl/curl.h>
-#include <spdlog/fmt/bundled/printf.h>
+#include "config_spdlog.h"
 
 #include <thread> // for parallel_for
 #include <future> // parallel_for

--- a/src/ct/ct_misc_utils.h
+++ b/src/ct/ct_misc_utils.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "config_spdlog.h"
 #include "ct_types.h"
 #include <gtksourceviewmm.h>
 #include <gtkmm/treeiter.h>


### PR DESCRIPTION
This is important for some distributions like Fedora where packages are expected to not bundle dependencies.

I don't know if this is the best way to do this, but it's at least a functional way. I was able to build with and without the bundled spdlog on Fedora. 

I also understand that this is a non-trivial change to how the the build operates, so I am open to this being discussed for a while or rejected outright. :-)