### PR TITLE
Update build.sh to properly discover and tag DISTRIB_RELEASE on Debian testing and Debian unstable/sid releases.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -77,7 +77,12 @@ then
 elif [ -f /etc/debian_version ]
 then
   DISTRIB_ID="Debian"
-  DISTRIB_RELEASE="$(cat /etc/debian_version | awk -F. '{print $1}' | tr -d '\n')"
+    if grep -q sid /etc/debian_version
+    then
+      DISTRIB_RELEASE="$(cat /etc/debian_version | awk -F/ '{print $1}' | tr -d '\n')"
+    else
+      DISTRIB_RELEASE="$(cat /etc/debian_version | awk -F. '{print $1}' | tr -d '\n')"
+    fi
 elif [ -f /etc/fedora-release ]
 then
   DISTRIB_ID="Fedora"


### PR DESCRIPTION
build.sh does not properly discover and tag DISTRIB_RELEASE on Debian testing and Debian unstable/sid releases, resulting in the following error message when running 

> ./build.sh deb

`mv: cannot move 'cherrytree-1.0.3-Linux.deb' to 'cherrytree-1.0.3~Debiantrixie/sid_amd64.deb': No such file or directory`


This is due to `/etc/debian_version` on Debian's testing & unstable branches not using an explicit version number, but instead using the release _codename_/sid

> drasey@stewie:~/git/cherrytree$ cat /etc/debian_version 
> trixie/sid

This PR is aims to resolve that by checking if /etc/debian_version includes **_sid_**, and using the release codename (trixie in my case) for DISTRIB_RELEASE.