### PR TITLE
fixed crash when creating lightweight table

### DIFF
--- a/src/ct/ct_actions_edit.cc
+++ b/src/ct/ct_actions_edit.cc
@@ -140,7 +140,11 @@ void CtActions::table_insert()
         for (auto& row : rows) {
             tbl_matrix.push_back(CtTableRow{});
             for (auto& cell : row) {
-                tbl_matrix.back().push_back(new CtTextCell{_pCtMainWin, cell, CtConst::TABLE_CELL_TEXT_ID});
+                if (is_light) {
+                    tbl_matrix.back().push_back(new Glib::ustring{});
+                } else {
+                    tbl_matrix.back().push_back(new CtTextCell{_pCtMainWin, cell, CtConst::TABLE_CELL_TEXT_ID});    
+                }
             }
         }
     }


### PR DESCRIPTION
When I tried create a lightweight table, it crashed. It turned out that the data type of table cell is not right for lightweight table. 
I just make a simple fix. I hope it can help.