### PR TITLE
Add libxml2-utils to Debian/Ubuntu build dependencies 

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -53,7 +53,7 @@ gdb ./build/cherrytree
 ## Building Cherrytree on Debian (+Ubuntu/Linux Mint)
 Install dependencies:
 ```sh
-sudo apt install build-essential cmake ninja-build libgtkmm-3.0-dev libgtksourceviewmm-3.0-dev libxml++2.6-dev libsqlite3-dev gettext libgspell-1-dev libcurl4-openssl-dev libuchardet-dev libfribidi-dev libvte-2.91-dev libfmt-dev libspdlog-dev file
+sudo apt install build-essential cmake ninja-build libgtkmm-3.0-dev libgtksourceviewmm-3.0-dev libxml++2.6-dev libsqlite3-dev gettext libgspell-1-dev libcurl4-openssl-dev libuchardet-dev libfribidi-dev libvte-2.91-dev libfmt-dev libspdlog-dev file libxml2-utils
 sudo apt install texlive-latex-base dvipng # optional for LatexBoxes support
 ```
 Note: On Debian10 / Ubuntu 18.04 libfmt-dev and libspdlog-dev are not used since too old; bundled source code is built instead

--- a/src/ct/ct_actions_find.cc
+++ b/src/ct/ct_actions_find.cc
@@ -203,10 +203,12 @@ void CtActions::find_in_multiple_nodes()
     while (node_iter) {
         _s_state.all_matches_first_in_node = true;
         CtTreeIter ct_node_iter = ctTreeStore.to_ct_tree_iter(node_iter);
-        Glib::RefPtr<Gsv::Buffer> rTextBuffer = ct_node_iter.get_node_text_buffer();
-        if (not rTextBuffer) {
-            CtDialogs::error_dialog(str::format(_("Failed to retrieve the content of the node '%s'"), ct_node_iter.get_node_name()), *_pCtMainWin);
-            break;
+        if (_s_options.node_content) {
+            Glib::RefPtr<Gsv::Buffer> rTextBuffer = ct_node_iter.get_node_text_buffer();
+            if (not rTextBuffer) {
+                CtDialogs::error_dialog(str::format(_("Failed to retrieve the content of the node '%s'"), ct_node_iter.get_node_name()), *_pCtMainWin);
+                break;
+            }
         }
         while (_parse_given_node_content(ct_node_iter, re_pattern, forward, first_fromsel, all_matches)) {
             ++_s_state.matches_num;
@@ -385,10 +387,12 @@ bool CtActions::_parse_given_node_content(CtTreeIter node_iter,
             while (child_iter and not _pCtMainWin->get_status_bar().is_progress_stop()) {
                 _s_state.all_matches_first_in_node = true;
                 CtTreeIter ct_node_iter = ctTreeStore.to_ct_tree_iter(child_iter);
-                Glib::RefPtr<Gsv::Buffer> rTextBuffer = ct_node_iter.get_node_text_buffer();
-                if (not rTextBuffer) {
-                    CtDialogs::error_dialog(str::format(_("Failed to retrieve the content of the node '%s'"), ct_node_iter.get_node_name()), *_pCtMainWin);
-                    break;
+                if (_s_options.node_content) {
+                    Glib::RefPtr<Gsv::Buffer> rTextBuffer = ct_node_iter.get_node_text_buffer();
+                    if (not rTextBuffer) {
+                        CtDialogs::error_dialog(str::format(_("Failed to retrieve the content of the node '%s'"), ct_node_iter.get_node_name()), *_pCtMainWin);
+                        break;
+                    }
                 }
                 while (_parse_given_node_content(ct_node_iter, re_pattern, forward, first_fromsel, all_matches)) {
                     _s_state.matches_num += 1;


### PR DESCRIPTION
Adding libxml2-utils to resolve following message when building on Debian/Ubuntu


xml-stripblanks preprocessing requested, but XMLLINT is not set, and xmllint is not in PATH
