### PR TITLE
bugfix - status icon (missing / bad render) #1703 and tree node visibility #1704

### DIFF
--- a/src/ct/ct_app.cc
+++ b/src/ct/ct_app.cc
@@ -107,8 +107,12 @@ void CtApp::_on_startup()
 
     if (not _no_gui) {
         _rStatusIcon = Gtk::StatusIcon::create(CtConst::APP_NAME);
-        _rStatusIcon->set_visible(false);
-        _rStatusIcon->set_name(CtConst::APP_NAME);
+        /* The following two lines of original code, when active, cause the
+           StatusIcon to fail to properly appear in the system tray. A blank
+           placeholder, or sometimes a poorly rendered icon, appear in its 
+           place. */
+        //_rStatusIcon->set_visible(false);
+        //_rStatusIcon->set_name(CtConst::APP_NAME);
         _rStatusIcon->set_title(CtConst::APP_NAME);
         _rStatusIcon->set_tooltip_markup(_("CherryTree Hierarchical Note Taking"));
         _rStatusIcon->signal_button_press_event().connect([&](GdkEventButton* event) {

--- a/src/ct/ct_main_win.cc
+++ b/src/ct/ct_main_win.cc
@@ -144,6 +144,17 @@ CtMainWin::CtMainWin(bool                            no_gui,
     }
     else {
         if (_pCtConfig->systrayOn and _pCtConfig->startOnSystray) {
+            /* Calling the 'present()' function apparently sets up selected
+               node visibility within the TreeView panel, whereas this
+               node setup is skipped when only calling 'set_visible(false)'.
+               Calling 'present()' and then hiding the window with
+               'set_visible(false)' works to place the selected node within
+               the visible portion of the TreeView panel but does not seem
+               like the correct way to achieve this. Is there a function
+               that specifically sets the selected node to the top row of
+               the visible area in the panel?
+            */
+            present();
             set_visible(false);
         }
         else {


### PR DESCRIPTION
Pull request to address Cherrytree Issue #1703 & #1704.
