### PR TITLE
fixed html paste

### DIFF
--- a/src/ct/ct_parser_html.cc
+++ b/src/ct/ct_parser_html.cc
@@ -504,7 +504,7 @@ void CtHtml2Xml::_pop_tag_styles()
 {
     // every tag has at least one style
     int tag_id = _tag_styles.back().tag_id;
-    while (_tag_styles.back().tag_id == tag_id)
+    while (!_tag_styles.empty() && _tag_styles.back().tag_id == tag_id)
         _tag_styles.pop_back();
 }
 


### PR DESCRIPTION
For valid html, _tag_styles.back() will be called on empty std::list, which is undefined behavior.
https://en.cppreference.com/w/cpp/container/list/back

When I paste 'text/html' content into cherrytree, assert is triggered in libc++
(llvm libcxx compiled with -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE)