### PR TITLE
Add gnome-icon-theme dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cpack -G DEB
 
 Install dependencies::
 ```sh
-sudo apt install build-essential libxml2-utils cmake libgtkmm-3.0-dev libgtksourceviewmm-3.0-dev libxml++2.6-dev libsqlite3-dev gettext libgspell-1-dev libcurl4-openssl-dev libuchardet-dev libfmt-dev libspdlog-dev
+sudo apt install build-essential libxml2-utils cmake libgtkmm-3.0-dev libgtksourceviewmm-3.0-dev libxml++2.6-dev libsqlite3-dev gettext libgspell-1-dev libcurl4-openssl-dev libuchardet-dev libfmt-dev libspdlog-dev gnome-icon-theme
 ```
 Get cherrytree source, compile and run:
 ```sh


### PR DESCRIPTION
Add gnome-icon-theme dependency to Ubuntu build instructions.

`cherrytree` launch aborts with `gtk-icon-theme-error-quark` exception when gnome-icon-theme isn't installed in a chroot environment.