### PR TITLE
Update ct_menu_actions.cc

### DIFF
--- a/src/ct/ct_menu_actions.cc
+++ b/src/ct/ct_menu_actions.cc
@@ -201,9 +201,9 @@ void CtMenu::init_actions(CtActions* pActions)
         _("Justify Right the Current Paragraph"), sigc::mem_fun(*pActions, &CtActions::apply_tag_justify_right)});
     _actions.push_back(CtMenuAction{fmt_cat, "fmt_justify_fill", "ct_justify-fill", _("Justify _Fill"), None,
         _("Justify Fill the Current Paragraph"), sigc::mem_fun(*pActions, &CtActions::apply_tag_justify_fill)});
-    _actions.push_back(CtMenuAction{fmt_cat, "fmt_indent", "ct_fmt-indent", _("_Indent Paragraph"), KB_CONTROL+KB_SHIFT+"greater",
+    _actions.push_back(CtMenuAction{fmt_cat, "fmt_indent", "ct_fmt-indent", _("_Indent Paragraph"), KB_CONTROL+"greater",
         _("Indent the Current Paragraph"), sigc::mem_fun(*pActions, &CtActions::apply_tag_indent)});
-    _actions.push_back(CtMenuAction{fmt_cat, "fmt_unindent", "ct_fmt-unindent", _("_Unindent Paragraph"), KB_CONTROL+KB_SHIFT+"less",
+    _actions.push_back(CtMenuAction{fmt_cat, "fmt_unindent", "ct_fmt-unindent", _("_Unindent Paragraph"), KB_CONTROL+"less",
         _("Unindent the Current Paragraph"), sigc::mem_fun(*pActions, &CtActions::reduce_tag_indent)});
 
     const char* tools_cat = _("Tools");


### PR DESCRIPTION
Shift removed.
The pressed keys Shift+Ctrl+> result in Ctrl+>.
The pressed keys Shift+Ctrl+< also result in Ctrl+>.