### PR TITLE
Add Gruvbox light and dark theme

### DIFF
--- a/styles/gruvbox-dark.xml
+++ b/styles/gruvbox-dark.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of GtkSourceView
+
+ Copyright (C) 2016 Jean-Patrick Guerrero <jeanpatrick.guerrero@gmail.com>
+ Color scheme by morhetz - https://github.com/morhetz/gruvbox
+
+ GtkSourceView is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ GtkSourceView is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+-->
+
+<style-scheme id="gruvbox-dark" _name="Gruvbox-Dark" version="1.0">
+
+  <author>Jean-Patrick Guerrero</author>
+  <_description>Dark color scheme using the Gruvbox color palette</_description>
+
+  <!-- Gruvbox Palette -->
+
+  <color name="dark0_hard"	value="#1d2021"/>
+  <color name="dark0"		value="#282828"/>
+  <color name="dark0_soft"	value="#32302f"/>
+  <color name="dark1"		value="#3c3836"/>
+  <color name="dark2"		value="#504945"/>
+  <color name="dark3"		value="#665c54"/>
+  <color name="dark4"		value="#7c6f64"/>
+
+  <color name="gray"		value="#928374"/>
+
+  <color name="light0_hard"	value="#f9f5d7"/>
+  <color name="light0"		value="#fbf1c7"/>
+  <color name="light0_soft"	value="#f2e5bc"/>
+  <color name="light1"		value="#ebdbb2"/>
+  <color name="light2"		value="#d5c4a1"/>
+  <color name="light3"		value="#bdae93"/>
+  <color name="light4"		value="#a89984"/>
+
+  <color name="bright_red"	value="#fb4934"/>
+  <color name="bright_green"	value="#b8bb26"/>
+  <color name="bright_yellow"	value="#fabd2f"/>
+  <color name="bright_blue"	value="#83a598"/>
+  <color name="bright_purple"	value="#d3869b"/>
+  <color name="bright_aqua"	value="#8ec07c"/>
+  <color name="bright_orange"	value="#fe8019"/>
+
+  <color name="neutral_red"	value="#cc241d"/>
+  <color name="neutral_green"	value="#98971a"/>
+  <color name="neutral_yellow"	value="#d79921"/>
+  <color name="neutral_blue"	value="#458588"/>
+  <color name="neutral_purple"	value="#b16286"/>
+  <color name="neutral_aqua"	value="#689d6a"/>
+  <color name="neutral_orange"	value="#d65d0e"/>
+
+  <color name="faded_red"	value="#9d0006"/>
+  <color name="faded_green"	value="#79740e"/>
+  <color name="faded_yellow"	value="#b57614"/>
+  <color name="faded_blue"	value="#076678"/>
+  <color name="faded_purple"	value="#8f3f71"/>
+  <color name="faded_aqua"	value="#427b58"/>
+  <color name="faded_orange"	value="#af3a03"/>
+
+
+  <!-- Global Settings -->
+  <style name="text"			foreground="light0" background="dark0"/>
+  <style name="selection"		foreground="light0" background="dark4"/>
+  <style name="cursor"			foreground="light1"/>
+  <style name="secondary-cursor"	foreground="light1"/>
+  <style name="current-line"		background="dark1"/>
+  <style name="line-numbers"		foreground="dark4" background="dark0_hard"/>
+  <style name="draw-spaces"		foreground="light2"/>
+  <style name="background-pattern"	background="#2e2c2b"/>
+
+  <!-- Bracket Matching -->
+  <style name="bracket-match"		foreground="bright_orange"/>
+  <style name="bracket-mismatch"	foreground="dark0" background="bright_red"/>
+
+  <!-- Right Margin -->
+  <style name="right-margin"		foreground="light0" background="light1"/>
+
+  <!-- Search Matching -->
+  <style name="search-match"		foreground="dark0" background="bright_orange"/>
+
+  <!-- Code -->
+  <style name="def:base-n-integer"	foreground="bright_purple"/>
+  <style name="def:boolean"		foreground="bright_purple"/>
+  <style name="def:builtin"		foreground="bright_orange"/>
+  <style name="def:character"		foreground="bright_purple"/>
+  <style name="def:comment"		foreground="gray"/>
+  <style name="def:complex"		foreground="bright_purple"/>
+  <style name="def:decimal"		foreground="bright_purple"/>
+  <style name="def:doc-comment"		foreground="gray"/>
+  <style name="def:doc-comment-element" italic="true"/>
+  <style name="def:error"		foreground="dark0" background="bright_red" bold="true"/>
+  <style name="def:floating-point"	foreground="bright_purple"/>
+  <style name="def:function"		foreground="bright_green"/>
+  <style name="def:identifier"		foreground="bright_blue"/>
+  <style name="def:keyword"		foreground="bright_orange"/>
+  <style name="def:note"		foreground="gray"/>
+  <style name="def:number"		foreground="bright_purple"/>
+  <style name="def:operator"		foreground="bright_purple"/>
+  <style name="def:preprocessor"	foreground="bright_aqua"/>
+  <style name="def:reserved"		foreground="bright_aqua"/>
+  <style name="def:shebang"		foreground="gray"/>
+  <style name="def:special-char"	foreground="bright_orange"/>
+  <style name="def:special-constant"	foreground="bright_purple"/>
+  <style name="def:statement"		foreground="bright_orange"/>
+  <style name="def:string"		foreground="bright_green"/>
+  <style name="def:type"		foreground="bright_yellow"/>
+  <style name="def:underlined"		italic="true" underline="single"/>
+  <style name="def:warning"		foreground="dark0" background="bright_red"/>
+
+</style-scheme>

