### PR TITLE
Corrected translation for 'open folder' in Brazilian Portuguese

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1577,7 +1577,7 @@ msgid "_Open File..."
 msgstr "Abrir arquivo..."
 
 msgid "Open Fo_lder..."
-msgstr "Abrir Arquivo..."
+msgstr "Abrir pasta..."
 
 msgid "Open a CherryTree Folder"
 msgstr "Abrir uma pasta do CherryTree"


### PR DESCRIPTION
Hello! I have noticed today a small issue in the Brazilian Portuguese translation of Cherrytree. The sentence "Open Folder..." is being mistakenly translated the same "Open File...", which is very confusing.

"Arquivo" means "file", while "pasta" means "folder". As such I have adjusted the string in the file `pt_BR.po`.

![image](https://github.com/user-attachments/assets/3da2fa4c-d6e1-43c2-9b31-3f0188c9934b)
