### PR TITLE
Modified the main menu and translation

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: CherryTree\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-02-17 18:22+0000\n"
-"PO-Revision-Date: 2021-02-17 18:40+0000\n"
+"PO-Revision-Date: 2021-03-20 00:25+0600\n"
 "Last-Translator: Viktor Polyanskiy <camilot55@yandex.ru>\n"
 "Language-Team: Russian <camilot55@yandex.ru>\n"
 "Language: ru\n"
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Language: ru_RU\n"
 "X-Source-Language: C\n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 2.4.2\n"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_file.cc:80
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_file.cc:97
@@ -217,18 +217,16 @@ msgstr ""
 " \n"
 "Ваша система не поддерживает область уведомлений!"
 
-# msgstr "Новый язык будет доступен после рестарта CherryTree"
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_misc.cc:232
 msgid "The New Language will be Available Only After Restarting CherryTree"
-msgstr "Изменения вступят в силу после рестарта приложения"
+msgstr "Чтобы изменения вступили в силу,\n"
+"следует перезапустить приложение"
 
-# Подсказка для кнопки +
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_toolbar.cc:50
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_plain_text_n_code.cc:67
 msgid "Add"
 msgstr "Добавить часто используемые команды"
 
-# Подсказка для кнопки -
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_toolbar.cc:53
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_plain_text_n_code.cc:70
 msgid "Remove Selected"
@@ -249,7 +247,7 @@ msgid "Split Toolbar"
 msgstr "Разделитель панели инструментов"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_toolbar.cc:131
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:91
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:102
 msgid "Open a CherryTree Document"
 msgstr ""
 "Открыть...\n"
@@ -262,7 +260,7 @@ msgid "Select Element to Add"
 msgstr "Часто используемые команды"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.cc:28
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:102
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:108
 msgid "Preferences"
 msgstr "Настройки приложения"
 
@@ -280,18 +278,18 @@ msgstr "Форматированный текст"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.cc:38
 msgid "Plain Text and Code"
-msgstr "Обычный текст и код"
+msgstr "Простой текст и код"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.cc:39
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_special_chars.cc:34
+#: /home/giuseppe/git/cherrytree/src/ct/ct_actions_edit.cc:462
 msgid "Special Characters"
-msgstr "Символы"
+msgstr "Спецсимволы"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.cc:40
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:160
+#: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.cc:62
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:51
-msgid "Tree"
-msgstr "Дерево"
+msgid "Tree Explorer"
+msgstr "Обозреватель дерева"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.cc:41
 msgid "Theme"
@@ -304,7 +302,7 @@ msgstr "Шрифты"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.cc:43
 msgid "Links"
-msgstr "Ссылка"
+msgstr "Ссылки"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.cc:44
 msgid "Toolbar"
@@ -324,11 +322,11 @@ msgstr "Моноширинный текст"
 #: /home/giuseppe/git/cherrytree/src/ct/ct_dialogs.cc:1686
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:79
 msgid "Plain Text"
-msgstr "Обычный текст"
+msgstr "Простой текст"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.cc:82
 msgid "Code Font"
-msgstr "Текст CodeBox-а"
+msgstr "Текст кода"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.cc:84
 msgid "Tree Font"
@@ -336,19 +334,19 @@ msgstr "Текст дерева"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.cc:157
 msgid "Enable Custom Web Link Clicked Action"
-msgstr "Открывать веб-страницы"
+msgstr "При открытии ссылки на веб-страницу"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.cc:159
 msgid "Enable Custom File Link Clicked Action"
-msgstr "Открывать файлы"
+msgstr "При открытии ссылки на файл"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.cc:161
 msgid "Enable Custom Folder Link Clicked Action"
-msgstr "Открывать папки"
+msgstr "При открытии ссылки на папку"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.cc:170
 msgid "Custom Actions"
-msgstr "Действия"
+msgstr "Действие"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.cc:187
 #: /home/giuseppe/git/cherrytree/src/ct/ct_dialogs.cc:808
@@ -399,35 +397,59 @@ msgid "_Edit"
 msgstr "Правка"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:73
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:1070
-msgid "For_matting"
-msgstr "Формат"
+msgid "_Insert"
+msgstr "Вставка"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:74
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:97
+msgid "_Format"
+msgstr "Формат"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:75
 msgid "_Tree"
 msgstr "Дерево"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:75
-msgid "Node _Move"
-msgstr "Переместить"
-
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:76
-msgid "Nodes _Sort"
-msgstr "Сортировать"
+msgid "_Tools"
+msgstr "Инструменты"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:77
-msgid "Nodes _Import"
-msgstr "Импорт"
+msgid "_Search"
+msgstr "Поиск"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:78
-msgid "Nodes E_xport"
-msgstr "Экспорт"
+msgid "_View"
+msgstr "Вид"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:79
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:89
+msgid "_Help"
+msgstr "Справка"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:82
+msgid "Node _Move"
+msgstr "Переместить..."
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:83
+msgid "Nodes _Sort"
+msgstr "Сортировать..."
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:84
+msgid "_Bookmarks"
+msgstr "Перечень закладок"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:85
+msgid "_Import"
+msgstr "Импорт..."
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:86
+msgid "_Export"
+msgstr "Экспорт..."
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:87
 msgid "_Recent Documents"
 msgstr "История..."
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:79
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:87
 #: /home/giuseppe/git/cherrytree/src/ct/ct_main_win.cc:874
 msgid "Open a Recent CherryTree Document"
 msgstr ""
@@ -438,74 +460,85 @@ msgstr ""
 "Также можно удалить из истории недавно\n"
 "открытые документы CherryTree"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:80
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:1070
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:1123
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:88
 msgid "C_hange Case"
 msgstr "Регистр"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:81
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:1070
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:1123
-msgid "_Search"
-msgstr "Поиск"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:82
-msgid "_View"
-msgstr "Вид"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:83
-msgid "_Bookmarks"
-msgstr "Закладки"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:84
-msgid "_Import"
-msgstr "Импорт"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:85
-msgid "E_xport"
-msgstr "Экспорт"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:86
-msgid "_Help"
-msgstr "Справка"
-
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:89
+msgid "_List"
+msgstr "Список"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:90
+msgid "_Justify"
+msgstr "Выровнять"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:91
+msgid "_Font"
+msgstr "Шрифт"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:92
+msgid "_Toggle"
+msgstr "Заголовок"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:93
+msgid "I_nsert"
+msgstr "Вставить"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:94
+msgid "_Find"
+msgstr "Найти..."
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:95
+msgid "_Replace"
+msgstr "Заменить..."
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:96
+msgid "_Row"
+msgstr "Строка"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:100
 msgid "File"
 msgstr "Файл"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:90
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:101
 msgid "New _Instance"
 msgstr "Создать..."
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:90
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:101
 msgid "Start a New Instance of CherryTree"
 msgstr ""
 "Создать...\n"
 "\n"
 "Создать новый экземпляр CherryTree"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:91
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:247
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:102
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:254
 msgid "_Open File"
 msgstr "Открыть..."
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:92
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:254
+msgid "Open Embedded File"
+msgstr ""
+"Открыть файл...\n"
+"\n"
+"Открыть вставленный файл"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:103
 msgid "_Save"
 msgstr "Сохранить"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:92
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:103
 msgid "Save File"
 msgstr ""
 "Сохранить\n"
 "\n"
 "Сохранить текущий документ CherryTree"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:93
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:104
 msgid "Save and _Vacuum"
 msgstr "Сохранить и сжать"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:93
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:104
 msgid "Save File and Vacuum"
 msgstr ""
 "Сохранить и сжать\n"
@@ -513,13 +546,13 @@ msgstr ""
 "Сохранить и сжать документ CherryTree до \n"
 "минимального размера при помощи фрагментирования"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:94
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:246
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:105
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:253
 msgid "Save _As"
 msgstr "Сохранить как..."
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:94
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:246
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:253
 msgid "Save File As"
 msgstr ""
 "Сохранить как...\n"
@@ -529,38 +562,11 @@ msgstr ""
 "\n"
 "Сохранить вставленный файл"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:95
-msgid "Command Palette"
-msgstr "Команды..."
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:96
-msgid "_Execute Code"
-msgstr "Выполнить..."
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:96
-msgid "Execute Code"
-msgstr ""
-"Выполнить...\n"
-"\n"
-"Выполнить код из CodeBox с помощью\n"
-"интерпритатора или компилятора"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:97
-msgid "Open Preferences _Directory"
-msgstr "Открыть настройки..."
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:97
-msgid "Open the Directory with Preferences Files"
-msgstr ""
-"Открыть настройки...\n"
-"\n"
-"Открыть папку с настройками приложения"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:98
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:106
 msgid "Pa_ge Setup"
 msgstr "Параметры страницы"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:98
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:106
 msgid "Set up the Page for Printing"
 msgstr ""
 "Параметры страницы\n"
@@ -568,22 +574,35 @@ msgstr ""
 "Настроить параметры страницы для печати: \n"
 "ориентация, поля, размер и подача бумаги"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:99
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:107
 msgid "_Print"
 msgstr "_Печать"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:99
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:107
 msgid "Print"
 msgstr ""
 "Печать\n"
 "\n"
 "Настроить параметры печати документа"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:100
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:108
+msgid "_Preferences"
+msgstr "Настройки..."
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:109
+msgid "Tree _Info"
+msgstr "Информация..."
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:109
+#: /home/giuseppe/git/cherrytree/src/ct/ct_dialogs.cc:2211
+msgid "Tree Summary Information"
+msgstr "Информация о дереве"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:110
 msgid "_Quit"
 msgstr "Выход"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:100
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:110
 #: /home/giuseppe/git/cherrytree/src/ct/ct_main_win.cc:888
 msgid "Quit the Application"
 msgstr ""
@@ -591,12 +610,12 @@ msgstr ""
 "\n"
 "Выйти из CherryTree"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:101
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:111
 #: /home/giuseppe/git/cherrytree/src/ct/ct_app.cc:115
 msgid "_Exit CherryTree"
 msgstr "Выход"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:101
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:111
 #: /home/giuseppe/git/cherrytree/src/ct/ct_app.cc:115
 msgid "Exit from CherryTree"
 msgstr ""
@@ -604,44 +623,9 @@ msgstr ""
 "\n"
 "Выйти из CherryTree"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:102
-msgid "_Preferences"
-msgstr "Настройки..."
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:103
-msgid "_Check Newer Version"
-msgstr "Проверить обновления..."
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:103
-msgid "Check for a Newer Version"
-msgstr ""
-"Проверить обновления...\n"
-"\n"
-"Проверить наличие обновлений CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:104
-msgid "Online _Manual"
-msgstr "Справка в интернете"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:104
-msgid "Application's Online Manual"
-msgstr ""
-"Справка в интернете\n"
-"\n"
-"Показать онлайн справку по CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:105
-msgid "_About"
-msgstr "О приложении..."
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:105
-#: /home/giuseppe/git/cherrytree/src/ct/ct_dialogs.cc:1981
-msgid "About CherryTree"
-msgstr "О приложении..."
-
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:106
-msgid "Editor"
-msgstr "Правка"
+msgid "Edit/Insert"
+msgstr "Правка/Вставка"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:107
 msgid "_Undo"
@@ -770,11 +754,11 @@ msgstr ""
 "в настройках приложения"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:118
+#: /home/giuseppe/git/cherrytree/src/ct/ct_actions_edit.cc:421
 msgid "Insert _Special Character"
 msgstr "Символ"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:118
-#: /home/giuseppe/git/cherrytree/src/ct/ct_actions_edit.cc:421
 msgid "Insert a Special Character"
 msgstr ""
 "Символ\n"
@@ -962,7 +946,7 @@ msgstr ""
 "\n"
 "Удалить лишние пробелы в конце строк"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:134
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:137
 msgid "Format"
 msgstr "Формат"
 
@@ -1191,52 +1175,58 @@ msgstr ""
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:154
 msgid "Justify _Left"
-msgstr "Выровнять по левому краю"
+msgstr "По левому краю"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:154
 msgid "Justify Left the Current Paragraph"
 msgstr ""
-"Выровнять по левому краю\n"
+"По левому краю\n"
 "\n"
-"Выровнять текст по левому краю"
+"Выравнивание содержимого по левому краю\n"
+"Этот тип выравнивания обычно используется\n"
+"для основного текста и облегчает чтение документа."
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:155
 msgid "Justify _Center"
-msgstr "Выровнять по центру"
+msgstr "По центру"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:155
 msgid "Justify Center the Current Paragraph"
 msgstr ""
-"Выровнять по центру\n"
+"По центру\n"
 "\n"
-"Выровнять текст по центру"
+"Выравнивание содержимого по центру\n"
+"С помощью этого типа выравнивания вы можете\n"
+"придать документу официальный вид. Он часто \n"
+"используется для цитат и заголовков."
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:156
 msgid "Justify _Right"
-msgstr "Выровнять по правому краю"
+msgstr "По правому краю"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:156
 msgid "Justify Right the Current Paragraph"
 msgstr ""
-"Выровнять по правому краю\n"
+"По правому краю\n"
 "\n"
-"Выровнять текст по правому краю"
+"Выравнивание содержимого по правому краю\n"
+"Этот тип выравнивания обычно используется\n"
+"для небольших фрагментов содержимого текста."
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:157
 msgid "Justify _Fill"
-msgstr "Выровнять по ширине"
+msgstr "По ширине"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:157
 msgid "Justify Fill the Current Paragraph"
 msgstr ""
-"Выровнять по ширине\n"
+"По ширине\n"
 "\n"
-"Выровнять текст одновременно по\n"
-"левому и правому краям поля за счёт\n"
-"добавления дополнительных интервалов\n"
-"между словами там, где это необходимо.\n"
-"Текст распределяется равномерно между\n"
-"левым и правым краями страницы"
+"Выравнивание содержимого по ширине\n"
+"Равномерное распределение текста между\n"
+"левым и правым краям поля.\n"
+"Выровненный по ширине текст делает края\n"
+"документа ровными и чёткими."
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:158
 msgid "Indent Paragraph"
@@ -1261,6 +1251,38 @@ msgstr ""
 "\n"
 "Уменьшить отступ от края колонки одной\n"
 "или нескольких строк, идущих подряд."
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:163
+msgid "Tools"
+msgstr "Инструменты"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:166
+msgid "_Command Palette"
+msgstr "Команды..."
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:166
+msgid "Command Palette"
+msgstr ""
+"Команды...\n"
+"\n"
+"Выполнить любую из команд представленную\n"
+"в \"Настройки приложения\\Горячие клавиши\" "
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:167
+msgid "_Execute Code"
+msgstr "Выполнить..."
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:167
+msgid "Execute Code"
+msgstr ""
+"Выполнить...\n"
+"\n"
+"Выполнить код из CodeBox с помощью\n"
+"интерпретатора или компилятора"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:168
+msgid "Tree"
+msgstr "Дерево"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:161
 msgid "Add _Node"
@@ -1343,15 +1365,6 @@ msgstr ""
 "Если ветвь с сегодняшней датой существует, то \n"
 "ветвь не добавляется, а становится активной"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:168
