### PR TITLE
Fix building with fmt 10.

### DIFF
--- a/src/ct/ct_config.cc
+++ b/src/ct/ct_config.cc
@@ -170,7 +170,7 @@ void CtConfig::_populate_current_group_from_map(const std::map<std::string, std:
 
 void CtConfig::_unexpected_keyfile_error(const gchar* key, const Glib::KeyFileError& kferror)
 {
-    spdlog::error("!! {} error code {} ", key, kferror.code());
+    spdlog::error("!! {} error code {} ", key, fmt::underlying(kferror.code()));
 }
 
 void CtConfig::_populate_keyfile_from_data()


### PR DESCRIPTION
Build is failing with fmt 10 due to changes with how enums are treated.

Specifically, an enum now need to have a `format_as` function, or be casted to its underlying type:
```
Removed deprecated implicit conversions for enums and conversions to primitive types for compatibility with std::format and to prevent potential ODR violations. Use format_as instead.
```