### PR TITLE
fixes image placement in MenuBar/context menu

### DIFF
--- a/src/ct/ct_app.cc
+++ b/src/ct/ct_app.cc
@@ -76,9 +76,9 @@ CtApp::CtApp() : Gtk::Application("com.giuspen.cherrytree", Gio::APPLICATION_HAN
     });
     _rStatusIcon->signal_popup_menu().connect([&](guint button, guint32 activate_time){
         Gtk::Menu* systrayMenu = Gtk::manage(new Gtk::Menu());
-        auto item1 = CtMenu::create_menu_item(GTK_WIDGET(systrayMenu->gobj()), _("Show/Hide _CherryTree"), CtConst::APP_NAME, _("Toggle Show/Hide CherryTree"));
+        auto item1 = CtMenu::create_menu_item(systrayMenu, _("Show/Hide _CherryTree"), CtConst::APP_NAME, _("Toggle Show/Hide CherryTree"));
         item1->signal_activate().connect([&] {_systray_show_hide_windows();});
-        auto item2 = CtMenu::create_menu_item(GTK_WIDGET(systrayMenu->gobj()), _("_Exit CherryTree"), "ct_quit-app", _("Exit from CherryTree"));
+        auto item2 = CtMenu::create_menu_item(systrayMenu, _("_Exit CherryTree"), "ct_quit-app", _("Exit from CherryTree"));
         item2->signal_activate().connect([&] { _systray_close_all(); });
         systrayMenu->show_all();
         systrayMenu->popup(button, activate_time);

--- a/src/ct/ct_codebox.cc
+++ b/src/ct/ct_codebox.cc
@@ -138,7 +138,7 @@ CtCodebox::CtCodebox(CtMainWin* pCtMainWin,
         if (not _pCtMainWin->user_active()) return;
         for (auto iter : menu->get_children()) menu->remove(*iter);
         _pCtMainWin->get_ct_actions()->curr_codebox_anchor = this;
-        _pCtMainWin->get_ct_menu().build_popup_menu(GTK_WIDGET(menu->gobj()), CtMenu::POPUP_MENU_TYPE::Codebox);
+        _pCtMainWin->get_ct_menu().build_popup_menu(menu, CtMenu::POPUP_MENU_TYPE::Codebox);
     });
     _ctTextview.signal_key_press_event().connect(sigc::mem_fun(*this, &CtCodebox::_on_key_press_event), false);
     _ctTextview.signal_key_release_event().connect([this](GdkEventKey*) { _key_down = false; return false; }, false);

--- a/src/ct/ct_main_win.cc
+++ b/src/ct/ct_main_win.cc
@@ -88,7 +88,7 @@ CtMainWin::CtMainWin(bool             no_gui,
     _pRecentDocsSubmenu = CtMenu::find_menu_item(_pMenuBar, "RecentDocsMenu");
     _pSpecialCharsSubmenu = CtMenu::find_menu_item(_pMenuBar, "SpecialCharsMenu");
     _pMenuBar->show_all();
-    gtk_window_add_accel_group(GTK_WINDOW(gobj()), _uCtMenu->default_accel_group());
+    add_accel_group(_uCtMenu->get_accel_group());
     _pToolbars = _uCtMenu->build_toolbars(_pRecentDocsMenuToolButton);
 
     _vboxMain.pack_start(*_pMenuBar, false, false);
@@ -1797,16 +1797,16 @@ void CtMainWin::_on_textview_populate_popup(Gtk::Menu* menu)
                 if (do_set_cursor) curr_buffer()->place_cursor(target_iter);
             }
             //for (auto iter : menu->get_children()) menu->remove(*iter);
-            get_ct_menu().build_popup_menu(GTK_WIDGET(menu->gobj()), CtMenu::POPUP_MENU_TYPE::Link);
+            get_ct_menu().build_popup_menu(menu, CtMenu::POPUP_MENU_TYPE::Link);
         }
         else {
             //for (auto iter : menu->get_children()) menu->remove(*iter);
-            get_ct_menu().build_popup_menu(GTK_WIDGET(menu->gobj()), CtMenu::POPUP_MENU_TYPE::Text);
+            get_ct_menu().build_popup_menu(menu, CtMenu::POPUP_MENU_TYPE::Text);
         }
     }
     else {
         //for (auto iter : menu->get_children()) menu->remove(*iter);
-        _uCtActions->getCtMainWin()->get_ct_menu().build_popup_menu(GTK_WIDGET(menu->gobj()), CtMenu::POPUP_MENU_TYPE::Code);
+        _uCtActions->getCtMainWin()->get_ct_menu().build_popup_menu(menu, CtMenu::POPUP_MENU_TYPE::Code);
     }
 }
 

