### PR TITLE
update test dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
       cmake \
       gettext \
       ninja-build \
-      libcpputest-dev \
       libcurl4-openssl-dev \
       libgspell-1-dev \
       libgtkmm-3.0-dev \


### PR DESCRIPTION
I recently went through the current Gentoo [ebuild for cherrytree](https://gitweb.gentoo.org/repo/gentoo.git/tree/app-text/cherrytree/cherrytree-1.2.0.ebuild) while troubleshooting something, and noticed that the tests are currently restricted from running by default, with the comment:

> Has deps that aren't available in ::gentoo repo

However, I'm able to build the tests on my Gentoo machine with no problem, despite not having `cpputest` installed or having taken any other special action. The only mention of `cpputest` I could find was in the devcontainer Dockerfile. I don't see any other  documentation specifying test dependencies either.

Please let me know if this change is in fact invalid, and/or if there are other testing dependencies that I'm unaware of, (apart from having an X server available it seems). I'll put together a patch for the ebuild to remove the testing restriction and dependency on cpputest if so, replacing it with gtest. I'm also happy to put together a doc update to cherrytree for the testing requirements, if they are in fact more complex than I'm understanding.

Of course, thanks for this application, and more importantly for your time spent maintaining it!