-msgid "Tree _Info"
-msgstr "Информация..."
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:168
-#: /home/giuseppe/git/cherrytree/src/ct/ct_dialogs.cc:2211
-msgid "Tree Summary Information"
-msgstr "Информация о дереве"
-
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:169
 msgid "Node _Up"
 msgstr "Ветвь вверх"
@@ -1418,7 +1431,7 @@ msgid "Sort the Tree Ascending"
 msgstr ""
 "Дерево по возрастанию\n"
 "\n"
-"Сортировать все ветви\n"
+"Сортировать ветви\n"
 "дерева по возрастанию"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:175
@@ -1442,7 +1455,7 @@ msgid "Sort all the Siblings of the Selected Node Ascending"
 msgstr ""
 "Ветви по возрастанию\n"
 "\n"
-"Сортировать ветвь с дочерними по возрастанию"
+"Сортировать ветви по возрастанию в выбранной ветви"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:177
 msgid "Sort Siblings D_escending"
@@ -1453,7 +1466,7 @@ msgid "Sort all the Siblings of the Selected Node Descending"
 msgstr ""
 "Ветви по убыванию\n"
 "\n"
-"Сортировать ветвь с дочерними по убыванию"
+"Сортировать ветви по убыванию в выбранной ветви"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:178
 msgid "_Inherit Syntax"
@@ -1488,7 +1501,7 @@ msgid "Add the Current Node to the Bookmarks List"
 msgstr ""
 "Добавить в закладки\n"
 "\n"
-"Добавить ветвь в список закладок"
+"Добавить ветвь в перечень закладок"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:181
 msgid "_Remove from Bookmarks"
@@ -1499,7 +1512,7 @@ msgid "Remove the Current Node from the Bookmarks List"
 msgstr ""
 "Удалить из закладок\n"
 "\n"
-"Удалить ветвь из списка закладок"
+"Удалить ветвь из перечня закладок"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:182
 msgid "_Handle Bookmarks"
@@ -1508,7 +1521,7 @@ msgstr "Управление закладками"
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:182
 #: /home/giuseppe/git/cherrytree/src/ct/ct_dialogs.cc:417
 msgid "Handle the Bookmarks List"
-msgstr "Закладки..."
+msgstr "Перечень закладок"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:183
 msgid "Go _Back"
@@ -1545,52 +1558,52 @@ msgstr ""
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:186
 msgid "Find/Replace"
-msgstr "Поиск/Замена"
+msgstr "Найти/Заменить"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:187
 msgid "_Find in Node Content"
-msgstr "Искать в ветви"
+msgstr "В ветви"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:187
 msgid "Find into the Selected Node Content"
 msgstr ""
-"Искать в ветви\n"
+"В ветви\n"
 "\n"
 "Поиск текста или другого содержимого\n"
 "в содержании ветви"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:188
 msgid "Find in _All Nodes Contents"
-msgstr "Искать во всех ветвях"
+msgstr "В ветвях"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:188
 msgid "Find into All the Tree Nodes Contents"
 msgstr ""
-"Искать во всех ветвях\n"
+"В ветвях\n"
 "\n"
 "Поиск текста или другого содержимого\n"
 "в содержании всех ветвей"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:189
 msgid "Find in _Selected Node and Subnodes Contents"
-msgstr "Искать в ветви с дочерними"
+msgstr "В ветви с дочерними"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:189
 msgid "Find into the Selected Node and Subnodes Contents"
 msgstr ""
-"Искать в ветви с дочерними\n"
+"В ветви с дочерними\n"
 "\n"
 "Поиск текста или другого содержимого\n"
 "в содержании ветви с дочерними "
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:190
 msgid "Find in _Nodes Names and Tags"
-msgstr "Искать в именах ветвей и тэгах"
+msgstr "В именах ветвей и тэгах"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:190
 msgid "Find in Nodes Names and Tags"
 msgstr ""
-"Искать в именах ветвей и тэгах\n"
+"В именах ветвей и тэгах\n"
 "\n"
 "Поиск текста или другого содержимого\n"
 "в именах ветвей и тэгах"
@@ -1621,45 +1634,45 @@ msgstr ""
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:193
 msgid "_Replace in Node Content"
-msgstr "Заменить в ветви"
+msgstr "В ветви"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:193
 msgid "Replace into the Selected Node Content"
 msgstr ""
-"Заменить в ветви\n"
+"В ветви\n"
 "\n"
 "Заменить текст или другое содержимое в ветви"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:194
 msgid "Replace in _All Nodes Contents"
-msgstr "Заменить во всех ветвях"
+msgstr "В ветвях"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:194
 msgid "Replace into All the Tree Nodes Contents"
 msgstr ""
-"Заменить во всех ветвях\n"
+"В ветвях\n"
 "\n"
-"Заменить текст или другое содержимое в всех ветвей"
+"Заменить текст или другое содержимое во всех ветвях"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:195
 msgid "Replace in _Selected Node and Subnodes Contents"
-msgstr "Заменить в ветви с дочерними"
+msgstr "В ветви с дочерними"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:195
 msgid "Replace into the Selected Node and Subnodes Contents"
 msgstr ""
-"Заменить в ветви с дочерними\n"
+"В ветви с дочерними\n"
 "\n"
 "Заменить текст или другое содержимое в ветви с дочерними"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:196
 msgid "Replace in Nodes _Names"
-msgstr "Заменить в именах ветвей"
+msgstr "В именах ветвей"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:196
 msgid "Replace in Nodes Names"
 msgstr ""
-"Заменить в именах ветвей\n"
+"В именах ветвей\n"
 "\n"
 "Заменить текст или другое содержимое в именах ветвей"
 
@@ -1683,22 +1696,23 @@ msgid "Show Search All Matches Dialog"
 msgstr ""
 "Совпадения...\n"
 "\n"
-"Показать совпадения найденные при последнем поиске"
+"Показать диалоговое окно с совпадениями найденные\n"
+"при поиске или при замене содержимого"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:199
 msgid "View"
 msgstr "Вид"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:200
-msgid "Show/Hide _Tree"
-msgstr "Дерево"
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:209
+msgid "Show/Hide _Tree Explorer"
+msgstr "Обозреватель дерева"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:200
 msgid "Toggle Show/Hide Tree"
 msgstr ""
-"Дерево\n"
+"Обозреватель дерева\n"
 "\n"
-"Показать или скрыть навигатор по дереву, который\n"
+"Показать/Скрыть обозреватель дерева, который\n"
 "позволяет просматривать древовидное представление\n"
 "документа и быстро перемещаться по его ветвям"
 
@@ -1711,7 +1725,7 @@ msgid "Toggle Show/Hide Toolbar"
 msgstr ""
 "Панель инструментов\n"
 "\n"
-"Показать или скрыть панель инструментов.\n"
+"Показать/Скрыть панель инструментов.\n"
 "\n"
 "При помощи панели инструментов вы можете\n"
 "вызывать команды меню, вставлять объекты\n"
@@ -1731,7 +1745,7 @@ msgid "Toggle Show/Hide Node Name Header"
 msgstr ""
 "Заголовок\n"
 "\n"
-"Показать или скрыть заголовок ветви в текстовом редакторе"
+"Показать/Скрыть заголовок ветви в текстовом редакторе"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:203
 msgid "Toggle _Focus Tree/Text"
@@ -1742,7 +1756,7 @@ msgid "Toggle Focus Between Tree and Text"
 msgstr ""
 "Переключить фокус...\n"
 "\n"
-"Переключить фокус между Деревом и Текстовым редактором"
+"Переключить фокус между Обозревателем дерева и Текстовым редактором"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:204
 msgid "E_xpand All Nodes"
@@ -1798,6 +1812,197 @@ msgstr ""
 "На весь экран\n"
 "\n"
 "Развернуть приложение на весь экран"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:214
+msgid "Import"
+msgstr "Импорт"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:215
+msgid "From _CherryTree File"
+msgstr "Из документа CherryTree"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:215
+msgid "Add Nodes of a CherryTree File to the Current Tree"
+msgstr ""
+"Импорт данных из документа CherryTree\n"
+"\n"
+"Получить внешние данные из документа CherryTree"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:216
+msgid "From _Plain Text File"
+msgstr "Из текстового файла"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:216
+msgid "Add Node from a Plain Text File to the Current Tree"
+msgstr ""
+"Импорт данных из текстового файла\n"
+"\n"
+"Получить внешние данные из текстового файла"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:217
+msgid "From _Folder of Plain Text Files"
+msgstr "Из папки с текстовыми файлами"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:217
+msgid "Add Nodes from a Folder of Plain Text Files to the Current Tree"
+msgstr ""
+"Импорт данных из папки с текстовыми файлами\n"
+"\n"
+"Получить внешние данные из папки с текстовыми файлами"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:218
+msgid "From _HTML File"
+msgstr "Из файла HTML"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:218
+msgid "Add Node from an HTML File to the Current Tree"
+msgstr ""
+"Импорт данных из файла HTML\n"
+"\n"
+"Получить внешние данные из файла HTML"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:219
+msgid "From _Folder of HTML Files"
+msgstr "Из папки с файлами HTML"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:219
+msgid "Add Nodes from a Folder of HTML Files to the Current Tree"
+msgstr ""
+"Импорт данных из папки с файлами HTML\n"
+"\n"
+"Получить внешние данные из папки с файлами HTML"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:220
+msgid "From _Markdown File"
+msgstr "Из файла Markdown"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:220
+msgid "Add a node from a Markdown File to the Current Tree"
+msgstr ""
+"Импорт данных из файла Markdown\n"
+"\n"
+"Получить внешние данные из файла Markdown"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:221
+msgid "From _Folder of Markdown Files"
+msgstr "Из папки с файлами Markdown"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:221
+msgid "Add Nodes from a Folder of Markdown Files to the Current Tree"
+msgstr ""
+"Импорт данных из папки с файлами Markdown\n"
+"\n"
+"Получить внешние данные из папки с файлами Markdown"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:224
+msgid "From _Gnote Folder"
+msgstr "Из Gnote"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:224
+msgid "Add Nodes of a Gnote Folder to the Current Tree"
+msgstr ""
+"Импорт данных из Gnote\n"
+"\n"
+"Получить внешние данные из файла Gnote"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:225
+msgid "From _KeepNote Folder"
+msgstr "Из KeepNote"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:225
+msgid "Add Nodes of a KeepNote Folder to the Current Tree"
+msgstr ""
+"Импорт данных из KeepNote\n"
+"\n"
+"Получить внешние данные из файла KeepNote"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:228
+msgid "From _Leo File"
+msgstr "Из Leo"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:228
+msgid "Add Nodes of a Leo File to the Current Tree"
+msgstr ""
+"Импорт данных из Leo\n"
+"\n"
+"Получить внешние данные из файла Leo"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:229
+msgid "From _Mempad File"
+msgstr "Из Mempad"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:229
+msgid "Add Nodes of a Mempad File to the Current Tree"
+msgstr ""
+"Импорт данных из Mempad\n"
+"\n"
+"Получить внешние данные из файла Mempad"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:230
+msgid "From _NoteCase HTML File"
+msgstr "Из NoteCase HTML файла"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:230
+msgid "Add Nodes of a NoteCase HTML File to the Current Tree"
+msgstr ""
+"Импорт данных из NoteCase HTML файла\n"
+"\n"
+"Получить внешние данные из NoteCase HTML файла"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:231
+msgid "From _RedNotebook HTML"
+msgstr "Из RedNotebook HTML"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:231
+msgid "Add Nodes of a RedNotebook HTML file to the Current Tree"
+msgstr ""
+"Импорт данных из RedNotebook HTML\n"
+"\n"
+"Получить внешние данные из файла RedNotebook HTML"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:232
+msgid "From T_omboy Folder"
+msgstr "Из T_omboy"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:232
+msgid "Add Nodes of a Tomboy Folder to the Current Tree"
+msgstr ""
+"Импорт данных из T_omboy\n"
+"\n"
+"Получить внешние данные из папки с файлами Tomboy"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:233
+msgid "From T_reepad Lite File"
+msgstr "Из T_reepad"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:233
+msgid "Add Nodes of a Treepad Lite File to the Current Tree"
+msgstr ""
+"Импорт данных из T_reepad\n"
+"\n"
+"Получить внешние данные из файла Treepad"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:235
+msgid "From _Zim Folder"
+msgstr "Из Zim"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:235
+msgid "Add Nodes of a Zim Folder to the Current Tree"
+msgstr ""
+"Импорт данных из Zim\n"
+"\n"
+"Получить внешние данные из папки с файлами Zim"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:236
+msgid "From File using _Pandoc"
+msgstr "Из файла используя Pandoc"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:236
+msgid "Add a node to the current tree using Pandoc"
+msgstr ""
+"Импорт данных из файла используя Pandoc\n"
+"\n"
+"Получить внешние данные из файла с использованием Pandoc"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:209
 msgid "Export"
@@ -1859,213 +2064,51 @@ msgstr ""
 "ветвь, ветвь с дочерними\n"
 "или полностью всё дерево"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:214
-msgid "Import"
-msgstr "Импорт"
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:239
+msgid "Help"
+msgstr "Справка"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:215
-msgid "From _CherryTree File"
-msgstr "Из документа CherryTree"
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:240
+msgid "_Check Newer Version"
+msgstr "Проверить обновления..."
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:215
-msgid "Add Nodes of a CherryTree File to the Current Tree"
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:240
+msgid "Check for a Newer Version"
 msgstr ""
-"Из документа CherryTree\n"
+"Проверить обновления...\n"
 "\n"
-"Импортировать данные из документа CherryTree\n"
-"в текущее дерево документа CherryTree"
+"Проверить наличие обновлений CherryTree"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:216
-msgid "From _Plain Text File"
-msgstr "Из текстового файла"
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:241
+msgid "Online _Manual"
+msgstr "Справка в интернете"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:216
-msgid "Add Node from a Plain Text File to the Current Tree"
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:241
+msgid "Application's Online Manual"
 msgstr ""
-"Из текстового файла\n"
+"Справка в интернете\n"
 "\n"
-"Импортировать данные из текстового файла\n"
-"в текущее дерево документа CherryTree"
+"Показать онлайн справку по CherryTree"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:217
-msgid "From _Folder of Plain Text Files"
-msgstr "Из папки с текстовыми файлами"
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:242
+msgid "_About"
+msgstr "О приложении..."
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:217
-msgid "Add Nodes from a Folder of Plain Text Files to the Current Tree"
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:242
+#: /home/giuseppe/git/cherrytree/src/ct/ct_dialogs.cc:1981
+msgid "About CherryTree"
+msgstr "О приложении..."
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:243
+msgid "Open Preferences _Directory"
+msgstr "Открыть настройки..."
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:243
+msgid "Open the Directory with Preferences Files"
 msgstr ""
-"Из папки с текстовыми файлами\n"
+"Открыть настройки...\n"
 "\n"
