### PR TITLE
legacy_canonicalize_filename: manage empty filename

### DIFF
--- a/src/ct/ct_filesystem.cc
+++ b/src/ct/ct_filesystem.cc
@@ -46,6 +46,10 @@ static fs::path _mingw64Dir;
 // replacement of Glib::canonicalize_filename for Glibmm < 2.64
 std::string legacy_canonicalize_filename(const std::string& filename, const std::string& relative_to/*= ""*/)
 {
+    // manage case where filename is an empty string -- just send it back unchanged
+    if (filename == "")
+      return "";
+
     std::string retFilepath;
     GFile* pGFile{nullptr};
     if (not Glib::path_is_absolute(filename) and not relative_to.empty()) {


### PR DESCRIPTION
this function crashes if the filename is an empty string just return an empty string if it comes in as one
see: https://github.com/giuspen/cherrytree/issues/2112