### PR TITLE
More GCC11 fixes

### DIFF
--- a/src/ct/ct_table.h
+++ b/src/ct/ct_table.h
@@ -25,6 +25,7 @@
 
 #include "ct_codebox.h"
 #include "ct_widgets.h"
+#include <optional>
 #include <ostream>
 #include <istream>
 


### PR DESCRIPTION
Add one more missing `#include <optional>` to make GCC 11 happy.

This is an additional (and final, it appears) fix for #1436.