### PR TITLE
Fix compilation for MSYS2 Clang64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options("-Wno-#warnings")
   add_compile_options(-Wthread-safety)
+  add_definitions(-D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR)
 endif()
 
 if(APPLE)

--- a/src/7za/C/Alloc.c
+++ b/src/7za/C/Alloc.c
@@ -78,7 +78,7 @@ void *MyAlloc(size_t size)
   #endif
 }
 
-void MyFree(void *address)
+void MyFree7Z(void *address)
 {
   #ifdef _SZ_ALLOC_DEBUG
   if (address != 0)
@@ -296,7 +296,7 @@ void BigFree(void *address)
 }
 
 static void *SzAlloc(void *p, size_t size) { UNUSED_VAR(p); return MyAlloc(size); }
-static void SzFree(void *p, void *address) { UNUSED_VAR(p); MyFree(address); }
+static void SzFree(void *p, void *address) { UNUSED_VAR(p); MyFree7Z(address); }
 ISzAlloc g_Alloc = { SzAlloc, SzFree };
 
 static void *SzBigAlloc(void *p, size_t size) { UNUSED_VAR(p); return BigAlloc(size); }

--- a/src/7za/C/Alloc.h
+++ b/src/7za/C/Alloc.h
@@ -9,7 +9,7 @@
 EXTERN_C_BEGIN
 
 void *MyAlloc(size_t size);
-void MyFree(void *address);
+void MyFree7Z(void *address);
 
 void SetLargePageSize();
 

--- a/src/7za/CPP/7zip/Archive/Cab/CabBlockInStream.cpp
+++ b/src/7za/CPP/7zip/Archive/Cab/CabBlockInStream.cpp
@@ -23,7 +23,7 @@ bool CCabBlockInStream::Create()
 
 CCabBlockInStream::~CCabBlockInStream()
 {
-  ::MyFree(_buf);
+  ::MyFree7Z(_buf);
 }
 
 static UInt32 CheckSum(const Byte *p, UInt32 size)

--- a/src/7za/CPP/7zip/Archive/Cab/CabHandler.cpp
+++ b/src/7za/CPP/7zip/Archive/Cab/CabHandler.cpp
@@ -571,7 +571,7 @@ private:
 
   void FreeTempBuf()
   {
-    ::MyFree(TempBuf);
+    ::MyFree7Z(TempBuf);
     TempBuf = NULL;
   }
 

--- a/src/7za/CPP/7zip/Archive/XzHandler.cpp
+++ b/src/7za/CPP/7zip/Archive/XzHandler.cpp
@@ -524,8 +524,8 @@ CXzUnpackerCPP::CXzUnpackerCPP(): InBuf(0), OutBuf(0)
 CXzUnpackerCPP::~CXzUnpackerCPP()
 {
   XzUnpacker_Free(&p);
-  MyFree(InBuf);
-  MyFree(OutBuf);
+  MyFree7Z(InBuf);
+  MyFree7Z(OutBuf);
 }
 
 HRESULT CDecoder::Decode(ISequentialInStream *seqInStream, ISequentialOutStream *outStream, ICompressProgressInfo *progress)

--- a/src/7za/CPP/7zip/Common/StreamObjects.cpp
+++ b/src/7za/CPP/7zip/Common/StreamObjects.cpp
@@ -184,7 +184,7 @@ static const UInt64 kEmptyTag = (UInt64)(Int64)-1;
 
 void CCachedInStream::Free() throw()
 {
-  MyFree(_tags);
+  MyFree7Z(_tags);
   _tags = 0;
   MidFree(_data);
   _data = 0;
@@ -206,7 +206,7 @@ bool CCachedInStream::Alloc(unsigned blockSizeLog, unsigned numBlocksLog) throw(
   }
   if (_tags == 0 || numBlocksLog != _numBlocksLog)
   {
-    MyFree(_tags);
+    MyFree7Z(_tags);
     _tags = (UInt64 *)MyAlloc(sizeof(UInt64) << numBlocksLog);
     if (_tags == 0)
       return false;

--- a/src/7za/CPP/7zip/Compress/DeflateEncoder.cpp
+++ b/src/7za/CPP/7zip/Compress/DeflateEncoder.cpp
@@ -219,9 +219,9 @@ HRESULT CCoder::BaseSetEncoderProperties2(const PROPID *propIDs, const PROPVARIA
 void CCoder::Free()
 {
   ::MidFree(m_OnePosMatchesMemory); m_OnePosMatchesMemory = 0;
-  ::MyFree(m_DistanceMemory); m_DistanceMemory = 0;
-  ::MyFree(m_Values); m_Values = 0;
-  ::MyFree(m_Tables); m_Tables = 0;
+  ::MyFree7Z(m_DistanceMemory); m_DistanceMemory = 0;
+  ::MyFree7Z(m_Values); m_Values = 0;
+  ::MyFree7Z(m_Tables); m_Tables = 0;
 }
 
 CCoder::~CCoder()

--- a/src/7za/CPP/7zip/Compress/LzmaDecoder.cpp
+++ b/src/7za/CPP/7zip/Compress/LzmaDecoder.cpp
@@ -38,7 +38,7 @@ CDecoder::CDecoder(): _inBuf(0), _propsWereSet(false), _outSizeDefined(false),
 CDecoder::~CDecoder()
 {
   LzmaDec_Free(&_state, &g_Alloc);
-  MyFree(_inBuf);
+  MyFree7Z(_inBuf);
 }
 
 STDMETHODIMP CDecoder::SetInBufSize(UInt32 , UInt32 size) { _inBufSize = size; return S_OK; }
@@ -48,7 +48,7 @@ HRESULT CDecoder::CreateInputBuffer()
 {
   if (_inBuf == 0 || _inBufSize != _inBufSizeAllocated)
   {
-    MyFree(_inBuf);
+    MyFree7Z(_inBuf);
     _inBuf = (Byte *)MyAlloc(_inBufSize);
     if (_inBuf == 0)
       return E_OUTOFMEMORY;

--- a/src/7za/CPP/7zip/Compress/ZDecoder.cpp
+++ b/src/7za/CPP/7zip/Compress/ZDecoder.cpp
@@ -22,9 +22,9 @@ static const unsigned kNumMaxBits = 16;
 
 void CDecoder::Free()
 {
-  MyFree(_parents); _parents = 0;
-  MyFree(_suffixes); _suffixes = 0;
-  MyFree(_stack); _stack = 0;
+  MyFree7Z(_parents); _parents = 0;
+  MyFree7Z(_suffixes); _suffixes = 0;
+  MyFree7Z(_stack); _stack = 0;
 }
 
 CDecoder::~CDecoder() { Free(); }


### PR DESCRIPTION
Fixes two issues I've found when trying to compile using MSYS2 clang64
```
C:/msys64/clang64/include/libxml++-2.6/libxml++/validators/xsdvalidator.h:149:8: error: no template named 'auto_ptr' in namespace 'std'
  std::auto_ptr<Impl> pimpl_;
  ~~~~~^
6 errors generated.
```
and

```
ld.lld: error: duplicate symbol: MyFree
>>> defined at C:/msys64/home/user/cherrytree/src/7za/C/Alloc.c:82
>>>            lib7za_static.a(Alloc.c.obj)
>>> defined at SETUPAPI.dll
```