### PR TITLE
Fix formatting issues with fmt 11 (#2548)

### DIFF
--- a/src/ct/ct_export2html.cc
+++ b/src/ct/ct_export2html.cc
@@ -180,7 +180,7 @@ void CtExport2Html::nodes_all_export_to_multiple_html(bool all_tree, const CtExp
     tree_links_text += "</div>\n";
 
     // create index html page
-    Glib::ustring html_text = str::format(HTML_HEADER, _pCtMainWin->get_ct_storage()->get_file_name());
+    Glib::ustring html_text = str::format(HTML_HEADER, _pCtMainWin->get_ct_storage()->get_file_name().string());
     if (options.index_in_page) {
         html_text += "<div class='two-panels'>\n<div class='tree-panel'>\n";
         html_text += tree_links_text;
@@ -283,7 +283,7 @@ void CtExport2Html::nodes_all_export_to_single_html(bool all_tree, const CtExpor
         }
     };
 
-    Glib::ustring html_header = str::format(HTML_HEADER, _pCtMainWin->get_ct_storage()->get_file_name());
+    Glib::ustring html_header = str::format(HTML_HEADER, _pCtMainWin->get_ct_storage()->get_file_name().string());
     rFileStream->write(html_header.c_str(), html_header.bytes());
 
     // start to iterarte nodes

--- a/src/ct/ct_storage_control.cc
+++ b/src/ct/ct_storage_control.cc
@@ -78,7 +78,7 @@ static const std::string BAD_ARCHIVE{"_BAD_ARC_"};
                     return nullptr;
                 }
                 if (extracted_file_path.string() == BAD_ARCHIVE) {
-                    throw std::runtime_error(str::format(_("'%s' is Not a Valid Archive"), file_path));
+                    throw std::runtime_error(str::format(_("'%s' is Not a Valid Archive"), file_path.string()));
                 }
             }
         }
@@ -533,14 +533,14 @@ void CtStorageControl::_backupEncryptThread()
                 // move back the latest file version
                 (void)fs::move_file(pBackupEncryptData->main_backup, pBackupEncryptData->file_path);
 #if defined(DEBUG_BACKUP_ENCRYPT)
-                spdlog::debug("{} -> {}", pBackupEncryptData->main_backup, pBackupEncryptData->file_path);
+                spdlog::debug("{} -> {}", pBackupEncryptData->main_backup, pBackupEncryptData->file_path.string());
 #endif // DEBUG_BACKUP_ENCRYPT
                 _pCtMainWin->errorsDEQueue.push_back(_("Failed to encrypt the file"));
                 _pCtMainWin->dispatcherErrorMsg.emit();
                 continue;
             }
 #if defined(DEBUG_BACKUP_ENCRYPT)
-            spdlog::debug("{} => {}", pBackupEncryptData->extracted_copy, pBackupEncryptData->file_path);
+            spdlog::debug("{} => {}", pBackupEncryptData->extracted_copy, pBackupEncryptData->file_path.string());
 #endif // DEBUG_BACKUP_ENCRYPT
         }
 
@@ -729,12 +729,12 @@ void CtStorageControl::add_nodes_from_storage(const fs::path& file_path,
 {
     if (is_folder) {
         if (not fs::is_directory(file_path)) {
-            throw std::runtime_error(fmt::format("{} not a dir", file_path));
+            throw std::runtime_error(fmt::format("{} not a dir", file_path.string()));
         }
     }
     else {
         if (not fs::is_regular_file(file_path)) {
-            throw std::runtime_error(fmt::format("{} not a file", file_path));
+            throw std::runtime_error(fmt::format("{} not a file", file_path.string()));
         }
     }
 
@@ -747,7 +747,7 @@ void CtStorageControl::add_nodes_from_storage(const fs::path& file_path,
             return;
         }
         if (extracted_file_path.string() == BAD_ARCHIVE) {
-            throw std::runtime_error(str::format(_("'%s' is Not a Valid Archive"), file_path));
+            throw std::runtime_error(str::format(_("'%s' is Not a Valid Archive"), file_path.string()));
         }
     }
 

--- a/src/ct/ct_storage_multifile.cc
+++ b/src/ct/ct_storage_multifile.cc
@@ -510,7 +510,7 @@ bool CtStorageMultiFile::populate_treestore(const fs::path& dir_path, Glib::ustr
                 parsingOk = true;
             }
             catch (std::exception& ex) {
-                spdlog::error("parse {} : {} - trying first backup...", node_xml_path, ex.what());
+                spdlog::error("parse {} : {} - trying first backup...", node_xml_path.string(), ex.what());
             }
             if (not parsingOk) {
                 std::string first_backup_dir;
@@ -527,13 +527,13 @@ bool CtStorageMultiFile::populate_treestore(const fs::path& dir_path, Glib::ustr
                             parsingOk = true;
                         }
                         catch (std::exception& ex) {
-                            spdlog::error("parse {} : {} - trying backup {}...", node_xml_path, ex.what(), b+2);
+                            spdlog::error("parse {} : {} - trying backup {}...", node_xml_path.string(), ex.what(), b+2);
                         }
                         if (parsingOk) {
                             if (fs::exists(node_xml_path)) {
                                 fs::move_file(node_xml_path, node_xml_path.parent_path() / (node_xml_path.stem() + std::string{"_BAD.xml"}));
                             }
-                            spdlog::debug("parse backed up data ok, copying {} -> {}", backup_node_xml_path, node_xml_path);
+                            spdlog::debug("parse backed up data ok, copying {} -> {}", backup_node_xml_path.string(), node_xml_path.string());
                             fs::copy_file(backup_node_xml_path, node_xml_path);
                             if (error.empty()) error += _("A Restore From Backup Was Necessary For:");
                             error += "\n\n" + node_xml_path.string();

--- a/src/ct/ct_storage_sqlite.cc
+++ b/src/ct/ct_storage_sqlite.cc
@@ -207,10 +207,10 @@ void CtStorageSqlite::test_connection()
     }
     catch(std::exception& e) {
         spdlog::debug("{} {}", __FUNCTION__, e.what());
-        throw std::runtime_error(str::format(_("%s write failed - file is missing. Reattach USB drive or shared resource!"), _file_path));
+        throw std::runtime_error(str::format(_("%s write failed - file is missing. Reattach USB drive or shared resource!"), _file_path.string()));
     }
     if (not test_readwrite())
-        throw std::runtime_error(str::format(_("%s write failed - is file blocked by a sync program?"), _file_path));
+        throw std::runtime_error(str::format(_("%s write failed - is file blocked by a sync program?"), _file_path.string()));
     (void)_check_database_integrity();
 }
 
@@ -223,7 +223,7 @@ void CtStorageSqlite::try_reopen()
     }
     catch(std::exception& e) {
         spdlog::debug("{} {}", __FUNCTION__, e.what());
-        throw std::runtime_error(str::format(_("%s reopen failed - file is missing. Reattach USB drive or shared resource!"), _file_path));
+        throw std::runtime_error(str::format(_("%s reopen failed - file is missing. Reattach USB drive or shared resource!"), _file_path.string()));
     }
     (void)_check_database_integrity();
 }


### PR DESCRIPTION
CherryTree fails to build on Fedora Rawhide due to errors introduced by fmt 11. This commit fixes all of the remaining errors raised during compile.

Fixes #2548

This builds successfully on both Fedora Linux 39 and Fedora Rawhide. The resulting binary passes a basic functionality test.