-"Импортировать данные из папки с текстовыми файлами\n"
-"в текущее дерево документа CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:218
-msgid "From _HTML File"
-msgstr "Из файла HTML"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:218
-msgid "Add Node from an HTML File to the Current Tree"
-msgstr ""
-"Из файла HTML\n"
-"\n"
-"Импортировать данные из файла HTML\n"
-"в текущее дерево документа CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:219
-msgid "From _Folder of HTML Files"
-msgstr "Из папки с файлами HTML"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:219
-msgid "Add Nodes from a Folder of HTML Files to the Current Tree"
-msgstr ""
-"Из папки с файлами HTML\n"
-"\n"
-"Импортировать данные из папки с файлами HTML\n"
-"в текущее дерево документа CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:220
-msgid "From _Markdown File"
-msgstr "Из файла Markdown"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:220
-msgid "Add a node from a Markdown File to the Current Tree"
-msgstr ""
-"Из файла Markdown\n"
-"\n"
-"Импортировать данные из файла Markdown\n"
-"в текущее дерево документа CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:221
-msgid "From _Folder of Markdown Files"
-msgstr "Из папки с файлами Markdown"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:221
-msgid "Add Nodes from a Folder of Markdown Files to the Current Tree"
-msgstr ""
-"Из папки с файлами Markdown\n"
-"\n"
-"Импортировать данные из папки с файлами Markdown\n"
-"в текущее дерево документа CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:224
-msgid "From _Gnote Folder"
-msgstr "Из Gnote"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:224
-msgid "Add Nodes of a Gnote Folder to the Current Tree"
-msgstr ""
-"Из Gnote\n"
-"\n"
-"Импортировать данные из файла Gnote\n"
-"в текущее дерево документа CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:225
-msgid "From _KeepNote Folder"
-msgstr "Из KeepNote"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:225
-msgid "Add Nodes of a KeepNote Folder to the Current Tree"
-msgstr ""
-"Из KeepNote\n"
-"\n"
-"Импортировать данные из файла KeepNote\n"
-"в текущее дерево документа CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:228
-msgid "From _Leo File"
-msgstr "Из Leo"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:228
-msgid "Add Nodes of a Leo File to the Current Tree"
-msgstr ""
-"Из Leo\n"
-"\n"
-"Импортировать данные из файла Leo\n"
-"в текущее дерево документа CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:229
-msgid "From _Mempad File"
-msgstr "Из Mempad"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:229
-msgid "Add Nodes of a Mempad File to the Current Tree"
-msgstr ""
-"Из Mempad\n"
-"\n"
-"Импортировать данные из файла Mempad\n"
-"в текущее дерево документа CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:230
-msgid "From _NoteCase HTML File"
-msgstr "Из NoteCase HTML файла"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:230
-msgid "Add Nodes of a NoteCase HTML File to the Current Tree"
-msgstr ""
-"Из NoteCase HTML файла\n"
-"\n"
-"Импортировать данные из NoteCase HTML файла\n"
-"в текущее дерево документа CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:231
-msgid "From _RedNotebook HTML"
-msgstr "Из RedNotebook HTML"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:231
-msgid "Add Nodes of a RedNotebook HTML file to the Current Tree"
-msgstr ""
-"Из RedNotebook HTML\n"
-"\n"
-"Импортировать данные из файла RedNotebook HTML\n"
-"в текущее дерево документа CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:232
-msgid "From T_omboy Folder"
-msgstr "Из T_omboy"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:232
-msgid "Add Nodes of a Tomboy Folder to the Current Tree"
-msgstr ""
-"Из T_omboy\n"
-"\n"
-"Импортировать данные из папки с файлами Tomboy\n"
-"в текущее дерево документа CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:233
-msgid "From T_reepad Lite File"
-msgstr "Из T_reepad"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:233
-msgid "Add Nodes of a Treepad Lite File to the Current Tree"
-msgstr ""
-"Из T_reepad\n"
-"\n"
-"Импортировать данные из файла Treepad\n"
-"в текущее дерево документа CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:235
-msgid "From _Zim Folder"
-msgstr "Из Zim"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:235
-msgid "Add Nodes of a Zim Folder to the Current Tree"
-msgstr ""
-"Из Zim\n"
-"\n"
-"Импортировать данные из папки с файлами Zim\n"
-"в текущее дерево документа CherryTree"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:236
-msgid "From File using _Pandoc"
-msgstr "Из файла используя Pandoc"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:236
-msgid "Add a node to the current tree using Pandoc"
-msgstr ""
-"Из файла используя Pandoc\n"
-"\n"
-"Импортировать данные из файла в документ \n"
-"CherryTree с использованием Pandoc"
+"Открыть папку с настройками приложения"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:238
 msgid "C_ut Anchor"
@@ -2159,16 +2202,9 @@ msgstr ""
 "\n"
 "Удалить файл из документа"
 
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:247
-msgid "Open Embedded File"
-msgstr ""
-"Открыть файл...\n"
-"\n"
-"Открыть вставленный файл"
-
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:248
 msgid "_Rename"
-msgstr "Переименовать"
+msgstr "Переименовать..."
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:248
 msgid "Rename Embedded File"
@@ -2260,7 +2296,7 @@ msgstr ""
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:256
 #: /home/giuseppe/git/cherrytree/src/ct/ct_app.cc:113
 msgid "Show/Hide _CherryTree"
-msgstr "<b> Открыть CherryTree </b>"
+msgstr "Открыть CherryTree"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:256
 #: /home/giuseppe/git/cherrytree/src/ct/ct_app.cc:113
@@ -2547,8 +2583,8 @@ msgid "Execute CodeBox Code"
 msgstr ""
 "Выполнить код CodeBox\n"
 "\n"
-"Выполнить код из CodeBox с помощью\n"
-"интерпритатора или компилятора"
+"Выполнить код CodeBox с помощью\n"
+"интерпретатора или компилятора"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:296
 msgid "CodeBox _Load From Text File"
@@ -2668,29 +2704,6 @@ msgstr ""
 #: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:410
 msgid "Remove from list"
 msgstr "Удалить из истории"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:1070
-msgid "_List"
-msgstr "Список"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:1070
-msgid "_Justify"
-msgstr "Выравнивание"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:1070
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:1123
-msgid "_Insert"
-msgstr "Вставка"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:1070
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:1123
-msgid "_Row"
-msgstr "Строка"
-
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:1070
-#: /home/giuseppe/git/cherrytree/src/ct/ct_menu.cc:1123
-msgid "_Replace"
-msgstr "Заменить"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_find.cc:60
 msgid "Replace in Current Node..."
@@ -2813,10 +2826,9 @@ msgstr "Изменена до"
 msgid "Time filter"
 msgstr "По дате ветви..."
 
-# Диалог последних замен
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_find.cc:535
 msgid "Show Iterated Find/Replace Dialog"
-msgstr "Показать диалог Найти/Заменить"
+msgstr "Показать диалоговое окно \"Совпадения...\" "
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_find.cc:559
 msgid "Search options"
@@ -2842,7 +2854,6 @@ msgstr "Следующий"
 msgid "Replace"
 msgstr "Заменить"
 
-# Меню:Правка/Отменить
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_find.cc:1012
 msgid "Undo"
 msgstr "Отменить"
@@ -2891,7 +2902,6 @@ msgstr ""
 "\n"
 "Пожалуйста проверьте его наличие"
 
-# Диалог Выбрать родителя при импорте данных
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_import.cc:234
 msgid "Who is the Parent?"
 msgstr "Добавить в..."
@@ -2926,7 +2936,7 @@ msgstr "Курсор за пределами абзаца"
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_format.cc:381
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_others.cc:253
 msgid "Insert/Edit Link"
-msgstr "Изменение ссылки"
+msgstr "Свойства ссылки"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_format.cc:389
 msgid "Pick a Foreground Color"
@@ -3122,7 +3132,6 @@ msgstr ""
 msgid "Image Format Not Recognized"
 msgstr "Не известный формат изображения"
 
-# Название окошка и его содержимого
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_edit.cc:79
 msgid "Insert Table"
 msgstr "Вставить таблицу"
@@ -3161,11 +3170,11 @@ msgstr "Пробелы вместо табуляции"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_text_n_code.cc:41
 msgid "Use Line Wrapping"
-msgstr "Перенос текста"
+msgstr "Переносить строки"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_text_n_code.cc:45
 msgid "Line Wrapping Indentation"
-msgstr "Отступ переноса текста"
+msgstr "Отступ строк"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_text_n_code.cc:52
 msgid "Enable Automatic Indentation"
@@ -3178,15 +3187,15 @@ msgstr "Нумерация строк"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_text_n_code.cc:56
 msgid "Scroll Beyond Last Line"
-msgstr "Прокрутка за пределы документа"
+msgstr "Прокрутка за пределы строки"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_text_n_code.cc:60
 msgid "Vertical Space Around Lines"
-msgstr "Вертикальный отступ"
+msgstr "Междустрочный интервал"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_text_n_code.cc:70
 msgid "Vertical Space in Wrapped Lines"
-msgstr "Вертикальный отступ для строк"
+msgstr "Вертикальный отступ строк"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_text_n_code.cc:93
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_special_chars.cc:119
@@ -3197,6 +3206,10 @@ msgstr "Текстовый редактор"
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_text_n_code.cc:97
 msgid "Timestamp Format"
 msgstr "Формат даты"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_text_n_code.cc:103
+msgid "Online Manual"
+msgstr "Справка в интернете"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_text_n_code.cc:108
 msgid "Horizontal Rule"
@@ -3304,7 +3317,7 @@ msgstr "Сортировать по возрастанию"
 #: /home/giuseppe/git/cherrytree/src/ct/ct_dialogs.cc:676
 #, c-format
 msgid "Hide (Restore with '%s')"
-msgstr "Закрыть (Восстановить с помощью '%s')"
+msgstr "Свернуть/Восстановить ('%s')"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_dialogs.cc:680
 #: /home/giuseppe/git/cherrytree/src/ct/ct_dialogs.cc:1680
@@ -3603,11 +3616,11 @@ msgstr "Светлый текст на тёмном фоне"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:37
 msgid "Custom Background"
-msgstr "Цвет фона"
+msgstr "Фон"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:41
 msgid "and Text"
-msgstr "Цвет текста"
+msgstr "Текст"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:86
 msgid "Table"
@@ -3615,27 +3628,27 @@ msgstr "Таблица"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:93
 msgid "Code"
-msgstr "Текст CodeBox-а"
+msgstr "Код"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:111
 msgid "Style Schemes"
-msgstr "Стиль"
+msgstr "Текстовый редактор"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:162
 msgid "Text Foreground"
-msgstr "Цвет текста"
+msgstr "Текст"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:164
 msgid "Text Background"
-msgstr "Цвет фона"
+msgstr "Фон"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:166
 msgid "Selection Foreground"
-msgstr "На передний план"
+msgstr "Выделенный текст"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:168
 msgid "Selection Background"
-msgstr "На задний план"
+msgstr "Фон выделенного текста"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:170
 msgid "Cursor"
@@ -3643,19 +3656,19 @@ msgstr "Курсор"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:172
 msgid "Current Line Background"
-msgstr "Цвет фона текеущей строки"
+msgstr "Фон активной строки"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:174
 msgid "Line Numbers Foreground"
-msgstr "Номера строк на переднем плане"
+msgstr "Нумерация строк"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:176
 msgid "Line Numbers Background"
-msgstr "Номера строк на заднем плане"
+msgstr "Фон нумерации строк"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_theme.cc:320
 msgid "Style Scheme Editor"
-msgstr "Редактор стилей"
+msgstr "Настраиваемая тема"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_export2pdf.cc:420
 msgid "Warning: One or More Images Were Reduced to Enter the Page"
@@ -3685,17 +3698,14 @@ msgstr "Эта функция доступна только для формат�
 msgid "This Feature is Not Available in Automatic Syntax Highlighting Nodes"
 msgstr "Эта функция не доступна для подсветки синтаксиса"
 
-# Название окошка
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_tree.cc:172
 msgid "New Child Node Properties"
 msgstr "Свойства новой дочерней ветви"
 
-# Название окошка
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_tree.cc:172
 msgid "New Node Properties"
 msgstr "Свойства новой ветви"
 
-# Диалог Изменения свойст ветви
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_tree.cc:292
 msgid "Node Properties"
 msgstr "Свойства ветви"
@@ -3705,7 +3715,7 @@ msgid ""
 "Leaving the Node Type Rich Text you will Lose all Formatting for This Node, "
 "Do you want to Continue?"
 msgstr ""
-"При смене <b> \"Форматированный текст\" </b> на <b> \"Обычный текст\" </b>,\n"
+"При смене <b> \"Форматированный текст\" </b> на <b> \"Простой текст\" </b>,\n"
 "вы полностью потеряете форматирование текста для данной ветви.\n"
 "Продолжить?"
 
@@ -3737,9 +3747,10 @@ msgstr "Выбранная новая родительская ветвь явл
 msgid "PDF File"
 msgstr "Документ PDF"
 
+#: /home/giuseppe/git/cherrytree/src/ct/ct_imports.h:167
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_export.cc:373
 msgid "Plain Text Document"
-msgstr "Обычный текст"
+msgstr "Текстовый документ"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_special_chars.cc:61
 msgid "Chars for Bulleted List"
@@ -3781,7 +3792,7 @@ msgstr "Подсвечивать активную строку"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_plain_text_n_code.cc:93
 msgid "Command per Node/CodeBox Type"
-msgstr "Команда по типу Ветвь/CodeBox"
+msgstr "Команда интерпретатора/компилятора"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_plain_text_n_code.cc:97
 msgid "Terminal Command"
@@ -3822,7 +3833,6 @@ msgstr ""
 "\n"
 "Искомый якорь <b>' %s '</b> не найден!"
 
-# Название окошка
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_others.cc:405
 msgid "Edit CodeBox"
 msgstr "Свойства CodeBox"
@@ -3853,17 +3863,14 @@ msgstr ""
 "Установите пакет 'xterm' или настройте другой терминал в настройках "
 "приложения"
 
-# Название окошка
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_others.cc:693
 msgid "Edit Table Properties"
 msgstr "Свойства таблицы"
 
-# Название_окошка_при_добавлении_якоря
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_others.cc:728
 msgid "Insert Anchor"
 msgstr "Вставить якорь"
 
-# Название_окошка_для_редактирования_якоря
 #: /home/giuseppe/git/cherrytree/src/ct/ct_actions_others.cc:728
 msgid "Edit Anchor"
 msgstr "Свойства якоря"
@@ -3890,7 +3897,7 @@ msgstr "Автоподбор по содержимому CodeBox"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_rich_text.cc:62
 msgid "Monospace Background"
-msgstr "Цвет фона моношрифта"
+msgstr "Фон моношрифта"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_rich_text.cc:74
 msgid "Embedded File Icon Size"
@@ -3918,7 +3925,7 @@ msgstr "Включить автозамену Markdown (Эксперимента
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_tree.cc:33
 msgid "Use Different Cherries per Level"
-msgstr "Разные вишенки для каждой ветви"
+msgstr "Разные вишенки для каждого уровня"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_tree.cc:36
 msgid "No Icon"
@@ -3926,7 +3933,7 @@ msgstr "Без значка"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_tree.cc:38
 msgid "Hide Right Side Auxiliary Icon"
