### PR TITLE
Add "meta" as an option to keyboard shortcut settings

### DIFF
--- a/pygtk2/modules/config.py
+++ b/pygtk2/modules/config.py
@@ -1998,7 +1998,7 @@ def preferences_tab_kb_shortcuts(dad, vbox_tool, pref_dialog):
         if not tree_iter: return
         action_name = model[tree_iter][0]
         kb_shortcut_full = model[tree_iter][2] if model[tree_iter][2] else ""
-        kb_shortcut_key = kb_shortcut_full.replace(menus.KB_CONTROL, "").replace(menus.KB_SHIFT, "").replace(menus.KB_ALT, "")
+        kb_shortcut_key = kb_shortcut_full.replace(menus.KB_CONTROL, "").replace(menus.KB_SHIFT, "").replace(menus.KB_ALT, "").replace(menus.KB_META, "")
         #print "'%s' -> '%s'" % (action_name, kb_shortcut)
         dialog = gtk.Dialog(title=_("Edit Keyboard Shortcut"),
             parent=dad.window,
@@ -2013,7 +2013,8 @@ def preferences_tab_kb_shortcuts(dad, vbox_tool, pref_dialog):
         ctrl_toggle = gtk.ToggleButton("control")
         shift_toggle = gtk.ToggleButton("shift")
         alt_toggle = gtk.ToggleButton("alt")
-        for widget in [ctrl_toggle, shift_toggle, alt_toggle]:
+        meta_toggle = gtk.ToggleButton("meta")
+        for widget in [ctrl_toggle, shift_toggle, alt_toggle, meta_toggle]:
             widget.set_size_request(70, -1)
         key_entry = gtk.Entry()
         key_entry.set_text(kb_shortcut_key)
@@ -2023,6 +2024,7 @@ def preferences_tab_kb_shortcuts(dad, vbox_tool, pref_dialog):
         hbox.pack_start(ctrl_toggle)
         hbox.pack_start(shift_toggle)
         hbox.pack_start(alt_toggle)
+        hbox.pack_start(meta_toggle)
         hbox.pack_start(key_entry)
         hbox.set_spacing(5)
         vbox.pack_start(radiobutton_kb_none)
@@ -2061,6 +2063,7 @@ def preferences_tab_kb_shortcuts(dad, vbox_tool, pref_dialog):
         ctrl_toggle.set_active(menus.KB_CONTROL in kb_shortcut_full)
         shift_toggle.set_active(menus.KB_SHIFT in kb_shortcut_full)
         alt_toggle.set_active(menus.KB_ALT in kb_shortcut_full)
+        meta_toggle.set_active(menus.KB_META) in kb_shortcut_full)
         kb_shortcut_on_off(bool(kb_shortcut_full))
         content_area.show_all()
         response = dialog.run()
@@ -2072,6 +2075,7 @@ def preferences_tab_kb_shortcuts(dad, vbox_tool, pref_dialog):
                 if ctrl_toggle.get_active(): kb_shortcut_full += menus.KB_CONTROL
                 if shift_toggle.get_active(): kb_shortcut_full += menus.KB_SHIFT
                 if alt_toggle.get_active(): kb_shortcut_full += menus.KB_ALT
+                if meta_toggle.get_active(): kb_shortcut_full += menus.KB_META
                 kb_shortcut_full += kb_shortcut_key
             #print kb_shortcut_full
             if kb_shortcut_full:

--- a/pygtk2/modules/menus.py
+++ b/pygtk2/modules/menus.py
@@ -24,6 +24,7 @@ import cons
 KB_CONTROL = "<control>"
 KB_SHIFT = "<shift>"
 KB_ALT = "<alt>"
