### PR TITLE
fix multiprocess export tests

### DIFF
--- a/src/ct/ct_app.cc
+++ b/src/ct/ct_app.cc
@@ -29,8 +29,8 @@
 #include "ct_logging.h"
 #include <iostream>
 
-CtApp::CtApp(const Glib::ustring application_id_postfix)
- : Gtk::Application{Glib::ustring{"net.giuspen.cherrytree"} + application_id_postfix, Gio::APPLICATION_HANDLES_OPEN}
+CtApp::CtApp(const Glib::ustring application_id_postfix, Gio::ApplicationFlags flags)
+ : Gtk::Application{Glib::ustring{"net.giuspen.cherrytree"} + application_id_postfix, Gio::APPLICATION_HANDLES_OPEN | flags}
  , _pCtConfig{CtConfig::GetCtConfig()}
 {
 #if GTK_SOURCE_MAJOR_VERSION >= 4

--- a/src/ct/ct_app.h
+++ b/src/ct/ct_app.h
@@ -36,7 +36,7 @@ class CtMainWin;
 class CtApp : public Gtk::Application
 {
 protected:
-    CtApp(const Glib::ustring application_id_postfix = Glib::ustring{});
+    CtApp(const Glib::ustring application_id_postfix = Glib::ustring{}, Gio::ApplicationFlags flags = Gio::APPLICATION_FLAGS_NONE);
     ~CtApp() override;
 
 public:

--- a/tests/tests_exports.cpp
+++ b/tests/tests_exports.cpp
@@ -29,7 +29,7 @@ class TestCtApp : public CtApp
 {
 public:
     TestCtApp()
-     : CtApp{"_test_exports"}
+     : CtApp{"_test_exports", Gio::APPLICATION_NON_UNIQUE}
     {
         _no_gui = true;
         _on_startup(); // so that _uCtTmp is ready straight away


### PR DESCRIPTION
Running the tests using ctest with multiple jobs does not succeed, due to the Gtk application re-using existing instances which leads to inconsistent behavior. This change allows the test application instance to specify that non-unique behavior is required.

This can be triggered by executing `ctest -j 2 --tests-regex "Export"`. The tests will fail with any number of jobs greater than 1, unless the jobs are in fact executed sequentially (for example if system load is too high).

This is an issue for the test stage in the Gentoo ebuild, which by default will use the number of jobs that is configured for the build system. If this is greater than 1, then the tests will likely fail. One [possible fix](https://github.com/gentoo/gentoo/pull/40462) for this is to override the number of jobs to hardcode to 1, but it would be better if the tests could be run in parallel.

I'm submitting this patch as one possible fix, but I recognize that this changes the main interface to the application, which may not be acceptable. I'm happy to work through alternative solutions if more work is needed.