### PR TITLE
Correct the FSF's postal address

### DIFF
--- a/language-specs/nasm.lang
+++ b/language-specs/nasm.lang
@@ -16,8 +16,8 @@
 
  You should have received a copy of the GNU Library General Public
  License along with this library; if not, write to the
- Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- Boston, MA 02111-1307, USA.
+ Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ Boston, MA 02111-1301, USA.
 
 -->
 <!--

--- a/src/7za/CPP/myWindows/wine_date_and_time.cpp
+++ b/src/7za/CPP/myWindows/wine_date_and_time.cpp
@@ -11,7 +11,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02111-1301  USA
  *
  */
 

--- a/styles/Amy.xml
+++ b/styles/Amy.xml
@@ -17,8 +17,8 @@
 
  You should have received a copy of the GNU Library General Public
  License along with this library; if not, write to the
- Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- Boston, MA 02111-1307, USA.
+ Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ Boston, MA 02111-1301, USA.
 -->
 
 <style-scheme id="amy" _name="Amy" version="1.0">


### PR DESCRIPTION
This is flagged by package review tools in Fedora and Debian.

See, e.g, https://lintian.debian.org/tags/old-fsf-address-in-copyright-file.html

Signed-off-by: Ben Cotton <bcotton@fedoraproject.org>