### PR TITLE
adds `--new-window` option

### DIFF
--- a/src/ct/ct_app.h
+++ b/src/ct/ct_app.h
@@ -62,8 +62,10 @@ protected:
     std::string   _export_to_txt_dir;
     std::string   _export_to_pdf_file;
     bool          _export_overwrite{false};
+    bool          _startup2{false};
 
 protected:
+    void on_startup2();
     void on_activate() override;
     void on_open(const Gio::Application::type_vec_files& files, const Glib::ustring& hint) override;
     void on_window_removed(Gtk::Window* window) override;


### PR DESCRIPTION
Resolves #1339

Also, I put all UI initialization from App constructor into a separate function, so second instance can start really fast. Actions actually are really convenient way to send different commands from command line into the existed instance (e.g. inkscape uses them that way)