--- a/src/ct/ct_menu.cc
+++ b/src/ct/ct_menu.cc
@@ -66,14 +66,14 @@ const std::string& CtMenuAction::get_shortcut(CtConfig* pCtConfig) const
 CtMenu::CtMenu(CtConfig* pCtConfig, CtActions* pActions)
  : _pCtConfig(pCtConfig)
 {
-    _pAccelGroup = gtk_accel_group_new();
+    _pAccelGroup = Gtk::AccelGroup::create();
     _rGtkBuilder = Gtk::Builder::create();
     init_actions(pActions);
 }
 
-/*static*/ Gtk::MenuItem* CtMenu::create_menu_item(GtkWidget* pMenu, const char* name, const char* image, const char* desc)
+/*static*/ Gtk::MenuItem* CtMenu::create_menu_item(Gtk::Menu* pMenu, const char* name, const char* image, const char* desc)
 {
-    return _add_menu_item(pMenu, name, image, nullptr, nullptr, desc, nullptr, nullptr, nullptr);
+    return _add_menu_item(pMenu, name, image, nullptr, Glib::RefPtr<Gtk::AccelGroup>(), desc, nullptr, nullptr, nullptr);
 }
 
 void CtMenu::init_actions(CtActions* pActions)
@@ -276,10 +276,8 @@ void CtMenu::init_actions(CtActions* pActions)
     {
         if (get_accel_type(action.id) == ACCEL_TYPE::TreeView)
         {
-            guint key;
-            GdkModifierType mod;
-            gtk_accelerator_parse(action.get_shortcut(_pCtConfig).c_str(), &key, &mod);
-            //gtk_widget_add_accelerator(GTK_WIDGET(pActions->getCtMainWin()->get_tree_view().gobj()), "activate", default_accel_group(), key, mod, GTK_ACCEL_VISIBLE);
+            //Gtk::AccelKey accel_key(action.get_shortcut(_pCtConfig));
+            //pActions->getCtMainWin()->get_tree_view().add_accelerator("activate", _pAccelGroup, accel_key.get_key(), accel_key.get_mod(), Gtk::ACCEL_VISIBLE);
         }
     }
 
@@ -337,11 +335,6 @@ CtMenuAction* CtMenu::find_action(const std::string& id)
     return nullptr;
 }
 
-GtkAccelGroup* CtMenu::default_accel_group()
-{
-    return _pAccelGroup;
-}
-
 /*static*/CtMenu::ACCEL_TYPE CtMenu::get_accel_type(const std::string& action_name)
 {
     if (TREE_VIEW_ACCEL_ACTION.count(action_name) != 0)
@@ -395,19 +388,21 @@ std::vector<Gtk::Toolbar*> CtMenu::build_toolbars(Gtk::MenuToolButton*& pRecentD
 
 Gtk::MenuBar* CtMenu::build_menubar()
 {
-    return Glib::wrap(GTK_MENU_BAR(_walk_menu_xml(gtk_menu_bar_new(), _get_ui_str_menu(), nullptr)));
+    Gtk::MenuBar* pMenuBar = Gtk::manage(new Gtk::MenuBar());
+    _walk_menu_xml(pMenuBar, _get_ui_str_menu(), nullptr);
+    return pMenuBar;
 }
 
 Gtk::Menu* CtMenu::build_bookmarks_menu(std::list<std::pair<gint64, std::string>>& bookmarks, sigc::slot<void, gint64>& bookmark_action)
 {
     Gtk::Menu* pMenu = Gtk::manage(new Gtk::Menu());
-    _add_menu_item(GTK_WIDGET(pMenu->gobj()), find_action("handle_bookmarks"));
-    _add_separator(GTK_WIDGET(pMenu->gobj()));
+    _add_menu_item(pMenu, find_action("handle_bookmarks"));
+    _add_menu_separator(pMenu);
     for (const auto& bookmark : bookmarks)
     {
         const gint64& node_id = bookmark.first;
         const std::string& node_name = bookmark.second;
-        Gtk::MenuItem* pMenuItem = _add_menu_item(GTK_WIDGET(pMenu->gobj()), node_name.c_str(), "ct_pin", nullptr, nullptr, node_name.c_str(), nullptr, nullptr, nullptr);
+        Gtk::MenuItem* pMenuItem = _add_menu_item(pMenu, node_name.c_str(), "ct_pin", nullptr, _pAccelGroup, node_name.c_str(), nullptr, nullptr, nullptr);
         pMenuItem->signal_activate().connect(sigc::bind(bookmark_action, node_id));
     }
     return pMenu;
@@ -421,16 +416,16 @@ Gtk::Menu* CtMenu::build_recent_docs_menu(const CtRecentDocsFilepaths& recentDoc
     for (const fs::path& filepath : recentDocsFilepaths)
     {
         bool file_exists = fs::exists(filepath);
-        Gtk::MenuItem* pMenuItem = _add_menu_item(GTK_WIDGET(pMenu->gobj()), filepath.c_str(), file_exists ? "ct_open" : "ct_urgent", nullptr, nullptr, filepath.c_str(), nullptr, nullptr, nullptr);
+        Gtk::MenuItem* pMenuItem = _add_menu_item(pMenu, filepath.c_str(), file_exists ? "ct_open" : "ct_urgent", nullptr, _pAccelGroup, filepath.c_str(), nullptr, nullptr, nullptr);
         pMenuItem->signal_activate().connect(sigc::bind(recent_doc_open_action, filepath.string()));
     }
-    Gtk::MenuItem* pMenuItemRm = _add_menu_item(GTK_WIDGET(pMenu->gobj()), _("Remove from list"), "ct_edit_delete", nullptr, nullptr, _("Remove from list"), nullptr, nullptr, nullptr);
+    Gtk::MenuItem* pMenuItemRm = _add_menu_item(pMenu, _("Remove from list"), "ct_edit_delete", nullptr, _pAccelGroup, _("Remove from list"), nullptr, nullptr, nullptr);
     Gtk::Menu* pMenuRm = Gtk::manage(new Gtk::Menu());
     pMenuItemRm->set_submenu(*pMenuRm);
     for (const fs::path& filepath : recentDocsFilepaths)
     {
         bool file_exists = fs::exists(filepath);
-        Gtk::MenuItem* pMenuItem = _add_menu_item(GTK_WIDGET(pMenuRm->gobj()), filepath.c_str(), file_exists ? "ct_edit_delete" : "ct_urgent", nullptr, nullptr, filepath.c_str(), nullptr, nullptr, nullptr);
+        Gtk::MenuItem* pMenuItem = _add_menu_item(pMenuRm, filepath.c_str(), file_exists ? "ct_edit_delete" : "ct_urgent", nullptr, _pAccelGroup, filepath.c_str(), nullptr, nullptr, nullptr);
         pMenuItem->signal_activate().connect(sigc::bind(recent_doc_rm_action, filepath.string()));
     }
     return pMenu;
@@ -442,7 +437,7 @@ Gtk::Menu* CtMenu::build_special_chars_menu(const Glib::ustring& specialChars, s
     for (gunichar ch : specialChars)
     {
         Glib::ustring name = Glib::ustring(1, ch);
-        Gtk::MenuItem* pMenuItem = _add_menu_item(GTK_WIDGET(pMenu->gobj()), name.c_str(), nullptr, nullptr, nullptr, name.c_str(), nullptr, nullptr, nullptr);
+        Gtk::MenuItem* pMenuItem = _add_menu_item(pMenu, name.c_str(), nullptr, nullptr, _pAccelGroup, name.c_str(), nullptr, nullptr, nullptr);
         pMenuItem->signal_activate().connect(sigc::bind(spec_char_action, ch));
     }
     return pMenu;
@@ -450,169 +445,165 @@ Gtk::Menu* CtMenu::build_special_chars_menu(const Glib::ustring& specialChars, s
 
 Gtk::Menu* CtMenu::get_popup_menu(POPUP_MENU_TYPE popupMenuType)
 {
-    if (_popupMenus[popupMenuType] == nullptr)
-        _popupMenus[popupMenuType] = build_popup_menu(gtk_menu_new(), popupMenuType);
+    if (_popupMenus[popupMenuType] == nullptr) {
+        Gtk::Menu* pMenu = Gtk::manage(new Gtk::Menu());
+        build_popup_menu(pMenu, popupMenuType);
+        _popupMenus[popupMenuType] = pMenu;
+    }
     return _popupMenus[popupMenuType];
 }
 
-Gtk::Menu* CtMenu::build_popup_menu(GtkWidget* pMenu, POPUP_MENU_TYPE popupMenuType)
-{
+void CtMenu::build_popup_menu(Gtk::Menu* pMenu, POPUP_MENU_TYPE popupMenuType)
+{    
     switch (popupMenuType)
     {
-    case CtMenu::POPUP_MENU_TYPE::Node: return Glib::wrap(GTK_MENU(_walk_menu_xml(pMenu, _get_ui_str_menu(), "/menubar/menu[@action='TreeMenu']/*")));
-    case CtMenu::POPUP_MENU_TYPE::Text: return Glib::wrap(GTK_MENU(_walk_menu_xml(pMenu, _get_popup_menu_ui_str_text(), nullptr)));
-    case CtMenu::POPUP_MENU_TYPE::Code: return Glib::wrap(GTK_MENU(_walk_menu_xml(pMenu, _get_popup_menu_ui_str_code(), nullptr)));
-    case CtMenu::POPUP_MENU_TYPE::Image: return Glib::wrap(GTK_MENU(_walk_menu_xml(pMenu, _get_popup_menu_ui_str_image(), nullptr)));
-    case CtMenu::POPUP_MENU_TYPE::Anchor: return Glib::wrap(GTK_MENU(_walk_menu_xml(pMenu, _get_popup_menu_ui_str_anchor(), nullptr)));
-    case CtMenu::POPUP_MENU_TYPE::EmbFile: return Glib::wrap(GTK_MENU(_walk_menu_xml(pMenu, _get_popup_menu_ui_str_embfile(), nullptr)));
+    case CtMenu::POPUP_MENU_TYPE::Node: _walk_menu_xml(pMenu, _get_ui_str_menu(), "/menubar/menu[@action='TreeMenu']/*"); break;
+    case CtMenu::POPUP_MENU_TYPE::Text: _walk_menu_xml(pMenu, _get_popup_menu_ui_str_text(), nullptr); break;
+    case CtMenu::POPUP_MENU_TYPE::Code: _walk_menu_xml(pMenu, _get_popup_menu_ui_str_code(), nullptr); break;
+    case CtMenu::POPUP_MENU_TYPE::Image: _walk_menu_xml(pMenu, _get_popup_menu_ui_str_image(), nullptr); break;
+    case CtMenu::POPUP_MENU_TYPE::Anchor: _walk_menu_xml(pMenu, _get_popup_menu_ui_str_anchor(), nullptr); break;
+    case CtMenu::POPUP_MENU_TYPE::EmbFile: _walk_menu_xml(pMenu, _get_popup_menu_ui_str_embfile(), nullptr); break;
     case CtMenu::POPUP_MENU_TYPE::Link:
     {
-        _add_separator(pMenu);
+        _add_menu_separator(pMenu);
         _add_menu_item(pMenu, find_action("apply_tag_link"));
-        _add_separator(pMenu);
+        _add_menu_separator(pMenu);
         _add_menu_item(pMenu, find_action("link_cut"));
         _add_menu_item(pMenu, find_action("link_copy"));
         _add_menu_item(pMenu, find_action("link_dismiss"));
         _add_menu_item(pMenu, find_action("link_delete"));
-        return Glib::wrap(GTK_MENU(pMenu));
     }
     case CtMenu::POPUP_MENU_TYPE::Codebox:
     {
-        _add_separator(pMenu);
+        _add_menu_separator(pMenu);
         _add_menu_item(pMenu, find_action("cut_plain"));
         _add_menu_item(pMenu, find_action("copy_plain"));
-        _add_separator(pMenu);
+        _add_menu_separator(pMenu);
         _add_menu_item(pMenu, find_action("codebox_change_properties"));
         _add_menu_item(pMenu, find_action("exec_code"));
         _add_menu_item(pMenu, find_action("codebox_load_from_file"));
         _add_menu_item(pMenu, find_action("codebox_save_to_file"));
-        _add_separator(pMenu);
+        _add_menu_separator(pMenu);
         _add_menu_item(pMenu, find_action("codebox_cut"));
         _add_menu_item(pMenu, find_action("codebox_copy"));
         _add_menu_item(pMenu, find_action("codebox_delete"));
         _add_menu_item(pMenu, find_action("codebox_delete_keeping_text"));
-        _add_separator(pMenu);
+        _add_menu_separator(pMenu);
         _add_menu_item(pMenu, find_action("codebox_increase_width"));
         _add_menu_item(pMenu, find_action("codebox_decrease_width"));
         _add_menu_item(pMenu, find_action("codebox_increase_height"));
         _add_menu_item(pMenu, find_action("codebox_decrease_height"));
-        return Glib::wrap(GTK_MENU(pMenu));
     }
     case CtMenu::POPUP_MENU_TYPE::PopupMenuNum:
-        break;
+    {
     }
-    return nullptr;
+    }
 }
 
-Gtk::Menu* CtMenu::build_popup_menu_table_cell(GtkWidget* pMenu, const bool first_row, const bool first_col, const bool last_row, const bool last_col)
+void CtMenu::build_popup_menu_table_cell(Gtk::Menu* pMenu, const bool first_row, const bool first_col, const bool last_row, const bool last_col)
 {
     _add_menu_item(pMenu, find_action("table_cut"));
     _add_menu_item(pMenu, find_action("table_copy"));
     _add_menu_item(pMenu, find_action("table_delete"));
-    _add_separator(pMenu);
+    _add_menu_separator(pMenu);
     _add_menu_item(pMenu, find_action("table_column_add"));
     _add_menu_item(pMenu, find_action("table_column_delete"));
-    _add_separator(pMenu);
+    _add_menu_separator(pMenu);
     if (not first_col) _add_menu_item(pMenu, find_action("table_column_left"));
     if (not last_col) _add_menu_item(pMenu, find_action("table_column_right"));
-    _add_separator(pMenu);
+    _add_menu_separator(pMenu);
     _add_menu_item(pMenu, find_action("table_row_add"));
     _add_menu_item(pMenu, find_action("table_row_cut"));
     _add_menu_item(pMenu, find_action("table_row_copy"));
     _add_menu_item(pMenu, find_action("table_row_paste"));
     _add_menu_item(pMenu, find_action("table_row_delete"));
-    _add_separator(pMenu);
+    _add_menu_separator(pMenu);
     if (not first_row) _add_menu_item(pMenu, find_action("table_row_up"));
     if (not last_row) _add_menu_item(pMenu, find_action("table_row_down"));
     _add_menu_item(pMenu, find_action("table_rows_sort_descending"));
     _add_menu_item(pMenu, find_action("table_rows_sort_ascending"));
-    _add_separator(pMenu);
+    _add_menu_separator(pMenu);
     _add_menu_item(pMenu, find_action("table_edit_properties"));
     _add_menu_item(pMenu, find_action("table_export"));
-    return Glib::wrap(GTK_MENU(pMenu));
 }
 
-GtkWidget* CtMenu::_walk_menu_xml(GtkWidget* pMenu, const char* document, const char* xpath)
+void CtMenu::_walk_menu_xml(Gtk::MenuShell* pMenuShell, const char* document, const char* xpath)
 {
     xmlpp::DomParser parser;
     parser.parse_memory(document);
     if (xpath)
     {
-        _walk_menu_xml(pMenu, parser.get_document()->get_root_node()->find(xpath)[0]);
+        _walk_menu_xml(pMenuShell, parser.get_document()->get_root_node()->find(xpath)[0]);
     }
     else
     {
-        _walk_menu_xml(pMenu, parser.get_document()->get_root_node());
+        _walk_menu_xml(pMenuShell, parser.get_document()->get_root_node());
     }
-    return pMenu;
 }
 
-void CtMenu::_walk_menu_xml(GtkWidget* pMenu, xmlpp::Node* pNode)
+void CtMenu::_walk_menu_xml(Gtk::MenuShell* pMenuShell, xmlpp::Node* pNode)
 {
     for (xmlpp::Node* pNodeIter = pNode; pNodeIter; pNodeIter = pNodeIter->get_next_sibling())
     {
         if (pNodeIter->get_name() == "menubar" || pNodeIter->get_name() == "popup")
         {
-            _walk_menu_xml(pMenu, pNodeIter->get_first_child());
+            _walk_menu_xml(pMenuShell, pNodeIter->get_first_child());
         }
         else if (pNodeIter->get_name() == "menu")
         {
             if (xmlpp::Attribute* pAttrName = get_attribute(pNodeIter, "_name")) // menu name which need to be translated
             {
                 xmlpp::Attribute* pAttrImage = get_attribute(pNodeIter, "image");
-                GtkWidget* pSubmenu = _add_submenu(pMenu, pAttrName->get_value().c_str(), _(pAttrName->get_value().c_str()), pAttrImage->get_value().c_str());
+                Gtk::Menu* pSubmenu = _add_menu_submenu(pMenuShell, pAttrName->get_value().c_str(), _(pAttrName->get_value().c_str()), pAttrImage->get_value().c_str());
                 _walk_menu_xml(pSubmenu, pNodeIter->get_first_child());
             }
             else // otherwise it is an action id
             {
                 CtMenuAction const* pAction = find_action(get_attribute(pNodeIter, "action")->get_value());
-                GtkWidget* pSubmenu = _add_submenu(pMenu, pAction->id.c_str(), pAction->name.c_str(), pAction->image.c_str());
+                Gtk::Menu* pSubmenu = _add_menu_submenu(pMenuShell, pAction->id.c_str(), pAction->name.c_str(), pAction->image.c_str());
                 _walk_menu_xml(pSubmenu, pNodeIter->get_first_child());
             }
         }
         else if (pNodeIter->get_name() == "menuitem")
         {
             CtMenuAction* pAction = find_action(get_attribute(pNodeIter, "action")->get_value());
-            _add_menu_item(pMenu, pAction);
+            _add_menu_item(pMenuShell, pAction);
         }
         else if (pNodeIter->get_name() == "separator")
         {
-            _add_separator(pMenu);
+            _add_menu_separator(pMenuShell);
         }
     }
 }
 
-GtkWidget* CtMenu::_add_submenu(GtkWidget* pMenu, const char* id, const char* name, const char* image)
+Gtk::Menu* CtMenu::_add_menu_submenu(Gtk::MenuShell* pMenuShell, const char* id, const char* name, const char* image)
 {
     Gtk::MenuItem* pMenuItem = Gtk::manage(new Gtk::MenuItem());
     pMenuItem->set_name(id);
-    GtkWidget* pLabel = gtk_accel_label_new(name);
-    gtk_label_set_markup_with_mnemonic(GTK_LABEL(pLabel), name);
-#if GTK_CHECK_VERSION(3,16,0)
-    gtk_label_set_xalign(GTK_LABEL(pLabel), 0.0);
-#else
-    gtk_misc_set_alignment(GTK_MISC(pLabel), 0.0, 0.5);
-#endif
+    Gtk::AccelLabel* pLabel = Gtk::manage(new Gtk::AccelLabel(name, true));
+    pLabel->set_xalign(0.0);
+    pLabel->set_accel_widget(*pMenuItem);
+
     _add_menu_item_image_or_label(pMenuItem, image, pLabel);
     pMenuItem->get_child()->set_name(id); // for find_menu_item()
     pMenuItem->show_all();
 
-    GtkWidget* pSubmenu = gtk_menu_new();
-    gtk_menu_item_set_submenu(GTK_MENU_ITEM(pMenuItem->gobj()), GTK_WIDGET(pSubmenu));
-    gtk_menu_shell_append(GTK_MENU_SHELL(pMenu), GTK_WIDGET(pMenuItem->gobj()));
-    return pSubmenu;
+    Gtk::Menu* pSubMenu = Gtk::manage(new Gtk::Menu());
+    pMenuItem->set_submenu(*pSubMenu);
+    pMenuShell->append(*pMenuItem);
+    return pSubMenu;
 }
 
-Gtk::MenuItem* CtMenu::_add_menu_item(GtkWidget* pMenu, CtMenuAction* pAction)
+Gtk::MenuItem* CtMenu::_add_menu_item(Gtk::MenuShell* pMenuShell, CtMenuAction* pAction)
 {
     std::string shortcut = pAction->get_shortcut(_pCtConfig);
     if (get_accel_type(pAction->id) != ACCEL_TYPE::Menu)
         shortcut = "";
-    Gtk::MenuItem* pMenuItem = _add_menu_item(pMenu,
+    Gtk::MenuItem* pMenuItem = _add_menu_item(pMenuShell,
                                               pAction->name.c_str(),
                                               pAction->image.c_str(),
                                               shortcut.c_str(),
-                                              default_accel_group(),
+                                              _pAccelGroup,
                                               pAction->desc.c_str(),
                                               (gpointer)pAction,
                                               &pAction->signal_set_sensitive,
@@ -621,12 +612,12 @@ Gtk::MenuItem* CtMenu::_add_menu_item(GtkWidget* pMenu, CtMenuAction* pAction)
     return pMenuItem;
 }
 
-// based on inkscape/src/ui/interface.cpp
-/*static*/ Gtk::MenuItem* CtMenu::_add_menu_item(GtkWidget* pMenu,
+// based on inkscape/src/ui/desktop/menubar.cpp
+/*static*/ Gtk::MenuItem* CtMenu::_add_menu_item(Gtk::MenuShell* pMenuShell,
                                                  const char* name,
                                                  const char* image,
                                                  const char* shortcut,
-                                                 GtkAccelGroup* accelGroup,
+                                                 Glib::RefPtr<Gtk::AccelGroup> accelGroup,
                                                  const char* desc,
                                                  gpointer action_data,
                                                  sigc::signal<void, bool>* signal_set_sensitive,
@@ -639,28 +630,14 @@ Gtk::MenuItem* CtMenu::_add_menu_item(GtkWidget* pMenu, CtMenuAction* pAction)
         pMenuItem->set_tooltip_text(desc);
     }
     // Now create the label and add it to the menu item
-    GtkWidget* pLabel = gtk_accel_label_new(name);
-    gtk_label_set_markup_with_mnemonic(GTK_LABEL(pLabel), name);
-
-#if GTK_CHECK_VERSION(3,16,0)
-    gtk_label_set_xalign(GTK_LABEL(pLabel), 0.0);
-#else
-    gtk_misc_set_alignment(GTK_MISC(pLabel), 0.0, 0.5);
-#endif
-
+    Gtk::AccelLabel* pLabel = Gtk::manage(new Gtk::AccelLabel(name, true));
+    pLabel->set_xalign(0.0);
+    pLabel->set_accel_widget(*pMenuItem);
     if (shortcut && strlen(shortcut))
     {
-        guint key;
-        GdkModifierType mod;
-        gtk_accelerator_parse(shortcut, &key, &mod);
-        gtk_widget_add_accelerator(GTK_WIDGET(pMenuItem->gobj()),
-                        "activate",
-                        accelGroup,
-                        key,
-                        mod,
-                        GTK_ACCEL_VISIBLE);
+        Gtk::AccelKey accel_key(shortcut);
+        pMenuItem->add_accelerator("activate", accelGroup, accel_key.get_key(), accel_key.get_mod(), Gtk::ACCEL_VISIBLE);
     }
-    gtk_accel_label_set_accel_widget(GTK_ACCEL_LABEL(pLabel), GTK_WIDGET(pMenuItem->gobj()));
 
     _add_menu_item_image_or_label(pMenuItem, image, pLabel);
 
@@ -682,38 +659,38 @@ Gtk::MenuItem* CtMenu::_add_menu_item(GtkWidget* pMenu, CtMenuAction* pAction)
     }
 
     pMenuItem->show_all();
-    gtk_menu_shell_append(GTK_MENU_SHELL(GTK_MENU(pMenu)), GTK_WIDGET(pMenuItem->gobj()));
+    pMenuShell->append(*pMenuItem);
 
     return pMenuItem;
 }
 
-/*static*/ void CtMenu::_add_menu_item_image_or_label(Gtk::Widget* pMenuItem, const char* image, GtkWidget* pLabel)
+/*static*/ void CtMenu::_add_menu_item_image_or_label(Gtk::MenuItem* pMenuItem, const char* image, Gtk::AccelLabel* pLabel)
 {
     if (image && strlen(image))
     {
         pMenuItem->set_name("ImageMenuItem");  // custom name to identify our "ImageMenuItems"
-
-        GtkWidget* pIcon = gtk_image_new_from_icon_name(image, GTK_ICON_SIZE_MENU);
+        Gtk::Image *pIcon = Gtk::manage(new Gtk::Image());
+        pIcon->set_from_icon_name(image, Gtk::ICON_SIZE_MENU);
 
         // create a box to hold icon and label as GtkMenuItem derives from GtkBin and can only hold one child
-        GtkWidget* pBox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-        gtk_box_pack_start(GTK_BOX(pBox), pIcon, FALSE, FALSE, 5);
-        gtk_box_pack_start(GTK_BOX(pBox), pLabel, TRUE, TRUE, 0);
+        auto const box = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL));
+        box->pack_start(*pIcon, false, false, 0);
+        box->pack_start(*pLabel, true, true, 0);
 
-        gtk_container_add(GTK_CONTAINER(pMenuItem->gobj()), pBox);
+        pMenuItem->add(*box);
     }
     else
     {
-        gtk_container_add(GTK_CONTAINER(pMenuItem->gobj()), pLabel);
+        pMenuItem->add(*pLabel);
     }
 }
 
-GtkWidget* CtMenu::_add_separator(GtkWidget* pMenu)
+Gtk::SeparatorMenuItem* CtMenu::_add_menu_separator(Gtk::MenuShell* pMenuShell)
 {
-    Gtk::Widget* pSeparatorItem = Gtk::manage(new Gtk::SeparatorMenuItem());
+    Gtk::SeparatorMenuItem* pSeparatorItem = Gtk::manage(new Gtk::SeparatorMenuItem());
     pSeparatorItem->show_all();
-    gtk_menu_shell_append(GTK_MENU_SHELL(GTK_MENU(pMenu)), pSeparatorItem->gobj());
-    return pSeparatorItem->gobj();
+    pMenuShell->append(*pSeparatorItem);
+    return pSeparatorItem;
 }
 
 std::vector<std::string> CtMenu::_get_ui_str_toolbars()

--- a/src/ct/ct_menu.h
+++ b/src/ct/ct_menu.h
@@ -64,15 +64,14 @@ public:
     enum ACCEL_TYPE {Menu, TreeView };
 
 public:
-   static Gtk::MenuItem* create_menu_item(GtkWidget* pMenu, const char* name, const char* image, const char* desc);
+   static Gtk::MenuItem* create_menu_item(Gtk::Menu* pMenu, const char* name, const char* image, const char* desc);
 
 public:
     void init_actions(CtActions* pActions);
 
     CtMenuAction*  find_action(const std::string& id);
     const std::list<CtMenuAction>& get_actions() { return _actions; }
-
-    GtkAccelGroup* default_accel_group();
+    Glib::RefPtr<Gtk::AccelGroup> get_accel_group() { return _pAccelGroup; }
 
     static ACCEL_TYPE       get_accel_type(const std::string& action_name);
     static Gtk::MenuItem*   find_menu_item(Gtk::MenuBar* menuBar, std::string name);
@@ -89,22 +88,21 @@ public:
                                                         sigc::slot<void, gunichar>& spec_char_action);
 
     Gtk::Menu*                 get_popup_menu(POPUP_MENU_TYPE popupMenuType);
-    Gtk::Menu*                 build_popup_menu(GtkWidget* pMenu, POPUP_MENU_TYPE popupMenuType);
-    Gtk::Menu*                 build_popup_menu_table_cell(GtkWidget* pMenu, const bool first_row, const bool first_col, const bool last_row, const bool last_col);
+    void                       build_popup_menu(Gtk::Menu* pMenu, POPUP_MENU_TYPE popupMenuType);
+    void                       build_popup_menu_table_cell(Gtk::Menu* pMenu, const bool first_row, const bool first_col, const bool last_row, const bool last_col);
 
 private:
-    GtkWidget*     _walk_menu_xml(GtkWidget* pMenu, const char* document, const char* xpath);
-    void           _walk_menu_xml(GtkWidget* pMenu, xmlpp::Node* pNode);
-    GtkWidget*     _add_submenu(GtkWidget* pMenu, const char* id, const char* name, const char* image);
-    Gtk::MenuItem* _add_menu_item(GtkWidget* pMenu, CtMenuAction* pAction);
-    static Gtk::MenuItem* _add_menu_item(GtkWidget* pMenu, const char* name, const char* image,
-                                         const char*shortcut, GtkAccelGroup* accelGroup,
-                                         const char* desc, gpointer action_data,
-                                         sigc::signal<void, bool>* signal_set_sensitive,
-                                         sigc::signal<void, bool>* signal_set_visible);
-
-    static void    _add_menu_item_image_or_label(Gtk::Widget* pMenuItem, const char* image, GtkWidget* pLabel);
-    GtkWidget*     _add_separator(GtkWidget* pMenu);
+    void                    _walk_menu_xml(Gtk::MenuShell* pMenuShell, const char* document, const char* xpath);
+    void                    _walk_menu_xml(Gtk::MenuShell* pMenuShell, xmlpp::Node* pNode);
+    Gtk::Menu*              _add_menu_submenu(Gtk::MenuShell* pMenuShell, const char* id, const char* name, const char* image);
+    Gtk::MenuItem*          _add_menu_item(Gtk::MenuShell* pMenuShell, CtMenuAction* pAction);
+    static Gtk::MenuItem*   _add_menu_item(Gtk::MenuShell* pMenuShell, const char* name, const char* image,
+                                           const char*shortcut, Glib::RefPtr<Gtk::AccelGroup> accelGroup,
+                                           const char* desc, gpointer action_data,
+                                           sigc::signal<void, bool>* signal_set_sensitive,
+                                           sigc::signal<void, bool>* signal_set_visible);
+    static void             _add_menu_item_image_or_label(Gtk::MenuItem* pMenuItem, const char* image, Gtk::AccelLabel* label);
+    Gtk::SeparatorMenuItem* _add_menu_separator(Gtk::MenuShell* pMenuShell);
 
     std::vector<std::string> _get_ui_str_toolbars();
     const char*              _get_ui_str_menu();
@@ -115,9 +113,9 @@ private:
     const char*              _get_popup_menu_ui_str_embfile();
 
 private:
-    CtConfig*                  _pCtConfig;
-    std::list<CtMenuAction>    _actions;
-    Glib::RefPtr<Gtk::Builder> _rGtkBuilder;
-    GtkAccelGroup*             _pAccelGroup;
-    Gtk::Menu*                 _popupMenus[POPUP_MENU_TYPE::PopupMenuNum] = {};
+    CtConfig*                     _pCtConfig;
+    std::list<CtMenuAction>       _actions;
+    Glib::RefPtr<Gtk::Builder>    _rGtkBuilder;
+    Glib::RefPtr<Gtk::AccelGroup> _pAccelGroup;
+    Gtk::Menu*                    _popupMenus[POPUP_MENU_TYPE::PopupMenuNum] = {};
 };

--- a/src/ct/ct_menu.h
+++ b/src/ct/ct_menu.h
@@ -76,6 +76,7 @@ public:
     static ACCEL_TYPE       get_accel_type(const std::string& action_name);
     static Gtk::MenuItem*   find_menu_item(Gtk::MenuBar* menuBar, std::string name);
     static Gtk::AccelLabel* get_accel_label(Gtk::MenuItem* item);
+    static int              calculate_image_shift(Gtk::MenuItem* menuItem);
 
     std::vector<Gtk::Toolbar*> build_toolbars(Gtk::MenuToolButton*& pRecentDocsMenuToolButton);
     Gtk::MenuBar*              build_menubar();

--- a/src/ct/ct_table.cc
+++ b/src/ct/ct_table.cc
@@ -346,7 +346,7 @@ void CtTable::_on_populate_popup_cell(Gtk::Menu* menu, int row, int col)
     const bool first_col = 0 == col;
     const bool last_row = static_cast<int>(_tableMatrix.size() - 1) == row;
     const bool last_col = _tableMatrix.size() and static_cast<int>(_tableMatrix.front().size() - 1) == col;
-    _pCtMainWin->get_ct_menu().build_popup_menu_table_cell(GTK_WIDGET(menu->gobj()), first_row, first_col, last_row, last_col);
+    _pCtMainWin->get_ct_menu().build_popup_menu_table_cell(menu, first_row, first_col, last_row, last_col);
 }
 
 bool CtTable::_on_key_press_event_cell(GdkEventKey* event, int row, int col)


### PR DESCRIPTION
Resolves #1289

@giuspen , the fix is quite simple, it shifts images by setting margin in css. But for some reason from time to time, gtk stops drawing images in Menu until you hover mouse over menu item causing redrawing (it happened several times on Linux and Win).  
Maybe we will have to disable this fix if people complain