+KB_META = "<meta>"
 
 CONFIG_ACTIONS_DICT = {
 "file": [

--- a/src/ct/ct_menu.h
+++ b/src/ct/ct_menu.h
@@ -59,7 +59,8 @@ public:
     const std::string KB_CONTROL = "<control>";
     const std::string KB_SHIFT   = "<shift>";
     const std::string KB_ALT     = "<alt>";
-
+    const std::string KB_META    = "<meta>";
+    
     enum POPUP_MENU_TYPE {Node, Text, Code, Link, Codebox, Image, Anchor, EmbFile, PopupMenuNum };
 
 public:

--- a/src/ct/ct_pref_dlg.cc
+++ b/src/ct/ct_pref_dlg.cc
@@ -1921,9 +1921,11 @@ bool CtPrefDlg::edit_shortcut_dialog(std::string& shortcut)
     Gtk::ToggleButton* ctrl_toggle = Gtk::manage(new Gtk::ToggleButton("control"));
     Gtk::ToggleButton* shift_toggle = Gtk::manage(new Gtk::ToggleButton("shift"));
     Gtk::ToggleButton* alt_toggle = Gtk::manage(new Gtk::ToggleButton("alt"));
+    Gtk::ToggleButton* meta_toggle = Gtk::manage(new Gtk::ToggleButton("meta"));
     ctrl_toggle->set_size_request(70, 1);
     shift_toggle->set_size_request(70, 1);
     alt_toggle->set_size_request(70, 1);
+    meta_toggle->set_size_request(70,1);
     Gtk::Entry* key_entry = Gtk::manage(new Gtk::Entry());
     Gtk::VBox* vbox = Gtk::manage(new Gtk::VBox());
     Gtk::HBox* hbox = Gtk::manage(new Gtk::HBox());
@@ -1931,6 +1933,7 @@ bool CtPrefDlg::edit_shortcut_dialog(std::string& shortcut)
     hbox->pack_start(*ctrl_toggle);
     hbox->pack_start(*shift_toggle);
     hbox->pack_start(*alt_toggle);
+    hbox->pack_start(*meta_toggle);
     hbox->pack_start(*key_entry);
     hbox->set_spacing(5);
     vbox->pack_start(*radiobutton_kb_none);
@@ -1941,6 +1944,7 @@ bool CtPrefDlg::edit_shortcut_dialog(std::string& shortcut)
     auto b1 = Glib::Binding::bind_property(key_entry->property_sensitive(), ctrl_toggle->property_sensitive());
     auto b2 = Glib::Binding::bind_property(key_entry->property_sensitive(), shift_toggle->property_sensitive());
     auto b3 = Glib::Binding::bind_property(key_entry->property_sensitive(), alt_toggle->property_sensitive());
+    auto b5 = Glib::Binding::bind_property(key_entry->property_sensitive(), meta_toggle->property_sensitive());
     auto b4 = Glib::Binding::bind_property(radiobutton_kb_shortcut->property_active(), key_entry->property_sensitive());
 
     key_entry->set_sensitive(!kb_shortcut_key.empty());
@@ -1950,6 +1954,7 @@ bool CtPrefDlg::edit_shortcut_dialog(std::string& shortcut)
     ctrl_toggle->set_active(shortcut.find(_pCtMenu->KB_CONTROL) != std::string::npos);
     shift_toggle->set_active(shortcut.find(_pCtMenu->KB_SHIFT) != std::string::npos);
     alt_toggle->set_active(shortcut.find(_pCtMenu->KB_ALT) != std::string::npos);
+    meta_toggle->set_active(shortcut.find(_pCtMenu->KB_META) != std::string::npos);
 
     key_entry->signal_key_press_event().connect([key_entry](GdkEventKey* key)->bool{
         Glib::ustring keyname = gdk_keyval_name(key->keyval);
@@ -1968,6 +1973,7 @@ bool CtPrefDlg::edit_shortcut_dialog(std::string& shortcut)
         if (ctrl_toggle->get_active()) shortcut += _pCtMenu->KB_CONTROL;
         if (shift_toggle->get_active()) shortcut += _pCtMenu->KB_SHIFT;
         if (alt_toggle->get_active()) shortcut += _pCtMenu->KB_ALT;
+        if (meta_toggle->get_active()) shortcut += _pCtMenu->KB_META;
         shortcut += key_entry->get_text();
     }
     return true;


### PR DESCRIPTION
Added the Meta key as an option when defining keyboard shortcuts, primarily to allow for use of the Command key on Mac.