### PR TITLE
Fix duplicate "Open File" in PT translation

### DIFF
--- a/po/pt.po
+++ b/po/pt.po
@@ -143,7 +143,7 @@ msgid "_Open File..."
 msgstr "_Abrir Ficheiro..."
 
 msgid "Open Fo_lder..."
-msgstr "_Abrir Ficheiro..."
+msgstr "_Abrir Pasta..."
 
 msgid "Open a CherryTree Folder"
 msgstr "Abrir um documento do CherryTree"


### PR DESCRIPTION
Now has both "Open File" and "Open Folder"
Fixes giuspen/cherrytree#2516