-msgstr "Скрыть дополнительный значок с правой стороны ветви"
+msgstr "Скрыть значок справа от ветви"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_tree.cc:52
 msgid "Default Text Nodes Icons"
@@ -3946,7 +3953,7 @@ msgstr "Сворачивать ветви"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_tree.cc:65
 msgid "Nodes in Bookmarks Always Visible"
-msgstr "Всегда видимые ветви в закладках"
+msgstr "Не скрывать ветви в закладках"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_tree.cc:73
 msgid "Nodes Status at Startup"
@@ -3958,7 +3965,7 @@ msgstr "Ширина переноса в имени ветви"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_tree.cc:90
 msgid "Display Tree on the Right Side"
-msgstr "Отображать панель дерева справа"
+msgstr "Обозреватель дерева справа"
 
 #: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg_tree.cc:92
 msgid "Move Focus to Text at Mouse Click"
@@ -3980,41 +3987,39 @@ msgstr "Размер значков панели инструментов мак
 msgid "The Size of the Toolbar Icons is already at the Minimum Value"
 msgstr "Размер значков панели инструментов минимальный"
 
-#~ msgid "_Tools"
-#~ msgstr "Инструменты"
+#: /home/giuseppe/git/cherrytree/src/ct/ct_pref_dlg.h:61
+msgid "Are you sure to Reset to Default?"
+msgstr "Восстановить значения по умолчанию?"
 
-#~ msgid "_Paste"
-#~ msgstr "Вставить"
+#: /home/giuseppe/git/cherrytree/src/ct/ct_imports.h:69
+msgid "HTML Document"
+msgstr "HTML документ"
 
-#~ msgid "_Find"
-#~ msgstr "Найти..."
+#: /home/giuseppe/git/cherrytree/src/ct/ct_imports.h:182
+msgid "Markdown Document"
+msgstr "Документ Markdown"
 
-#~ msgid "_Font"
-#~ msgstr "Шрифт"
+#: /home/giuseppe/git/cherrytree/src/ct/ct_imports.h:216
+msgid "Mempad Document"
+msgstr "Документ Mempad"
 
+#: /home/giuseppe/git/cherrytree/src/ct/ct_imports.h:225
+msgid "Treepad Document"
+msgstr "Документ Treepad"
+
+#: /home/giuseppe/git/cherrytree/src/ct/ct_imports.h:235
+msgid "Leo Document"
+msgstr "Документ Leo"
+
+# Закоментировано до лучших времён
 #~ msgid "NoteCase Document"
 #~ msgstr "Документ NoteCase"
-
-#~ msgid "HTML Document"
-#~ msgstr "HTML документ"
-
-#~ msgid "Treepad Document"
-#~ msgstr "Документ Treepad"
 
 #~ msgid "KeyNote Document"
 #~ msgstr "Документ KeyNote"
 
-#~ msgid "Mempad Document"
-#~ msgstr "Документ Mempad"
-
 #~ msgid "Knowit Document"
 #~ msgstr "Документ Knowit"
-
-#~ msgid "Leo Document"
-#~ msgstr "Документ Leo"
-
-#~ msgid "Are you sure to Reset to Default?"
-#~ msgstr "Восстановить значения по умолчанию?"
 
 #~ msgid "Export to PDF at specified file path"
 #~ msgstr "Экспорт в PDF в существующую директорию"

--- a/src/ct/ct_actions_edit.cc
+++ b/src/ct/ct_actions_edit.cc
@@ -460,7 +460,7 @@ void CtActions::special_char_insert()
         ++pathCurrIdx;
     }
     const Gtk::TreeIter treeIter = CtDialogs::choose_item_dialog(*_pCtMainWin,
-                                                                 _("Insert a Special Character"),
+                                                                 _("Special Characters"),
                                                                  itemStore,
                                                                  nullptr/*single_column_name*/,
                                                                  std::to_string(pathSelectIdx));

