### PR TITLE
Added FormFactor Property to .desktop

### DIFF
--- a/data/cherrytree.desktop
+++ b/data/cherrytree.desktop
@@ -28,3 +28,4 @@ Type=Application
 StartupNotify=true
 Categories=GNOME;GTK;Utility;
 Keywords=editor;notes;note-taking;
+X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
This adds the line explained on [Linmob.net](https://linmob.net/phosh-0-12-app-drawer/)
It could also be the kde variant.
Also I'm hesitant about the value. If its both Workstation and Mobile, there is no differentiation.
However maybe later this can become handy together with #1024.
