### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ brew install python3 cmake pkg-config gtksourceviewmm3 gnome-icon-theme gspell l
 Get cherrytree source, compile and run:
 ```sh
 git clone https://github.com/giuspen/cherrytree.git
+cd cherrytree
 git submodule update --init
 mkdir cherrytree/build
 cd cherrytree/build

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Get cherrytree source, compile and run:
 ```sh
 git clone https://github.com/giuspen/cherrytree.git
 git submodule update --init
-mkdir cherrytree/build
-cd cherrytree/build
+mkdir build
+cd build
 cmake ../
 make -j$(nproc --all)
 ./build/cherrytree


### PR DESCRIPTION
Had to add `cd cherrytree` after cloning in order for `git submodule update --init` to work as expected and be able to build on macOS