### PR TITLE
Added missing dependences to Dockerfile for dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
       build-essential \
       cmake \
       gettext \
+      ninja-build \
       libcpputest-dev \
       libcurl4-openssl-dev \
       libgspell-1-dev \
@@ -19,4 +20,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
       libfmt-dev \
       libspdlog-dev \
       libxml++2.6-dev \
-      libxml2-utils
+      libxml2-utils \
+      libuchardet-dev \
+      libfribidi-dev \
+      libvte-2.91-dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ms-vscode.cpptools"
+		"ms-vscode.cpptools-extension-pack"
 	],
 
 	"remoteEnv": {


### PR DESCRIPTION
Docker build environment provided by VSCode devContainers is currently broken due to missing ubuntu dependencies declared in the Dockerfile.

Also changed to "ms-vscode.cpptools-extension-pack" to be available as an extension in the docker build environment.