--- a/src/ct/ct_main_win.cc
+++ b/src/ct/ct_main_win.cc
@@ -74,8 +74,8 @@ CtMainWin::CtMainWin(bool                            no_gui,
 
     _pMenuBar = _uCtMenu->build_menubar();
     _pMenuBar->set_name("MenuBar");
-    _pBookmarksSubmenu = CtMenu::find_menu_item(_pMenuBar, "BookmarksMenu");
-    _pRecentDocsSubmenu = CtMenu::find_menu_item(_pMenuBar, "RecentDocsMenu");
+    _pBookmarksSubmenu = CtMenu::find_menu_item(_pMenuBar, "BookmarksSubMenu");
+    _pRecentDocsSubmenu = CtMenu::find_menu_item(_pMenuBar, "RecentDocsSubMenu");
     _pMenuBar->show_all();
     add_accel_group(_uCtMenu->get_accel_group());
     _pToolbars = _uCtMenu->build_toolbars(_pRecentDocsMenuToolButton);

--- a/src/ct/ct_menu.cc
+++ b/src/ct/ct_menu.cc
@@ -70,20 +70,31 @@ void CtMenu::init_actions(CtActions* pActions)
     // stubs for menu bar
     _actions.push_back(CtMenuAction{"", "FileMenu", None, _("_File"), None, None, sigc::signal<void>()});
     _actions.push_back(CtMenuAction{"", "EditMenu", None, _("_Edit"), None, None, sigc::signal<void>()});
-    _actions.push_back(CtMenuAction{"", "FormattingMenu", None, _("For_matting"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "InsertMenu", None, _("_Insert"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "FormatMenu", None, _("_Format"), None, None, sigc::signal<void>()});
     _actions.push_back(CtMenuAction{"", "TreeMenu", None, _("_Tree"), None, None, sigc::signal<void>()});
-    _actions.push_back(CtMenuAction{"", "TreeMoveMenu", "ct_go-jump", _("Node _Move"), None, None, sigc::signal<void>()});
-    _actions.push_back(CtMenuAction{"", "TreeSortMenu", "ct_sort-asc", _("Nodes _Sort"), None, None, sigc::signal<void>()});
-    _actions.push_back(CtMenuAction{"", "TreeImportMenu", CtConst::STR_STOCK_CT_IMP, _("Nodes _Import"), None, None, sigc::signal<void>()});
-    _actions.push_back(CtMenuAction{"", "TreeExportMenu", "ct_export_from_cherrytree", _("Nodes E_xport"), None, None, sigc::signal<void>()});
-    _actions.push_back(CtMenuAction{"", "RecentDocsMenu", "ct_open", _("_Recent Documents"), None, _("Open a Recent CherryTree Document"), sigc::signal<void>()});
-    _actions.push_back(CtMenuAction{"", "ChangeCaseMenu", "ct_case_toggle", _("C_hange Case"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "ToolsMenu", None, _("_Tools"), None, None, sigc::signal<void>()});
     _actions.push_back(CtMenuAction{"", "SearchMenu", None, _("_Search"), None, None, sigc::signal<void>()});
     _actions.push_back(CtMenuAction{"", "ViewMenu", None, _("_View"), None, None, sigc::signal<void>()});
-    _actions.push_back(CtMenuAction{"", "BookmarksMenu", None, _("_Bookmarks"), None, None, sigc::signal<void>()});
-    _actions.push_back(CtMenuAction{"", "ImportMenu", None, _("_Import"), None, None, sigc::signal<void>()});
-    _actions.push_back(CtMenuAction{"", "ExportMenu", None, _("E_xport"), None, None, sigc::signal<void>()});
     _actions.push_back(CtMenuAction{"", "HelpMenu", None, _("_Help"), None, None, sigc::signal<void>()});
+
+    // stubs for sumenu bar
+    _actions.push_back(CtMenuAction{"", "TreeMoveSubMenu", "ct_go-jump", _("Node _Move"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "TreeSortSubMenu", "ct_sort-asc", _("Nodes _Sort"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "BookmarksSubMenu", "ct_pin", _("_Bookmarks"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "ImportSubMenu", CtConst::STR_STOCK_CT_IMP, _("_Import"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "ExportSubMenu", "ct_export_from_cherrytree", _("_Export"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "RecentDocsSubMenu", "ct_open", _("_Recent Documents"), None, _("Open a Recent CherryTree Document"), sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "ChangeCaseSubMenu", "ct_case_toggle", _("C_hange Case"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "ListSubMenu", "ct_list_bulleted", _("_List"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "JustifySubMenu", "ct_justify-center", _("_Justify"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "FontSubMenu", "ct_fonts", _("_Font"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "ToggleSubMenu", "ct_fmt-txt-large", _("_Toggle"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "InsertSubMenu", "ct_insert", _("I_nsert"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "FindSubMenu", "ct_find", _("_Find"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "ReplaceSubMenu", "ct_find_replace", _("_Replace"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "RowSubMenu", "ct_edit", _("_Row"), None, None, sigc::signal<void>()});
+    _actions.push_back(CtMenuAction{"", "FormattingSubMenu", "ct_fmt-txt", _("_Format"), None, None, sigc::signal<void>()});
 
     // main actions
     const char* file_cat = _("File");
@@ -92,22 +103,16 @@ void CtMenu::init_actions(CtActions* pActions)
     _actions.push_back(CtMenuAction{file_cat, "ct_save", "ct_save", _("_Save"), KB_CONTROL+"S", _("Save File"), sigc::mem_fun(*pActions, &CtActions::file_save)});
     _actions.push_back(CtMenuAction{file_cat, "ct_vacuum", "ct_clear", _("Save and _Vacuum"), None, _("Save File and Vacuum"), sigc::mem_fun(*pActions, &CtActions::file_vacuum)});
     _actions.push_back(CtMenuAction{file_cat, "ct_save_as", "ct_save-as", _("Save _As"), KB_CONTROL+KB_SHIFT+"S", _("Save File As"), sigc::mem_fun(*pActions, &CtActions::file_save_as)});
-    _actions.push_back(CtMenuAction{file_cat, "command_palette", "ct_execute", _("Command Palette"), KB_CONTROL+KB_SHIFT+"P", _("Command Palette"), sigc::mem_fun(*pActions, &CtActions::command_palette)});
-    _actions.push_back(CtMenuAction{file_cat, "exec_code", "ct_execute", _("_Execute Code"), "F5", _("Execute Code"), sigc::mem_fun(*pActions, &CtActions::exec_code)});
-    _actions.push_back(CtMenuAction{file_cat, "open_cfg_folder", "ct_directory", _("Open Preferences _Directory"), None, _("Open the Directory with Preferences Files"), sigc::mem_fun(*pActions, &CtActions::folder_cfg_open)});
     _actions.push_back(CtMenuAction{file_cat, "print_page_setup", "ct_print", _("Pa_ge Setup"), None, _("Set up the Page for Printing"), sigc::mem_fun(*pActions, &CtActions::export_print_page_setup)});
     _actions.push_back(CtMenuAction{file_cat, "do_print", "ct_print", _("_Print"), KB_CONTROL+"P", _("Print"), sigc::mem_fun(*pActions, &CtActions::export_print)});
+    _actions.push_back(CtMenuAction{file_cat, "preferences_dlg", "ct_preferences", _("_Preferences"), KB_CONTROL+KB_ALT+"P", _("Preferences"), sigc::mem_fun(*pActions, &CtActions::dialog_preferences) });
+    _actions.push_back(CtMenuAction{file_cat, "tree_parse_info", "ct_info", _("Tree _Info"), None, _("Tree Summary Information"), sigc::mem_fun(*pActions, &CtActions::tree_info)});
     _actions.push_back(CtMenuAction{file_cat, "quit_app", "ct_quit-app", _("_Quit"), KB_CONTROL+"Q", _("Quit the Application"), sigc::mem_fun(*pActions, &CtActions::quit_or_hide_window)});
     _actions.push_back(CtMenuAction{file_cat, "exit_app", "ct_quit-app", _("_Exit CherryTree"), KB_CONTROL+KB_SHIFT+"Q", _("Exit from CherryTree"), sigc::mem_fun(*pActions, &CtActions::quit_window)});
-    _actions.push_back(CtMenuAction{file_cat, "preferences_dlg", "ct_preferences", _("_Preferences"), KB_CONTROL+KB_ALT+"P", _("Preferences"), sigc::mem_fun(*pActions, &CtActions::dialog_preferences) });
-    _actions.push_back(CtMenuAction{file_cat, "ct_check_newer", "ct_network", _("_Check Newer Version"), None, _("Check for a Newer Version"), sigc::mem_fun(*pActions, &CtActions::check_for_newer_version)});
-    _actions.push_back(CtMenuAction{file_cat, "ct_help", "ct_help", _("Online _Manual"), "F1", _("Application's Online Manual"), sigc::mem_fun(*pActions, &CtActions::online_help)});
-    _actions.push_back(CtMenuAction{file_cat, "ct_about", "ct_about", _("_About"), None, _("About CherryTree"), sigc::mem_fun(*pActions, &CtActions::dialog_about)});
-    const char* editor_cat = _("Editor");
+    const char* editor_cat = _("Edit/Insert");
     _actions.push_back(CtMenuAction{editor_cat, "act_undo", "ct_undo", _("_Undo"), KB_CONTROL+"Z", _("Undo Last Operation"), sigc::mem_fun(*pActions, &CtActions::requested_step_back)});
     _actions.push_back(CtMenuAction{editor_cat, "act_redo", "ct_redo", _("_Redo"), KB_CONTROL+"Y", _("Redo Previously Discarded Operation"), sigc::mem_fun(*pActions, &CtActions::requested_step_ahead)});
     _actions.push_back(CtMenuAction{editor_cat, "handle_image", "ct_image_insert", _("Insert I_mage"), KB_CONTROL+KB_ALT+"I", _("Insert an Image"), sigc::mem_fun(*pActions, &CtActions::image_handle)});
-    //_actions.push_back(CtAction{"handle_screenshot", "screenshot_insert", _("Insert _Screenshot"), KB_CONTROL+KB_SHIFT+KB_ALT+"S", _("Insert a Screenshot"), sigc::signal<void>() /* dad.screenshot_handle */});
     _actions.push_back(CtMenuAction{editor_cat, "handle_table", "ct_table_insert", _("Insert _Table"), KB_CONTROL+KB_ALT+"T", _("Insert a Table"), sigc::mem_fun(*pActions, &CtActions::table_handle)});
     _actions.push_back(CtMenuAction{editor_cat, "handle_codebox", "ct_codebox_insert", _("Insert _CodeBox"), KB_CONTROL+KB_ALT+"C", _("Insert a CodeBox"), sigc::mem_fun(*pActions, &CtActions::codebox_handle)});
     _actions.push_back(CtMenuAction{editor_cat, "handle_embfile", "ct_file_icon", _("Insert _File"), KB_CONTROL+KB_ALT+"E", _("Insert File"), sigc::mem_fun(*pActions, &CtActions::embfile_insert)});
@@ -120,7 +125,6 @@ void CtMenu::init_actions(CtActions* pActions)
     _actions.push_back(CtMenuAction{editor_cat, "case_down", "ct_case_lower", _("_Lower Case of Selection/Word"), KB_CONTROL+"W", _("Lower the Case of the Selection/the Underlying Word"), sigc::mem_fun(*pActions, &CtActions::text_selection_lower_case)});
     _actions.push_back(CtMenuAction{editor_cat, "case_up", "ct_case_upper", _("_Upper Case of Selection/Word"), KB_CONTROL+KB_SHIFT+"W", _("Upper the Case of the Selection/the Underlying Word"), sigc::mem_fun(*pActions, &CtActions::text_selection_upper_case)});
     _actions.push_back(CtMenuAction{editor_cat, "case_tggl", "ct_case_toggle", _("_Toggle Case of Selection/Word"), KB_CONTROL+"G", _("Toggle the Case of the Selection/the Underlying Word"), sigc::mem_fun(*pActions, &CtActions::text_selection_toggle_case)});
-    _actions.push_back(CtMenuAction{editor_cat, "spellcheck_toggle", "ct_spell-check", _("Enable/Disable _Spell Check"), KB_CONTROL+KB_ALT+"S", _("Toggle Enable/Disable Spell Check"), sigc::mem_fun(*pActions, &CtActions::toggle_ena_dis_spellcheck)});
     _actions.push_back(CtMenuAction{editor_cat, "cut_plain", "ct_edit_cut", _("Cu_t as Plain Text"), KB_CONTROL+KB_SHIFT+"X", _("Cut as Plain Text, Discard the Rich Text Formatting"), sigc::mem_fun(*pActions, &CtActions::cut_as_plain_text)});
     _actions.push_back(CtMenuAction{editor_cat, "copy_plain", "ct_edit_copy", _("_Copy as Plain Text"), KB_CONTROL+KB_SHIFT+"C", _("Copy as Plain Text, Discard the Rich Text Formatting"), sigc::mem_fun(*pActions, &CtActions::copy_as_plain_text)});
     _actions.push_back(CtMenuAction{editor_cat, "paste_plain", "ct_edit_paste", _("_Paste as Plain Text"), KB_CONTROL+KB_SHIFT+"V", _("Paste as Plain Text, Discard the Rich Text Formatting"), sigc::mem_fun(*pActions, &CtActions::paste_as_plain_text)});
@@ -130,7 +134,6 @@ void CtMenu::init_actions(CtActions* pActions)
     _actions.push_back(CtMenuAction{editor_cat, "dup_row", "ct_add", _("_Duplicate Row"), KB_CONTROL+"D", _("Duplicate the Current Row/Selection"), sigc::mem_fun(*pActions, &CtActions::text_row_selection_duplicate)});
     _actions.push_back(CtMenuAction{editor_cat, "mv_up_row", "ct_go-up", _("Move _Up Row"), KB_ALT+CtConst::STR_KEY_UP, _("Move Up the Current Row/Selected Rows"), sigc::mem_fun(*pActions, &CtActions::text_row_up)});
     _actions.push_back(CtMenuAction{editor_cat, "mv_down_row", "ct_go-down", _("Move _Down Row"), KB_ALT+CtConst::STR_KEY_DOWN, _("Move Down the Current Row/Selected Rows"), sigc::mem_fun(*pActions, &CtActions::text_row_down)});
-    _actions.push_back(CtMenuAction{editor_cat, "strip_trail_spaces", "ct_clear", _("Stri_p Trailing Spaces"), None, _("Strip Trailing Spaces"), sigc::mem_fun(*pActions, &CtActions::strip_trailing_spaces)});
     const char* fmt_cat = _("Format");
     _actions.push_back(CtMenuAction{fmt_cat, "fmt_clone", "ct_fmt-txt-clone", _("Format C_lone"), None, _("Clone the Text Format Type at Cursor"), sigc::mem_fun(*pActions, &CtActions::save_tags_at_cursor_as_latest)});
     _actions.push_back(CtMenuAction{fmt_cat, "fmt_latest", "ct_fmt-txt-latest", _("Format _Latest"), "F7", _("Memory of Latest Text Format Type"), sigc::mem_fun(*pActions, &CtActions::apply_tags_latest)});
@@ -157,15 +160,28 @@ void CtMenu::init_actions(CtActions* pActions)
     _actions.push_back(CtMenuAction{fmt_cat, "fmt_justify_fill", "ct_justify-fill", _("Justify _Fill"), None, _("Justify Fill the Current Paragraph"), sigc::mem_fun(*pActions, &CtActions::apply_tag_justify_fill)});
     _actions.push_back(CtMenuAction{fmt_cat, "fmt_indent", "ct_fmt-indent", _("Indent Paragraph"), KB_CONTROL+KB_SHIFT+"greater", _("Indent the Current Paragraph"), sigc::mem_fun(*pActions, &CtActions::apply_tag_indent)});
     _actions.push_back(CtMenuAction{fmt_cat, "fmt_unindent", "ct_fmt-unindent", _("Unindent Paragraph"), KB_CONTROL+KB_SHIFT+"less", _("Unindent the Current Paragraph"), sigc::mem_fun(*pActions, &CtActions::reduce_tag_indent)});
+    const char* tools_cat = _("Tools");
+    _actions.push_back(CtMenuAction{tools_cat, "spellcheck_toggle", "ct_spell-check", _("Enable/Disable _Spell Check"), KB_CONTROL+KB_ALT+"S", _("Toggle Enable/Disable Spell Check"), sigc::mem_fun(*pActions, &CtActions::toggle_ena_dis_spellcheck)});
+    _actions.push_back(CtMenuAction{tools_cat, "strip_trail_spaces", "ct_clear", _("Stri_p Trailing Spaces"), None, _("Strip Trailing Spaces"), sigc::mem_fun(*pActions, &CtActions::strip_trailing_spaces)});
+    _actions.push_back(CtMenuAction{tools_cat, "command_palette", "ct_execute", _("_Command Palette"), KB_CONTROL+KB_SHIFT+"P", _("Command Palette"), sigc::mem_fun(*pActions, &CtActions::command_palette)});
+    _actions.push_back(CtMenuAction{tools_cat, "exec_code", "ct_execute", _("_Execute Code"), "F5", _("Execute Code"), sigc::mem_fun(*pActions, &CtActions::exec_code)});
     const char* tree_cat = _("Tree");
+    _actions.push_back(CtMenuAction{tree_cat, "go_node_prev", "ct_go-back", _("Go _Back"), KB_ALT+CtConst::STR_KEY_LEFT, _("Go to the Previous Visited Node"), sigc::mem_fun(*pActions, &CtActions::node_go_back)});
+    _actions.push_back(CtMenuAction{tree_cat, "go_node_next", "ct_go-forward", _("Go _Forward"), KB_ALT+CtConst::STR_KEY_RIGHT, _("Go to the Next Visited Node"), sigc::mem_fun(*pActions, &CtActions::node_go_forward)});
     _actions.push_back(CtMenuAction{tree_cat, "tree_add_node", "ct_tree-node-add", _("Add _Node"), KB_CONTROL+"N", _("Add a Node having the same Parent of the Selected Node"), sigc::mem_fun(*pActions, &CtActions::node_add)});
     _actions.push_back(CtMenuAction{tree_cat, "tree_add_subnode", "ct_tree-subnode-add", _("Add _SubNode"), KB_CONTROL+KB_SHIFT+"N", _("Add a Child Node to the Selected Node"), sigc::mem_fun(*pActions, &CtActions::node_child_add)});
     _actions.push_back(CtMenuAction{tree_cat, "tree_dup_node", "ct_tree-node-dupl", _("_Duplicate Node"), KB_CONTROL+KB_SHIFT+"D", _("Duplicate the Selected Node"), sigc::mem_fun(*pActions, &CtActions::node_duplicate)});
     _actions.push_back(CtMenuAction{tree_cat, "tree_dup_node_subnodes", "ct_tree-nodesub-dupl", _("_Duplicate Node and Sub Nodes"), None, _("Duplicate the Selected Node With SubNodes"), sigc::mem_fun(*pActions, &CtActions::node_subnodes_duplicate)});
+    _actions.push_back(CtMenuAction{tree_cat, "tree_node_date", "ct_calendar", _("Insert Today's Node"), "F8", _("Insert a Node with Hierarchy Year/Month/Day"), sigc::mem_fun(*pActions, &CtActions::node_date)});
     _actions.push_back(CtMenuAction{tree_cat, "tree_node_prop", "ct_cherry_edit", _("Change Node _Properties"), "F2", _("Edit the Properties of the Selected Node"), sigc::mem_fun(*pActions, &CtActions::node_edit)});
     _actions.push_back(CtMenuAction{tree_cat, "tree_node_toggle_ro", "ct_locked", _("Toggle _Read Only"), KB_CONTROL+KB_ALT+"R", _("Toggle the Read Only Property of the Selected Node"), sigc::mem_fun(*pActions, &CtActions::node_toggle_read_only)});
-    _actions.push_back(CtMenuAction{tree_cat, "tree_node_date", "ct_calendar", _("Insert Today's Node"), "F8", _("Insert a Node with Hierarchy Year/Month/Day"), sigc::mem_fun(*pActions, &CtActions::node_date)});
-    _actions.push_back(CtMenuAction{tree_cat, "tree_parse_info", "ct_info", _("Tree _Info"), None, _("Tree Summary Information"), sigc::mem_fun(*pActions, &CtActions::tree_info)});
+    _actions.push_back(CtMenuAction{tree_cat, "tree_node_link", "ct_node_link", _("Copy Link to Node"), None, _("Copy Link to the Selected Node to Clipboard"), sigc::mem_fun(*pActions, &CtActions::node_link_to_clipboard)});
+    _actions.push_back(CtMenuAction{tree_cat, "child_nodes_inherit_syntax", "ct_execute", _("_Inherit Syntax"), None, _("Change the Selected Node's Children Syntax Highlighting to the Parent's Syntax Highlighting"), sigc::mem_fun(*pActions, &CtActions::node_inherit_syntax)});
+    _actions.push_back(CtMenuAction{tree_cat, "handle_bookmarks", "ct_edit", _("_Handle Bookmarks"), None, _("Handle the Bookmarks List"), sigc::mem_fun(*pActions, &CtActions::bookmarks_handle)});
+    _actions.push_back(CtMenuAction{tree_cat, "node_bookmark", "ct_pin-add", _("Add to _Bookmarks"), KB_CONTROL+KB_SHIFT+"B", _("Add the Current Node to the Bookmarks List"), sigc::mem_fun(*pActions, &CtActions::bookmark_curr_node)});
+    _actions.push_back(CtMenuAction{tree_cat, "node_unbookmark", "ct_pin-remove", _("_Remove from Bookmarks"), KB_CONTROL+KB_ALT+"B", _("Remove the Current Node from the Bookmarks List"), sigc::mem_fun(*pActions, &CtActions::bookmark_curr_node_remove)});
+    _actions.push_back(CtMenuAction{tree_cat, "nodes_all_expand", "ct_zoom-in", _("E_xpand All Nodes"), KB_CONTROL+KB_SHIFT+"E", _("Expand All the Tree Nodes"), sigc::mem_fun(*pActions, &CtActions::nodes_expand_all)});
+    _actions.push_back(CtMenuAction{tree_cat, "nodes_all_collapse", "ct_zoom-out", _("_Collapse All Nodes"), KB_CONTROL+KB_SHIFT+"L", _("Collapse All the Tree Nodes"), sigc::mem_fun(*pActions, &CtActions::nodes_collapse_all)});
     _actions.push_back(CtMenuAction{tree_cat, "tree_node_up", "ct_go-up", _("Node _Up"), KB_SHIFT+KB_ALT+CtConst::STR_KEY_UP, _("Move the Selected Node Up"), sigc::mem_fun(*pActions, &CtActions::node_up)});
     _actions.push_back(CtMenuAction{tree_cat, "tree_node_down", "ct_go-down", _("Node _Down"), KB_SHIFT+KB_ALT+CtConst::STR_KEY_DOWN, _("Move the Selected Node Down"), sigc::mem_fun(*pActions, &CtActions::node_down)});
     _actions.push_back(CtMenuAction{tree_cat, "tree_node_left", "ct_go-back", _("Node _Left"), KB_SHIFT+KB_ALT+CtConst::STR_KEY_LEFT, _("Move the Selected Node Left"), sigc::mem_fun(*pActions, &CtActions::node_left)});
@@ -175,14 +191,7 @@ void CtMenu::init_actions(CtActions* pActions)
     _actions.push_back(CtMenuAction{tree_cat, "tree_all_sort_desc", "ct_sort-desc", _("Sort Tree _Descending"), None, _("Sort the Tree Descending"), sigc::mem_fun(*pActions, &CtActions::tree_sort_descending)});
     _actions.push_back(CtMenuAction{tree_cat, "tree_sibl_sort_asc", "ct_sort-asc", _("Sort Siblings A_scending"), None, _("Sort all the Siblings of the Selected Node Ascending"), sigc::mem_fun(*pActions, &CtActions::node_siblings_sort_ascending)});
     _actions.push_back(CtMenuAction{tree_cat, "tree_sibl_sort_desc", "ct_sort-desc", _("Sort Siblings D_escending"), None, _("Sort all the Siblings of the Selected Node Descending"), sigc::mem_fun(*pActions, &CtActions::node_siblings_sort_descending)});
-    _actions.push_back(CtMenuAction{tree_cat, "child_nodes_inherit_syntax", "ct_execute", _("_Inherit Syntax"), None, _("Change the Selected Node's Children Syntax Highlighting to the Parent's Syntax Highlighting"), sigc::mem_fun(*pActions, &CtActions::node_inherit_syntax)});
     _actions.push_back(CtMenuAction{tree_cat, "tree_node_del", "ct_edit_delete", _("De_lete Node"), None, _("Delete the Selected Node"), sigc::mem_fun(*pActions, &CtActions::node_delete)});
-    _actions.push_back(CtMenuAction{tree_cat, "node_bookmark", "ct_pin-add", _("Add to _Bookmarks"), KB_CONTROL+KB_SHIFT+"B", _("Add the Current Node to the Bookmarks List"), sigc::mem_fun(*pActions, &CtActions::bookmark_curr_node)});
-    _actions.push_back(CtMenuAction{tree_cat, "node_unbookmark", "ct_pin-remove", _("_Remove from Bookmarks"), KB_CONTROL+KB_ALT+"B", _("Remove the Current Node from the Bookmarks List"), sigc::mem_fun(*pActions, &CtActions::bookmark_curr_node_remove)});
-    _actions.push_back(CtMenuAction{tree_cat, "handle_bookmarks", "ct_edit", _("_Handle Bookmarks"), None, _("Handle the Bookmarks List"), sigc::mem_fun(*pActions, &CtActions::bookmarks_handle)});
-    _actions.push_back(CtMenuAction{tree_cat, "go_node_prev", "ct_go-back", _("Go _Back"), KB_ALT+CtConst::STR_KEY_LEFT, _("Go to the Previous Visited Node"), sigc::mem_fun(*pActions, &CtActions::node_go_back)});
-    _actions.push_back(CtMenuAction{tree_cat, "go_node_next", "ct_go-forward", _("Go _Forward"), KB_ALT+CtConst::STR_KEY_RIGHT, _("Go to the Next Visited Node"), sigc::mem_fun(*pActions, &CtActions::node_go_forward)});
-    _actions.push_back(CtMenuAction{tree_cat, "tree_node_link", "ct_node_link", _("Copy Link to Node"), None, _("Copy Link to the Selected Node to Clipboard"), sigc::mem_fun(*pActions, &CtActions::node_link_to_clipboard)});
     const char* find_cat = _("Find/Replace");
     _actions.push_back(CtMenuAction{find_cat, "find_in_node", "ct_find_sel", _("_Find in Node Content"), KB_CONTROL+"F", _("Find into the Selected Node Content"), sigc::mem_fun(*pActions, &CtActions::find_in_selected_node)});
     _actions.push_back(CtMenuAction{find_cat, "find_in_allnodes", "ct_find_all", _("Find in _All Nodes Contents"), KB_CONTROL+KB_SHIFT+"F", _("Find into All the Tree Nodes Contents"), sigc::mem_fun(*pActions, &CtActions::find_in_all_nodes)});
@@ -197,20 +206,13 @@ void CtMenu::init_actions(CtActions* pActions)
     _actions.push_back(CtMenuAction{find_cat, "replace_iter_fw", "ct_replace_again", _("Replace _Again"), "F6", _("Iterate the Last Replace Operation"), sigc::mem_fun(*pActions, &CtActions::replace_again)});
     _actions.push_back(CtMenuAction{find_cat, "toggle_show_allmatches_dlg", "ct_find", _("Show _All Matches Dialog"), KB_CONTROL+KB_SHIFT+"A", _("Show Search All Matches Dialog"), sigc::mem_fun(*pActions, &CtActions::find_allmatchesdialog_restore)});
     const char* view_cat = _("View");
-    _actions.push_back(CtMenuAction{view_cat, "toggle_show_tree", "ct_cherries", _("Show/Hide _Tree"), "F9", _("Toggle Show/Hide Tree"), sigc::mem_fun(*pActions, &CtActions::toggle_show_hide_tree)});
+    _actions.push_back(CtMenuAction{view_cat, "toggle_show_tree", "ct_cherries", _("Show/Hide _Tree Explorer"), "F9", _("Toggle Show/Hide Tree"), sigc::mem_fun(*pActions, &CtActions::toggle_show_hide_tree)});
     _actions.push_back(CtMenuAction{view_cat, "toggle_show_toolbar", "ct_toolbar", _("Show/Hide Tool_bar"), None, _("Toggle Show/Hide Toolbar"), sigc::mem_fun(*pActions, &CtActions::toggle_show_hide_toolbars)});
     _actions.push_back(CtMenuAction{view_cat, "toggle_show_node_name_head", "ct_node_name_header", _("Show/Hide Node Name _Header"), None, _("Toggle Show/Hide Node Name Header"), sigc::mem_fun(*pActions, &CtActions::toggle_show_hide_node_name_header)});
     _actions.push_back(CtMenuAction{view_cat, "toggle_focus_tree_text", "ct_go-jump", _("Toggle _Focus Tree/Text"), KB_CONTROL+"Tab", _("Toggle Focus Between Tree and Text"), sigc::mem_fun(*pActions, &CtActions::toggle_tree_text)});
-    _actions.push_back(CtMenuAction{view_cat, "nodes_all_expand", "ct_zoom-in", _("E_xpand All Nodes"), KB_CONTROL+KB_SHIFT+"E", _("Expand All the Tree Nodes"), sigc::mem_fun(*pActions, &CtActions::nodes_expand_all)});
-    _actions.push_back(CtMenuAction{view_cat, "nodes_all_collapse", "ct_zoom-out", _("_Collapse All Nodes"), KB_CONTROL+KB_SHIFT+"L", _("Collapse All the Tree Nodes"), sigc::mem_fun(*pActions, &CtActions::nodes_collapse_all)});
     _actions.push_back(CtMenuAction{view_cat, "toolbar_icons_size_p", "ct_add", _("_Increase Toolbar Icons Size"), None, _("Increase the Size of the Toolbar Icons"), sigc::mem_fun(*pActions, &CtActions::toolbar_icons_size_increase)});
     _actions.push_back(CtMenuAction{view_cat, "toolbar_icons_size_m", "ct_remove", _("_Decrease Toolbar Icons Size"), None, _("Decrease the Size of the Toolbar Icons"), sigc::mem_fun(*pActions, &CtActions::toolbar_icons_size_decrease)});
     _actions.push_back(CtMenuAction{view_cat, "toggle_fullscreen", "ct_fullscreen", _("_Full Screen On/Off"), "F11", _("Toggle Full Screen On/Off"), sigc::mem_fun(*pActions, &CtActions::fullscreen_toggle)});
-    const char* export_cat = _("Export");
-    _actions.push_back(CtMenuAction{export_cat, "export_pdf", "ct_to_pdf", _("Export To _PDF"), None, _("Export To PDF"), sigc::mem_fun(*pActions, &CtActions::export_to_pdf)});
-    _actions.push_back(CtMenuAction{export_cat, "export_html", "ct_to_html", _("Export To _HTML"), None, _("Export To HTML"), sigc::mem_fun(*pActions, &CtActions::export_to_html)});
-    _actions.push_back(CtMenuAction{export_cat, "export_txt", "ct_to_txt", _("Export to Plain _Text"), None, _("Export to Plain Text"), sigc::mem_fun(*pActions, &CtActions::export_to_txt)});
-    _actions.push_back(CtMenuAction{export_cat, "export_ctd", "ct_to_cherrytree", _("_Export To CherryTree Document"), None, _("Export To CherryTree Document"), sigc::mem_fun(*pActions, &CtActions::export_to_ctd)});
     const char* import_cat = _("Import");
     _actions.push_back(CtMenuAction{import_cat, "import_cherrytree", "ct_from_cherrytree", _("From _CherryTree File"), None, _("Add Nodes of a CherryTree File to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_ct_file)});
     _actions.push_back(CtMenuAction{import_cat, "import_txt_file", "ct_from_txt", _("From _Plain Text File"), None, _("Add Node from a Plain Text File to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_node_from_plaintext_file)});
@@ -219,21 +221,26 @@ void CtMenu::init_actions(CtActions* pActions)
     _actions.push_back(CtMenuAction{import_cat, "import_html_folder", "ct_from_html", _("From _Folder of HTML Files"), None, _("Add Nodes from a Folder of HTML Files to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_node_from_html_directory)});
     _actions.push_back(CtMenuAction{import_cat, "import_md_file",  CtConst::STR_STOCK_CT_IMP, _("From _Markdown File"), None, _("Add a node from a Markdown File to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_node_from_md_file)});
     _actions.push_back(CtMenuAction{import_cat, "import_md_folder",  CtConst::STR_STOCK_CT_IMP, _("From _Folder of Markdown Files"), None, _("Add Nodes from a Folder of Markdown Files to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_md_directory)});
-    //_actions.push_back(CtMenuAction{import_cat, "import_basket", CtConst::STR_STOCK_CT_IMP, _("From _Basket Folder"), None, _("Add Nodes of a Basket Folder to the Current Tree"), sigc::signal<void>() /* dad.nodes_add_from_basket_folder */});
-    //_actions.push_back(CtMenuAction{import_cat, "import_epim_html", CtConst::STR_STOCK_CT_IMP, _("From _EssentialPIM HTML File"), None, _("Add Node from an EssentialPIM HTML File to the Current Tree"), sigc::signal<void>() /* dad.nodes_add_from_epim_html_file */});
     _actions.push_back(CtMenuAction{import_cat, "import_gnote", CtConst::STR_STOCK_CT_IMP, _("From _Gnote Folder"), None, _("Add Nodes of a Gnote Folder to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_gnote_directory)});
     _actions.push_back(CtMenuAction{import_cat, "import_keepnote", CtConst::STR_STOCK_CT_IMP, _("From _KeepNote Folder"), None, _("Add Nodes of a KeepNote Folder to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_keepnote_directory) /* dad.nodes_add_from_keepnote_folder */});
-    //_actions.push_back(CtMenuAction{import_cat, "import_keynote", CtConst::STR_STOCK_CT_IMP, _("From K_eyNote File"), None, _("Add Nodes of a KeyNote File to the Current Tree"), sigc::signal<void>() /* dad.nodes_add_from_keynote_file */});
-    //_actions.push_back(CtMenuAction{import_cat, "import_knowit", CtConst::STR_STOCK_CT_IMP, _("From K_nowit File"), None, _("Add Nodes of a Knowit File to the Current Tree"), sigc::signal<void>() /* dad.nodes_add_from_knowit_file */});
     _actions.push_back(CtMenuAction{import_cat, "import_leo", CtConst::STR_STOCK_CT_IMP, _("From _Leo File"), None, _("Add Nodes of a Leo File to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_leo_file)});
     _actions.push_back(CtMenuAction{import_cat, "import_mempad", CtConst::STR_STOCK_CT_IMP, _("From _Mempad File"), None, _("Add Nodes of a Mempad File to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_mempad_file)});
     _actions.push_back(CtMenuAction{import_cat, "import_notecase", CtConst::STR_STOCK_CT_IMP, _("From _NoteCase HTML File"), None, _("Add Nodes of a NoteCase HTML File to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_notecase_html)});
     _actions.push_back(CtMenuAction{import_cat, "import_rednotebook", CtConst::STR_STOCK_CT_IMP, _("From _RedNotebook HTML"), None, _("Add Nodes of a RedNotebook HTML file to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_rednotebook_html)});
     _actions.push_back(CtMenuAction{import_cat, "import_tomboy", CtConst::STR_STOCK_CT_IMP, _("From T_omboy Folder"), None, _("Add Nodes of a Tomboy Folder to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_tomboy_directory)});
     _actions.push_back(CtMenuAction{import_cat, "import_treepad", CtConst::STR_STOCK_CT_IMP, _("From T_reepad Lite File"), None, _("Add Nodes of a Treepad Lite File to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_treepad_file)});
-    //_actions.push_back(CtMenuAction{import_cat, "import_tuxcards", CtConst::STR_STOCK_CT_IMP, _("From _TuxCards File"), None, _("Add Nodes of a TuxCards File to the Current Tree"), sigc::signal<void>() /* dad.nodes_add_from_tuxcards_file */});
     _actions.push_back(CtMenuAction{import_cat, "import_zim", CtConst::STR_STOCK_CT_IMP, _("From _Zim Folder"), None, _("Add Nodes of a Zim Folder to the Current Tree"), sigc::mem_fun(*pActions, &CtActions::import_nodes_from_zim_directory) /* dad.nodes_add_from_zim_folder */});
     _actions.push_back(CtMenuAction{import_cat, "import_pandoc_file", CtConst::STR_STOCK_CT_IMP, _("From File using _Pandoc"), None, _("Add a node to the current tree using Pandoc"), sigc::mem_fun(*pActions, &CtActions::import_node_from_pandoc) });
+    const char* export_cat = _("Export");
+    _actions.push_back(CtMenuAction{export_cat, "export_pdf", "ct_to_pdf", _("Export To _PDF"), None, _("Export To PDF"), sigc::mem_fun(*pActions, &CtActions::export_to_pdf)});
+    _actions.push_back(CtMenuAction{export_cat, "export_html", "ct_to_html", _("Export To _HTML"), None, _("Export To HTML"), sigc::mem_fun(*pActions, &CtActions::export_to_html)});
+    _actions.push_back(CtMenuAction{export_cat, "export_txt", "ct_to_txt", _("Export to Plain _Text"), None, _("Export to Plain Text"), sigc::mem_fun(*pActions, &CtActions::export_to_txt)});
+    _actions.push_back(CtMenuAction{export_cat, "export_ctd", "ct_to_cherrytree", _("_Export To CherryTree Document"), None, _("Export To CherryTree Document"), sigc::mem_fun(*pActions, &CtActions::export_to_ctd)});
+    const char* help_cat = _("Help");
+    _actions.push_back(CtMenuAction{help_cat, "ct_check_newer", "ct_network", _("_Check Newer Version"), None, _("Check for a Newer Version"), sigc::mem_fun(*pActions, &CtActions::check_for_newer_version)});
+    _actions.push_back(CtMenuAction{help_cat, "ct_help", "ct_help", _("Online _Manual"), "F1", _("Application's Online Manual"), sigc::mem_fun(*pActions, &CtActions::online_help)});
+    _actions.push_back(CtMenuAction{help_cat, "ct_about", "ct_about", _("_About"), None, _("About CherryTree"), sigc::mem_fun(*pActions, &CtActions::dialog_about)});
+    _actions.push_back(CtMenuAction{help_cat, "open_cfg_folder", "ct_directory", _("Open Preferences _Directory"), None, _("Open the Directory with Preferences Files"), sigc::mem_fun(*pActions, &CtActions::folder_cfg_open)});
     const char* others_cat = "";
     _actions.push_back(CtMenuAction{others_cat, "anch_cut", "ct_edit_cut", _("C_ut Anchor"), None, _("Cut the Selected Anchor"), sigc::mem_fun(*pActions, &CtActions::anchor_cut)});
     _actions.push_back(CtMenuAction{others_cat, "anch_copy", "ct_edit_copy", _("_Copy Anchor"), None, _("Copy the Selected Anchor"), sigc::mem_fun(*pActions, &CtActions::anchor_copy)});
@@ -451,8 +458,6 @@ void CtMenu::build_popup_menu(Gtk::Menu* pMenu, POPUP_MENU_TYPE popupMenuType)
             _add_menu_item(pMenu, find_action("cut_plain"));
             _add_menu_item(pMenu, find_action("copy_plain"));
             _add_menu_separator(pMenu);
-            _add_menu_item(pMenu, find_action("codebox_change_properties"));
-            _add_menu_item(pMenu, find_action("exec_code"));
             _add_menu_item(pMenu, find_action("codebox_load_from_file"));
             _add_menu_item(pMenu, find_action("codebox_save_to_file"));
             _add_menu_separator(pMenu);
@@ -465,6 +470,9 @@ void CtMenu::build_popup_menu(Gtk::Menu* pMenu, POPUP_MENU_TYPE popupMenuType)
             _add_menu_item(pMenu, find_action("codebox_decrease_width"));
             _add_menu_item(pMenu, find_action("codebox_increase_height"));
             _add_menu_item(pMenu, find_action("codebox_decrease_height"));
+            _add_menu_separator(pMenu);
+            _add_menu_item(pMenu, find_action("exec_code"));
+            _add_menu_item(pMenu, find_action("codebox_change_properties"));
         } break;
         case CtMenu::POPUP_MENU_TYPE::PopupMenuNum: {
         } break;
@@ -491,11 +499,11 @@ void CtMenu::build_popup_menu_table_cell(Gtk::Menu* pMenu,
     _add_menu_item(pMenu, find_action("table_column_increase_width"));
     _add_menu_item(pMenu, find_action("table_column_decrease_width"));
     _add_menu_separator(pMenu);
-    _add_menu_item(pMenu, find_action("table_row_add"));
-    _add_menu_item(pMenu, find_action("table_row_delete"));
     _add_menu_item(pMenu, find_action("table_row_cut"));
     _add_menu_item(pMenu, find_action("table_row_copy"));
     _add_menu_item(pMenu, find_action("table_row_paste"));
+    _add_menu_item(pMenu, find_action("table_row_add"));
+    _add_menu_item(pMenu, find_action("table_row_delete"));
     _add_menu_separator(pMenu);
     if (not first_row) _add_menu_item(pMenu, find_action("table_row_up"));
     if (not last_row) _add_menu_item(pMenu, find_action("table_row_down"));
@@ -748,126 +756,10 @@ const char* CtMenu::_get_ui_str_menu()
   <menu action='FileMenu'>
     <menuitem action='ct_new_inst'/>
     <menuitem action='ct_open_file'/>
-    <menu action='RecentDocsMenu'>
+    <menu action='RecentDocsSubMenu'>
     </menu>
     <separator/>
-    <menuitem action='ct_vacuum'/>
-    <menuitem action='ct_save'/>
-    <menuitem action='ct_save_as'/>
-    <separator/>
-    <menuitem action='print_page_setup'/>
-    <menuitem action='do_print'/>
-    <separator/>
-    <menuitem action='preferences_dlg'/>
-    <menuitem action='tree_parse_info'/>
-    <separator/>
-    <menuitem action='command_palette'/>
-    <menuitem action='exec_code'/>
-    <separator/>
-    <menuitem action='quit_app'/>
-    <menuitem action='exit_app'/>
-  </menu>
-
-  <menu action='EditMenu'>
-    <menuitem action='act_undo'/>
-    <menuitem action='act_redo'/>
-    <separator/>
-    <menuitem action='handle_image'/>
-    <menuitem action='handle_table'/>
-    <menuitem action='handle_codebox'/>
-    <menuitem action='handle_embfile'/>
-    <menuitem action='handle_link'/>
-    <menuitem action='handle_anchor'/>
-    <menuitem action='insert_toc'/>
-    <menuitem action='insert_timestamp'/>
-    <menuitem action='insert_special_char'/>
-    <menuitem action='insert_horiz_rule'/>
-    <menuitem action='strip_trail_spaces'/>
-    <separator/>
-    <menu action='ChangeCaseMenu'>
-      <menuitem action='case_down'/>
-      <menuitem action='case_up'/>
-      <menuitem action='case_tggl'/>
-    </menu>
-    <separator/>
-    <menuitem action='spellcheck_toggle'/>
-    <separator/>
-    <menuitem action='cut_plain'/>
-    <menuitem action='copy_plain'/>
-    <menuitem action='paste_plain'/>
-    <separator/>
-    <menuitem action='cut_row'/>
-    <menuitem action='copy_row'/>
-    <menuitem action='del_row'/>
-    <menuitem action='dup_row'/>
-    <menuitem action='mv_up_row'/>
-    <menuitem action='mv_down_row'/>
-  </menu>
-
-  <menu action='FormattingMenu'>
-    <menuitem action='fmt_clone'/>
-    <menuitem action='fmt_latest'/>
-    <menuitem action='fmt_rm'/>
-    <separator/>
-    <menuitem action='fmt_color_fg'/>
-    <menuitem action='fmt_color_bg'/>
-    <menuitem action='fmt_bold'/>
-    <menuitem action='fmt_italic'/>
-    <menuitem action='fmt_underline'/>
-    <menuitem action='fmt_strikethrough'/>
-    <menuitem action='fmt_h1'/>
-    <menuitem action='fmt_h2'/>
-    <menuitem action='fmt_h3'/>
-    <menuitem action='fmt_small'/>
-    <menuitem action='fmt_superscript'/>
-    <menuitem action='fmt_subscript'/>
-    <menuitem action='fmt_monospace'/>
-    <separator/>
-    <menuitem action='handle_bull_list'/>
-    <menuitem action='handle_num_list'/>
-    <menuitem action='handle_todo_list'/>
-    <separator/>
-    <menuitem action='fmt_indent'/>
-    <menuitem action='fmt_unindent'/>
-    <separator/>
-    <menuitem action='fmt_justify_left'/>
-    <menuitem action='fmt_justify_center'/>
-    <menuitem action='fmt_justify_right'/>
-    <menuitem action='fmt_justify_fill'/>
-  </menu>
-
-  <menu action='TreeMenu'>
-    <menuitem action='tree_add_node'/>
-    <menuitem action='tree_add_subnode'/>
-    <menuitem action='tree_dup_node'/>
-    <menuitem action='tree_dup_node_subnodes'/>
-    <separator/>
-    <menuitem action='tree_node_prop'/>
-    <menuitem action='tree_node_toggle_ro'/>
-    <menuitem action='node_bookmark'/>
-    <menuitem action='node_unbookmark'/>
-    <menuitem action='tree_node_link'/>
-    <menuitem action='tree_node_date'/>
-    <separator/>
-    <menu action='TreeMoveMenu'>
-      <menuitem action='tree_node_up'/>
-      <menuitem action='tree_node_down'/>
-      <menuitem action='tree_node_left'/>
-      <menuitem action='tree_node_right'/>
-      <menuitem action='tree_node_new_father'/>
-    </menu>
-    <separator/>
-    <menu action='TreeSortMenu'>
-      <menuitem action='tree_all_sort_asc'/>
-      <menuitem action='tree_all_sort_desc'/>
-      <menuitem action='tree_sibl_sort_asc'/>
-      <menuitem action='tree_sibl_sort_desc'/>
-    </menu>
-    <separator/>
-    <menuitem action='find_in_node_names'/>
-    <menuitem action='replace_in_node_names'/>
-    <separator/>
-    <menu action='TreeImportMenu'>
+    <menu action='ImportSubMenu'>
       <menuitem action='import_cherrytree'/>
       <menuitem action='import_txt_file'/>
       <menuitem action='import_txt_folder'/>
@@ -886,82 +778,185 @@ const char* CtMenu::_get_ui_str_menu()
       <menuitem action='import_zim'/>
       <menuitem action='import_pandoc_file'/>
     </menu>
-    <separator/>
-    <menu action='TreeExportMenu'>
+    <menu action='ExportSubMenu'>
       <menuitem action='export_pdf'/>
       <menuitem action='export_html'/>
       <menuitem action='export_txt'/>
       <menuitem action='export_ctd'/>
     </menu>
     <separator/>
+    <menuitem action='ct_vacuum'/>
+    <menuitem action='ct_save'/>
+    <menuitem action='ct_save_as'/>
+    <separator/>
+    <menuitem action='print_page_setup'/>
+    <menuitem action='do_print'/>
+    <separator/>
+    <menuitem action='preferences_dlg'/>
+    <menuitem action='tree_parse_info'/>
+    <separator/>
+    <menuitem action='quit_app'/>
+    <menuitem action='exit_app'/>
+  </menu>
+
+  <menu action='EditMenu'>
+    <menuitem action='act_undo'/>
+    <menuitem action='act_redo'/>
+    <separator/>
+    <menuitem action='cut_plain'/>
+    <menuitem action='copy_plain'/>
+    <menuitem action='paste_plain'/>
+    <separator/>
+    <menuitem action='cut_row'/>
+    <menuitem action='copy_row'/>
+    <menuitem action='dup_row'/>
+    <menuitem action='mv_up_row'/>
+    <menuitem action='mv_down_row'/>
+    <menuitem action='del_row'/>
+  </menu>
+
+  <menu action='InsertMenu'>
+    <menuitem action='handle_image'/>
+    <menuitem action='handle_table'/>
+    <menuitem action='handle_codebox'/>
+    <menuitem action='handle_embfile'/>
+    <menuitem action='handle_link'/>
+    <menuitem action='handle_anchor'/>
+    <menuitem action='insert_toc'/>
+    <menuitem action='insert_timestamp'/>
+    <menuitem action='insert_special_char'/>
+    <menuitem action='insert_horiz_rule'/>
+    <menu action='ListSubMenu'>
+     <menuitem action='handle_bull_list'/>
+     <menuitem action='handle_num_list'/>
+     <menuitem action='handle_todo_list'/>
+    </menu>
+  </menu>
+
+  <menu action='FormatMenu'>
+    <menuitem action='fmt_clone'/>
+    <menuitem action='fmt_latest'/>
+    <menuitem action='fmt_rm'/>
+    <separator/>
+    <menuitem action='fmt_color_fg'/>
+    <menuitem action='fmt_color_bg'/>
+    <separator/>
+    <menu action='FontSubMenu'>
+      <menuitem action='fmt_bold'/>
+      <menuitem action='fmt_italic'/>
+      <menuitem action='fmt_underline'/>
+      <menuitem action='fmt_strikethrough'/>
+      <menuitem action='fmt_monospace'/>
+      <menuitem action='fmt_small'/>
+    </menu>
+    <menu action='ChangeCaseSubMenu'>
+      <menuitem action='case_down'/>
+      <menuitem action='case_up'/>
+      <menuitem action='case_tggl'/>
+    </menu>
+    <menu action='ToggleSubMenu'>
+      <menuitem action='fmt_h1'/>
+      <menuitem action='fmt_h2'/>
+      <menuitem action='fmt_h3'/>
+    </menu>
+    <separator/>
+    <menuitem action='fmt_superscript'/>
+    <menuitem action='fmt_subscript'/>
+    <separator/>
+    <menuitem action='fmt_indent'/>
+    <menuitem action='fmt_unindent'/>
+    <separator/>
+    <menu action='JustifySubMenu'>
+      <menuitem action='fmt_justify_left'/>
+      <menuitem action='fmt_justify_center'/>
+      <menuitem action='fmt_justify_right'/>
+      <menuitem action='fmt_justify_fill'/>
+    </menu>
+  </menu>
+
+  <menu action='ToolsMenu'>
+    <menuitem action='spellcheck_toggle'/>
+    <separator/>
+    <menuitem action='strip_trail_spaces'/>
+    <separator/>
+    <menuitem action='command_palette'/>
+    <menuitem action='exec_code'/>
+  </menu>
+
+  <menu action='TreeMenu'>
+    <menuitem action='go_node_next'/>
+    <menuitem action='go_node_prev'/>
+    <separator/>
+    <menuitem action='tree_add_node'/>
+    <menuitem action='tree_add_subnode'/>
+    <menuitem action='tree_dup_node'/>
+    <menuitem action='tree_dup_node_subnodes'/>
+    <menuitem action='tree_node_date'/>
+    <separator/>
+    <menuitem action='tree_node_prop'/>
+    <menuitem action='tree_node_toggle_ro'/>
+    <menuitem action='tree_node_link'/>
     <menuitem action='child_nodes_inherit_syntax'/>
     <separator/>
-    <menuitem action='tree_node_del'/>
+    <menu action='BookmarksSubMenu'>
+      <menuitem action='handle_bookmarks'/>
+    </menu>
+    <menuitem action='node_bookmark'/>
+    <menuitem action='node_unbookmark'/>
     <separator/>
-    <menuitem action='go_node_prev'/>
-    <menuitem action='go_node_next'/>
+    <menuitem action='nodes_all_expand'/>
+    <menuitem action='nodes_all_collapse'/>
+    <separator/>
+    <menu action='TreeMoveSubMenu'>
+      <menuitem action='tree_node_up'/>
+      <menuitem action='tree_node_down'/>
+      <menuitem action='tree_node_left'/>
+      <menuitem action='tree_node_right'/>
+      <menuitem action='tree_node_new_father'/>
+    </menu>
+    <menu action='TreeSortSubMenu'>
+      <menuitem action='tree_all_sort_asc'/>
+      <menuitem action='tree_all_sort_desc'/>
+      <menuitem action='tree_sibl_sort_asc'/>
+      <menuitem action='tree_sibl_sort_desc'/>
+    </menu>
+    <separator/>
+    <menuitem action='tree_node_del'/>
   </menu>
 
   <menu action='SearchMenu'>
-    <menuitem action='find_in_node'/>
-    <menuitem action='find_in_allnodes'/>
-    <menuitem action='find_in_node_n_sub'/>
-    <menuitem action='find_in_node_names'/>
+    <menu action='FindSubMenu'>
+      <menuitem action='find_in_node'/>
+      <menuitem action='find_in_allnodes'/>
+      <menuitem action='find_in_node_n_sub'/>
+      <menuitem action='find_in_node_names'/>
+    </menu>
+    <menu action='ReplaceSubMenu'>
+      <menuitem action='replace_in_node'/>
+      <menuitem action='replace_in_allnodes'/>
+      <menuitem action='replace_in_node_n_sub'/>
+      <menuitem action='replace_in_node_names'/>
+    </menu>
+    <separator/>
     <menuitem action='find_iter_fw'/>
     <menuitem action='find_iter_bw'/>
     <separator/>
-    <menuitem action='replace_in_node'/>
-    <menuitem action='replace_in_allnodes'/>
-    <menuitem action='replace_in_node_n_sub'/>
-    <menuitem action='replace_in_node_names'/>
     <menuitem action='replace_iter_fw'/>
+    <separator/>
+    <menuitem action='toggle_show_allmatches_dlg'/>
   </menu>
 
   <menu action='ViewMenu'>
     <menuitem action='toggle_show_tree'/>
     <menuitem action='toggle_show_toolbar'/>
     <menuitem action='toggle_show_node_name_head'/>
-    <menuitem action='toggle_show_allmatches_dlg'/>
     <separator/>
     <menuitem action='toggle_focus_tree_text'/>
-    <menuitem action='nodes_all_expand'/>
-    <menuitem action='nodes_all_collapse'/>
     <separator/>
     <menuitem action='toolbar_icons_size_p'/>
     <menuitem action='toolbar_icons_size_m'/>
     <separator/>
     <menuitem action='toggle_fullscreen'/>
-  </menu>
-
-  <menu action='BookmarksMenu'>
-    <menuitem action='handle_bookmarks'/>
-  </menu>
-
-  <menu action='ImportMenu'>
-    <menuitem action='import_cherrytree'/>
-    <menuitem action='import_txt_file'/>
-    <menuitem action='import_txt_folder'/>
-    <menuitem action='import_html_file'/>
-    <menuitem action='import_html_folder'/>
-    <menuitem action='import_md_file'/>
-    <menuitem action='import_md_folder'/>
-    <menuitem action='import_gnote'/>
-    <menuitem action='import_keepnote'/>
-    <menuitem action='import_leo'/>
-    <menuitem action='import_mempad'/>
-    <menuitem action='import_notecase'/>
-    <menuitem action='import_rednotebook'/>
-    <menuitem action='import_tomboy'/>
-    <menuitem action='import_treepad'/>
-    <menuitem action='import_zim'/>
-    <menuitem action='import_pandoc_file'/>
-  </menu>
-
-  <menu action='ExportMenu'>
-    <menuitem action='export_pdf'/>
-    <menuitem action='export_html'/>
-    <menuitem action='export_txt'/>
-    <menuitem action='export_ctd'/>
   </menu>
 
   <menu action='HelpMenu'>
@@ -986,40 +981,53 @@ const char* CtMenu::_get_popup_menu_ui_str_text()
   <menuitem action='copy_plain'/>
   <menuitem action='paste_plain'/>
   <separator/>
-  <menu _name='For_matting' image='ct_fmt-txt'>
+  <menu action='RowSubMenu'>
+    <menuitem action='cut_row'/>
+    <menuitem action='copy_row'/>
+    <menuitem action='dup_row'/>
+    <menuitem action='mv_up_row'/>
+    <menuitem action='mv_down_row'/>
+    <menuitem action='del_row'/>
+    <separator/>
+    <menuitem action='strip_trail_spaces'/>
+  </menu>
+  <menu action='FormattingSubMenu'>
     <menuitem action='fmt_clone'/>
     <menuitem action='fmt_latest'/>
     <menuitem action='fmt_rm'/>
     <separator/>
     <menuitem action='fmt_color_fg'/>
     <menuitem action='fmt_color_bg'/>
+    <separator/>
     <menuitem action='fmt_bold'/>
     <menuitem action='fmt_italic'/>
     <menuitem action='fmt_underline'/>
     <menuitem action='fmt_strikethrough'/>
+    <separator/>
     <menuitem action='fmt_h1'/>
     <menuitem action='fmt_h2'/>
     <menuitem action='fmt_h3'/>
+    <separator/>
     <menuitem action='fmt_small'/>
     <menuitem action='fmt_superscript'/>
     <menuitem action='fmt_subscript'/>
     <menuitem action='fmt_monospace'/>
+    <separator/>
+    <menuitem action='fmt_indent'/>
+    <menuitem action='fmt_unindent'/>
   </menu>
-  <menu _name='_List' image='ct_list_bulleted'>
+  <menu action='ListSubMenu'>
     <menuitem action='handle_bull_list'/>
     <menuitem action='handle_num_list'/>
     <menuitem action='handle_todo_list'/>
   </menu>
-  <menuitem action='fmt_indent'/>
-  <menuitem action='fmt_unindent'/>
-  <menu _name='_Justify' image='ct_justify-center'>
+  <menu action='JustifySubMenu'>
     <menuitem action='fmt_justify_left'/>
     <menuitem action='fmt_justify_center'/>
     <menuitem action='fmt_justify_right'/>
     <menuitem action='fmt_justify_fill'/>
   </menu>
-  <separator/>
-  <menu _name='_Insert' image='ct_insert'>
+  <menu action='InsertSubMenu'>
     <menuitem action='handle_image'/>
     <menuitem action='handle_table'/>
     <menuitem action='handle_codebox'/>
@@ -1031,22 +1039,13 @@ const char* CtMenu::_get_popup_menu_ui_str_text()
     <menuitem action='insert_special_char'/>
     <menuitem action='insert_horiz_rule'/>
   </menu>
-  <menu _name='C_hange Case' image='ct_case_toggle'>
+  <menu action='ChangeCaseSubMenu'>
     <menuitem action='case_down'/>
     <menuitem action='case_up'/>
     <menuitem action='case_tggl'/>
   </menu>
-  <menu _name='_Row' image='ct_edit'>
-    <menuitem action='cut_row'/>
-    <menuitem action='copy_row'/>
-    <menuitem action='del_row'/>
-    <menuitem action='dup_row'/>
-    <menuitem action='mv_up_row'/>
-    <menuitem action='mv_down_row'/>
-  </menu>
-  <menuitem action='strip_trail_spaces'/>
   <separator/>
-  <menu _name='_Search' image='ct_find'>
+  <menu action='FindSubMenu'>
     <menuitem action='find_in_node'/>
     <menuitem action='find_in_allnodes'/>
     <menuitem action='find_in_node_n_sub'/>
@@ -1054,21 +1053,16 @@ const char* CtMenu::_get_popup_menu_ui_str_text()
     <menuitem action='find_iter_fw'/>
     <menuitem action='find_iter_bw'/>
   </menu>
-  <menu _name='_Replace' image='ct_find_replace'>
+  <menu action='ReplaceSubMenu'>
     <menuitem action='replace_in_node'/>
     <menuitem action='replace_in_allnodes'/>
     <menuitem action='replace_in_node_n_sub'/>
     <menuitem action='replace_in_node_names'/>
     <menuitem action='replace_iter_fw'/>
-    <menuitem action='find_iter_bw'/>
   </menu>
 </popup>
     )MARKUP";
 }
-#if 0
-// the following is to have xgettext add <menu _name='THIS_STRING' to the strings to be translated
-_("For_matting"),_("_List"),_("_Justify"),_("_Insert"),_("C_hange Case"),_("_Row"),_("_Search"),_("_Replace")
-#endif
 
 const char* CtMenu::_get_popup_menu_ui_str_code()
 {
@@ -1079,27 +1073,28 @@ const char* CtMenu::_get_popup_menu_ui_str_code()
   <menuitem action='copy_plain'/>
   <separator/>
   <menuitem action='exec_code'/>
-  <menu _name='_Insert' image='ct_insert'>
+  <menu action='InsertSubMenu'>
     <menuitem action='insert_timestamp'/>
     <menuitem action='insert_special_char'/>
     <menuitem action='insert_horiz_rule'/>
   </menu>
-  <menuitem action='strip_trail_spaces'/>
-  <menu _name='C_hange Case' image='ct_case_toggle'>
+  <menu action='ChangeCaseSubMenu'>
     <menuitem action='case_down'/>
     <menuitem action='case_up'/>
     <menuitem action='case_tggl'/>
   </menu>
-  <menu _name='_Row' image='ct_edit'>
+  <menu action='RowSubMenu'>
     <menuitem action='cut_row'/>
     <menuitem action='copy_row'/>
     <menuitem action='del_row'/>
     <menuitem action='dup_row'/>
     <menuitem action='mv_up_row'/>
     <menuitem action='mv_down_row'/>
+  <separator/>
+    <menuitem action='strip_trail_spaces'/>
   </menu>
   <separator/>
-  <menu _name='_Search' image='ct_find'>
+  <menu action='FindSubMenu'>
     <menuitem action='find_in_node'/>
     <menuitem action='find_in_allnodes'/>
     <menuitem action='find_in_node_n_sub'/>
@@ -1107,21 +1102,16 @@ const char* CtMenu::_get_popup_menu_ui_str_code()
     <menuitem action='find_iter_fw'/>
     <menuitem action='find_iter_bw'/>
   </menu>
-  <menu _name='_Replace' image='ct_find_replace'>
+  <menu action='ReplaceSubMenu'>
     <menuitem action='replace_in_node'/>
     <menuitem action='replace_in_allnodes'/>
     <menuitem action='replace_in_node_n_sub'/>
     <menuitem action='replace_in_node_names'/>
     <menuitem action='replace_iter_fw'/>
-    <menuitem action='find_iter_bw'/>
   </menu>
 </popup>
     )MARKUP";
 }
-#if 0
-// the following is to have xgettext add <menu _name='THIS_STRING' to the strings to be translated
-_("_Insert"),_("C_hange Case"),_("_Row"),_("_Search"),_("_Replace")
-#endif
 
 const char* CtMenu::_get_popup_menu_ui_str_image()
 {

--- a/src/ct/ct_menu.h
+++ b/src/ct/ct_menu.h
@@ -56,10 +56,10 @@ public:
 
 public:
     const char*       None       = "";
-    const std::string KB_CONTROL = "<Ctrl>";
-    const std::string KB_SHIFT   = "<Shift>";
-    const std::string KB_ALT     = "<Alt>";
-    const std::string KB_META    = "<Meta>";
+    const std::string KB_CONTROL = "<control>";
+    const std::string KB_SHIFT   = "<shift>";
+    const std::string KB_ALT     = "<alt>";
+    const std::string KB_META    = "<meta>";
 
     enum POPUP_MENU_TYPE {Node, Text, Code, Link, Codebox, Image, Anchor, EmbFile, PopupMenuNum };
 

--- a/src/ct/ct_menu.h
+++ b/src/ct/ct_menu.h
@@ -60,7 +60,7 @@ public:
     const std::string KB_SHIFT   = "<shift>";
     const std::string KB_ALT     = "<alt>";
     const std::string KB_META    = "<meta>";
-
+    
     enum POPUP_MENU_TYPE {Node, Text, Code, Link, Codebox, Image, Anchor, EmbFile, PopupMenuNum };
 
 public:

--- a/src/ct/ct_menu.h
+++ b/src/ct/ct_menu.h
@@ -56,11 +56,11 @@ public:
 
 public:
     const char*       None       = "";
-    const std::string KB_CONTROL = "<control>";
-    const std::string KB_SHIFT   = "<shift>";
-    const std::string KB_ALT     = "<alt>";
-    const std::string KB_META    = "<meta>";
-    
+    const std::string KB_CONTROL = "<Ctrl>";
+    const std::string KB_SHIFT   = "<Shift>";
+    const std::string KB_ALT     = "<Alt>";
+    const std::string KB_META    = "<Meta>";
+
     enum POPUP_MENU_TYPE {Node, Text, Code, Link, Codebox, Image, Anchor, EmbFile, PopupMenuNum };
 
 public:

--- a/src/ct/ct_pref_dlg.cc
+++ b/src/ct/ct_pref_dlg.cc
@@ -59,7 +59,7 @@ CtPrefDlg::CtPrefDlg(CtMainWin* parent)
     pNotebook->append_page(*build_tab_rich_text(),          _("Rich Text"));
     pNotebook->append_page(*build_tab_plain_text_n_code(),  _("Plain Text and Code"));
     pNotebook->append_page(*build_tab_special_characters(), _("Special Characters"));
-    pNotebook->append_page(*build_tab_tree(),               _("Tree"));
+    pNotebook->append_page(*build_tab_tree(),               _("Tree Explorer"));
     pNotebook->append_page(*build_tab_theme(),              _("Theme"));
     pNotebook->append_page(*build_tab_fonts(),              _("Fonts"));
     pNotebook->append_page(*build_tab_links(),              _("Links"));

--- a/src/ct/ct_pref_dlg_kb_shortcuts.cc
+++ b/src/ct/ct_pref_dlg_kb_shortcuts.cc
@@ -155,10 +155,10 @@ bool CtPrefDlg::edit_shortcut_dialog(std::string& shortcut)
     auto radiobutton_kb_none = Gtk::manage(new Gtk::RadioButton{_("No Keyboard Shortcut")});
     auto radiobutton_kb_shortcut = Gtk::manage(new Gtk::RadioButton{});
     radiobutton_kb_shortcut->join_group(*radiobutton_kb_none);
-    auto ctrl_toggle = Gtk::manage(new Gtk::ToggleButton{"control"});
-    auto shift_toggle = Gtk::manage(new Gtk::ToggleButton{"shift"});
-    auto alt_toggle = Gtk::manage(new Gtk::ToggleButton{"alt"});
-    auto meta_toggle = Gtk::manage(new Gtk::ToggleButton{"meta"});
+    auto ctrl_toggle = Gtk::manage(new Gtk::ToggleButton{"Ctrl"});
+    auto shift_toggle = Gtk::manage(new Gtk::ToggleButton{"Shift"});
+    auto alt_toggle = Gtk::manage(new Gtk::ToggleButton{"Alt"});
+    auto meta_toggle = Gtk::manage(new Gtk::ToggleButton{"Meta"});
     ctrl_toggle->set_size_request(70, 1);
     shift_toggle->set_size_request(70, 1);
     alt_toggle->set_size_request(70, 1);

--- a/src/ct/ct_pref_dlg_text_n_code.cc
+++ b/src/ct/ct_pref_dlg_text_n_code.cc
@@ -100,6 +100,7 @@ Gtk::Widget* CtPrefDlg::build_tab_text_n_code()
     entry_timestamp_format->set_text(pConfig->timestampFormat);
     Gtk::Button* button_strftime_help = Gtk::manage(new Gtk::Button());
     button_strftime_help->set_image(*_pCtMainWin->new_image_from_stock("ct_help", Gtk::ICON_SIZE_BUTTON));
+    button_strftime_help->set_tooltip_text(_("Online Manual"));
     hbox_timestamp->pack_start(*label_timestamp, false, false);
     hbox_timestamp->pack_start(*entry_timestamp_format, false, false);
     hbox_timestamp->pack_start(*button_strftime_help, false, false);

--- a/src/ct/ct_pref_dlg_theme.cc
+++ b/src/ct/ct_pref_dlg_theme.cc
@@ -48,7 +48,7 @@ Gtk::Widget* CtPrefDlg::build_tab_theme()
     vbox_tt_theme->pack_start(*radiobutton_tt_col_light, false, false);
     vbox_tt_theme->pack_start(*radiobutton_tt_col_dark, false, false);
     vbox_tt_theme->pack_start(*hbox_tt_col_custom, false, false);
-    Gtk::Frame* frame_tt_theme = new_managed_frame_with_align(_("Tree"), vbox_tt_theme);
+    Gtk::Frame* frame_tt_theme = new_managed_frame_with_align(_("Tree Explorer"), vbox_tt_theme);
 
     if (pConfig->ttDefFg == CtConst::TREE_TEXT_DARK_FG && pConfig->ttDefBg == CtConst::TREE_TEXT_DARK_BG) {
         radiobutton_tt_col_dark->set_active(true);
@@ -257,7 +257,7 @@ Gtk::Widget* CtPrefDlg::build_tab_theme()
                 f_onUserStyleChanged(i+1);
             }
         });
-        pButtonsResetToDefault[i]->signal_clicked().connect([i, pConfig,
+        pButtonsResetToDefault[i]->signal_clicked().connect([this, i, pConfig,
                                                              pColorButtonTextFg,
                                                              pColorButtonTextBg,
                                                              pColorButtonSelectionFg,
@@ -268,6 +268,7 @@ Gtk::Widget* CtPrefDlg::build_tab_theme()
                                                              pColorButtonLineNumbersBg,
                                                              f_onUserStyleChanged](){
             bool anyChange{false};
+            if (CtDialogs::question_dialog(reset_warning, *this)) {
             if (pConfig->userStyleTextFg[i] != CtConst::USER_STYLE_TEXT_FG[i]) {
                 pConfig->userStyleTextFg[i] = CtConst::USER_STYLE_TEXT_FG[i];
                 pColorButtonTextFg[i]->set_rgba(Gdk::RGBA{pConfig->userStyleTextFg[i]});
@@ -313,6 +314,7 @@ Gtk::Widget* CtPrefDlg::build_tab_theme()
             }
             else {
                 spdlog::debug("{} nothing to reset", CtConfig::get_user_style_id(i+1));
+            }
             }
         });
     }


### PR DESCRIPTION
Hi, Giuseppe. I have everything prepared for the new version of the app. 
Summary of changes:
1. Modified main menu (ct_menu.сс)
2. Fixed the translation of ru.po. (cherrytree. pop did not fix it) 
3. In the files ct_menu. h and ct_pref_dlg_kb_shortcuts.cc fixed the names of the keys according to the keyboard. 
4. In the file ct_actions_edit.cc fixed the name of the dialog box for adding special characters. 
5. In the file ct_pref_dlg_theme.cc added a dialog for accepting or canceling default values. The user needs a choice! 
6. In the file ct_pref_dlg_text_n_code.cc added a hint for the help button.