### PR TITLE
Fix the cherrytree shebang

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -107,7 +107,7 @@ parts:
       cd pygtk2
       python2.7 setup.py install --prefix=$SNAPCRAFT_PART_INSTALL/usr -f 
       sed -i 's|^Icon=.*|Icon=${SNAP}/meta/gui/cherrytree.png|' linux/cherrytree.desktop
-      sed -i 's|#!/root/parts/cherrytree/install/usr/bin/python2.7|#!/usr/bin/env python2.7|' $SNAPCRAFT_PART_INSTALL/usr/bin/cherrytree
+      sed -i '1s|.*|#!/usr/bin/env python2.7|' $SNAPCRAFT_PART_INSTALL/usr/bin/cherrytree
       sed -i 's|VERSION = "0.39.4"|VERSION = "0.99.24"|' $SNAPCRAFT_PART_INSTALL/usr/share/cherrytree/modules/cons.py
       mkdir -p $SNAPCRAFT_PART_INSTALL/meta/gui/
       cp glade/cherrytree.png $SNAPCRAFT_PART_INSTALL/meta/gui/


### PR DESCRIPTION
It turns out that the snapcraft used on launchpad (which publishes to the snap store) was expanding this variable while my locally built snaps didn't have the problem.

This will fix the 0.99.24 snap runtime.

Once this change is merged, it will build and be available in the store and then to test:
```
$ sudo snap install cherrytree --edge
``` 