### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/scripts/metainfo_xml_write.py
+++ b/scripts/metainfo_xml_write.py
@@ -21,7 +21,10 @@ with open(DEBIAN_CHANGELOG_PATH, "r") as fd:
             VERSION = match.group(1)
             #print(VERSION)
             break
-DATE = time.strftime("%Y-%m-%d", time.gmtime())
+DATE = time.strftime(
+    "%Y-%m-%d",
+    time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time())))
+)
 
 # <?xml version="1.0" encoding="UTF-8"?>
 # <component type="desktop-application">


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This PR was done while working on reproducible builds for openSUSE.