### PR TITLE
New --export_single_file export option

### DIFF
--- a/src/ct/ct_actions.h
+++ b/src/ct/ct_actions.h
@@ -443,7 +443,7 @@ private:
     void _export_to_txt(const fs::path& auto_path, bool auto_overwrite);
 
     fs::path _get_pdf_filepath(const fs::path& proposed_name);
-    fs::path _get_txt_filepath(const fs::path& proposed_name);
+    fs::path _get_txt_filepath(const fs::path& dir_place, const fs::path& proposed_name);
     fs::path _get_txt_folder(fs::path dir_place, fs::path new_folder, bool export_overwrite);
 
 public:
@@ -456,8 +456,8 @@ public:
     void export_to_ctd();
 
     void export_to_pdf_auto(const std::string& dir, bool overwrite);
-    void export_to_html_auto(const std::string& dir, bool overwrite);
-    void export_to_txt_auto(const std::string& dir, bool overwrite);
+    void export_to_html_auto(const std::string& dir, bool overwrite, bool single_file);
+    void export_to_txt_auto(const std::string& dir, bool overwrite, bool single_file);
 
 private:
     // helpers for help actions

--- a/src/ct/ct_app.cc
+++ b/src/ct/ct_app.cc
@@ -184,10 +184,10 @@ void CtApp::on_open(const Gio::Application::type_vec_files& files, const Glib::u
             if (pWin->file_open(canonicalPath, "")) {
                 try {
                     if (not _export_to_txt_dir.empty()) {
-                        pWin->get_ct_actions()->export_to_txt_auto(_export_to_txt_dir, _export_overwrite);
+                        pWin->get_ct_actions()->export_to_txt_auto(_export_to_txt_dir, _export_overwrite, _export_single_file);
                     }
                     if (not _export_to_html_dir.empty()) {
-                        pWin->get_ct_actions()->export_to_html_auto(_export_to_html_dir, _export_overwrite);
+                        pWin->get_ct_actions()->export_to_html_auto(_export_to_html_dir, _export_overwrite, _export_single_file);
                     }
                     if (not _export_to_pdf_file.empty()) {
                         pWin->get_ct_actions()->export_to_pdf_auto(_export_to_pdf_file, _export_overwrite);
@@ -360,6 +360,7 @@ void CtApp::_add_main_option_entries()
     add_main_option_entry(Gio::Application::OPTION_TYPE_FILENAME, "export_to_txt_dir",  't', _("Export to Text at specified directory path"));
     add_main_option_entry(Gio::Application::OPTION_TYPE_FILENAME, "export_to_pdf_file", 'p', _("Export to PDF at specified file path"));
     add_main_option_entry(Gio::Application::OPTION_TYPE_BOOL,     "export_overwrite",   'w', _("Overwrite if export path already exists"));
+    add_main_option_entry(Gio::Application::OPTION_TYPE_BOOL,     "export_single_file", 's', _("Export to a single file (for HTML or TXT)"));
     add_main_option_entry(Gio::Application::OPTION_TYPE_BOOL,     "new-window",         'N', _("Create a new window"));
 }
 
@@ -389,6 +390,7 @@ int CtApp::_on_handle_local_options(const Glib::RefPtr<Glib::VariantDict>& rOpti
     rOptions->lookup_value("export_to_txt_dir", _export_to_txt_dir);
     rOptions->lookup_value("export_to_pdf_file", _export_to_pdf_file);
     rOptions->lookup_value("export_overwrite", _export_overwrite);
+    rOptions->lookup_value("export_single_file", _export_single_file);
     rOptions->lookup_value("new-window", new_window);
 
     if (new_window) {

--- a/src/ct/ct_app.h
+++ b/src/ct/ct_app.h
@@ -62,6 +62,7 @@ protected:
     std::string   _export_to_txt_dir;
     std::string   _export_to_pdf_file;
     bool          _export_overwrite{false};
+    bool          _export_single_file{false};
     bool          _startup2{false};
 
 protected:


### PR DESCRIPTION
--export_single_file can be used to export to a single text or html
file from the command line.
Also prevent "No Node is Selected" popup from appearing during export.