--- a/styles/gruvbox-light.xml
+++ b/styles/gruvbox-light.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of GtkSourceView
+
+ Copyright (C) 2016 Jean-Patrick Guerrero <jeanpatrick.guerrero@gmail.com>
+ Color scheme by morhetz - https://github.com/morhetz/gruvbox
+
+ GtkSourceView is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ GtkSourceView is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+-->
+
+<style-scheme id="gruvbox-light" _name="Gruvbox-Light" version="1.0">
+
+  <author>Jean-Patrick Guerrero</author>
+  <_description>Light color scheme using the Gruvbox color palette</_description>
+
+  <!-- Gruvbox Palette -->
+
+  <color name="dark0_hard"	value="#1d2021"/>
+  <color name="dark0"		value="#282828"/>
+  <color name="dark0_soft"	value="#32302f"/>
+  <color name="dark1"		value="#3c3836"/>
+  <color name="dark2"		value="#504945"/>
+  <color name="dark3"		value="#665c54"/>
+  <color name="dark4"		value="#7c6f64"/>
+
+  <color name="gray"		value="#928374"/>
+
+  <color name="light0_hard"	value="#f9f5d7"/>
+  <color name="light0"		value="#fbf1c7"/>
+  <color name="light0_soft"	value="#f2e5bc"/>
+  <color name="light1"		value="#ebdbb2"/>
+  <color name="light2"		value="#d5c4a1"/>
+  <color name="light3"		value="#bdae93"/>
+  <color name="light4"		value="#a89984"/>
+
+  <color name="bright_red"	value="#fb4934"/>
+  <color name="bright_green"	value="#b8bb26"/>
+  <color name="bright_yellow"	value="#fabd2f"/>
+  <color name="bright_blue"	value="#83a598"/>
+  <color name="bright_purple"	value="#d3869b"/>
+  <color name="bright_aqua"	value="#8ec07c"/>
+  <color name="bright_orange"	value="#fe8019"/>
+
+  <color name="neutral_red"	value="#cc241d"/>
+  <color name="neutral_green"	value="#98971a"/>
+  <color name="neutral_yellow"	value="#d79921"/>
+  <color name="neutral_blue"	value="#458588"/>
+  <color name="neutral_purple"	value="#b16286"/>
+  <color name="neutral_aqua"	value="#689d6a"/>
+  <color name="neutral_orange"	value="#d65d0e"/>
+
+  <color name="faded_red"	value="#9d0006"/>
+  <color name="faded_green"	value="#79740e"/>
+  <color name="faded_yellow"	value="#b57614"/>
+  <color name="faded_blue"	value="#076678"/>
+  <color name="faded_purple"	value="#8f3f71"/>
+  <color name="faded_aqua"	value="#427b58"/>
+  <color name="faded_orange"	value="#af3a03"/>
+
+
+  <!-- Global Settings -->
+  <style name="text"			foreground="dark0" background="light0"/>
+  <style name="selection"		foreground="dark4" background="light2"/>
+  <style name="cursor"			foreground="dark1"/>
+  <style name="secondary-cursor"	foreground="dark1"/>
+  <style name="current-line"		background="light1"/>
+  <style name="line-numbers"		foreground="light4" background="light0_hard"/>
+  <style name="draw-spaces"		foreground="dark2"/>
+  <style name="background-pattern"	background="#faedb7"/>
+
+  <!-- Bracket Matching -->
+  <style name="bracket-match"		foreground="faded_orange"/>
+  <style name="bracket-mismatch"	foreground="dark0" background="bright_red"/>
+
+  <!-- Right Margin -->
+  <style name="right-margin"		foreground="dark3" background="dark4"/>
+
+  <!-- Search Matching -->
+  <style name="search-match"		foreground="dark0" background="bright_yellow"/>
+
+  <!-- Code -->
+  <style name="def:base-n-integer"	foreground="faded_purple"/>
+  <style name="def:boolean"		foreground="faded_purple"/>
+  <style name="def:builtin"		foreground="faded_orange"/>
+  <style name="def:character"		foreground="faded_purple"/>
+  <style name="def:comment"		foreground="gray"/>
+  <style name="def:complex"		foreground="faded_purple"/>
+  <style name="def:decimal"		foreground="faded_purple"/>
+  <style name="def:doc-comment"		foreground="gray"/>
+  <style name="def:doc-comment-element" italic="true"/>
+  <style name="def:error"		foreground="dark0" background="bright_red" bold="true"/>
+  <style name="def:floating-point"	foreground="faded_purple"/>
+  <style name="def:function"		foreground="faded_green"/>
+  <style name="def:identifier"		foreground="faded_blue"/>
+  <style name="def:keyword"		foreground="faded_orange"/>
+  <style name="def:note"		foreground="gray"/>
+  <style name="def:number"		foreground="faded_purple"/>
+  <style name="def:operator"		foreground="faded_purple"/>
+  <style name="def:preprocessor"	foreground="faded_aqua"/>
+  <style name="def:reserved"		foreground="faded_aqua"/>
+  <style name="def:shebang"		foreground="gray"/>
+  <style name="def:special-char"	foreground="faded_orange"/>
+  <style name="def:special-constant"	foreground="faded_purple"/>
+  <style name="def:statement"		foreground="faded_orange"/>
+  <style name="def:string"		foreground="faded_green"/>
+  <style name="def:type"		foreground="faded_yellow"/>
+  <style name="def:underlined"		italic="true" underline="single"/>
+  <style name="def:warning"		foreground="dark0" background="bright_red"/>
+
+</style-scheme>
+


### PR DESCRIPTION

Add gruvbox style them from GtkSourceView

The XML style schemes were not made by me, and are protected under GNU Lesser General Public License v2.1. I just imported them to cherrytree.

Examples of how it looks, on my machine. I have built from source and have had 0 issues so far.

![image](https://github.com/giuspen/cherrytree/assets/76616664/36197969-35bc-4a28-932d-6796aed33250)

![image](https://github.com/giuspen/cherrytree/assets/76616664/160aa3c9-62e6-44b1-a27e-e2abcc77b958)



