### PR TITLE
fix: avoid crash in time_format when localtime returns null

### DIFF
--- a/src/ct/ct_misc_utils.cc
+++ b/src/ct/ct_misc_utils.cc
@@ -1621,6 +1621,7 @@ Glib::ustring str::re_escape(const Glib::ustring& text)
 Glib::ustring str::time_format(const std::string& format, const time_t& time)
 {
     std::tm* localtime = std::localtime(&time);
+    if (not localtime) return "";
     char buffer[100];
     size_t len = strftime(buffer, sizeof(buffer), format.c_str(), localtime);
     if (len == 0)

--- a/tests/tests_misc_utils.cpp
+++ b/tests/tests_misc_utils.cpp
@@ -25,6 +25,7 @@
 #include "ct_const.h"
 #include "ct_filesystem.h"
 #include "tests_common.h"
+#include <cstdint>
 #include <thread>
 
 TEST(MiscUtilsGroup, get_encoding)
@@ -131,6 +132,14 @@ TEST(MiscUtilsGroup, str__trim)
         std::string testTrimStr = "\t one two three ";
         ASSERT_STREQ("one two three", str::trim(testTrimStr).c_str());
     }
+}
+
+TEST(MiscUtilsGroup, str__time_format)
+{
+    // an out of range timestamp makes localtime return nullptr, must not crash
+    ASSERT_STREQ("", str::time_format("%Y/%m/%d - %H:%M", (time_t)INT64_MAX).c_str());
+    // a valid timestamp still formats (2009-02-13 23:31:30 UTC)
+    ASSERT_FALSE(str::time_format("%Y", (time_t)1234567890).empty());
 }
 
 TEST(MiscUtilsGroup, gint64_from_gstring)


### PR DESCRIPTION
Opening a document with an out of range ts_creation/ts_lastsave value crashes cherrytree with a segfault, as reported in #2869. std::localtime returns nullptr when the time_t cannot be represented, and time_format passed that pointer straight to strftime, which dereferences it (the gdb trace in the issue shows tp=0x0 inside __strftime_internal).

This adds a null check so the formatting returns an empty string instead, matching the existing behaviour when strftime yields nothing. Added a small test in tests_misc_utils covering an out of range timestamp.